### PR TITLE
Pivot to Plugin Framework via the MUX Framework

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,528 @@
+# Terraform Provider Migration: SDK v2 to Plugin Framework
+
+## Overview
+
+This guide provides detailed instructions for migrating a Terraform provider from SDK v2 to the newer Plugin Framework, based on real-world experience migrating terraform-provider-ironic and recommendations for terraform-provider-unifi.
+
+## Prerequisites
+
+- **Target Repository**: [terraform-provider-unifi (terraform-provider-mux branch)](https://github.com/ubiquiti-community/terraform-provider-unifi/tree/terraform-provider-mux)
+- **Framework**: Terraform Plugin Framework v1.0+
+- **Go Version**: 1.19+
+
+## Key Documentation References
+
+- [Plugin Framework Overview](https://developer.hashicorp.com/terraform/plugin/framework)
+- [Migration Guide from SDK v2](https://developer.hashicorp.com/terraform/plugin/framework/migrating)
+- [Provider Framework Tutorial](https://developer.hashicorp.com/terraform/tutorials/providers-plugin-framework)
+- [Schema Concepts](https://developer.hashicorp.com/terraform/plugin/framework/handling-data/schemas)
+- [Resource Implementation](https://developer.hashicorp.com/terraform/plugin/framework/resources)
+
+## Migration Steps
+
+### 1. Project Structure Reorganization
+
+**Current Structure** (SDK v2):
+```
+internal/
+├── provider/
+├── resources/
+└── datasources/
+```
+
+**Target Structure** (Plugin Framework):
+```
+{provider_name}/          # Use 'unifi' for terraform-provider-unifi
+├── provider.go
+├── resource_*.go
+├── data_source_*.go
+└── util/
+    └── conversion.go
+```
+
+### 2. Update Dependencies
+
+Update `go.mod`:
+```go
+module github.com/ubiquiti-community/terraform-provider-unifi
+
+require (
+    github.com/hashicorp/terraform-plugin-framework v1.4.2
+    github.com/hashicorp/terraform-plugin-framework-validators v0.12.0
+    github.com/hashicorp/terraform-plugin-go v0.19.0
+    github.com/hashicorp/terraform-plugin-mux v0.12.0
+    // Keep existing dependencies for SDK v2 resources during transition
+)
+```
+
+### 3. Main Provider Entry Point
+
+**For Framework-Only Provider** (like ironic):
+```go
+package main
+
+import (
+    "context"
+    "flag"
+    "log"
+
+    provider "github.com/ubiquiti-community/terraform-provider-unifi/unifi"
+    "github.com/hashicorp/terraform-plugin-framework/providerserver"
+)
+
+//go:generate go tool github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs generate -provider-name unifi
+func main() {
+    var debug bool
+
+    flag.BoolVar(
+        &debug,
+        "debug",
+        false,
+        "set to true to run the provider with support for debuggers like delve",
+    )
+    flag.Parse()
+
+    opts := providerserver.ServeOpts{
+        Address: "registry.terraform.io/ubiquiti-community/unifi",
+        Debug:   debug,
+    }
+
+    err := providerserver.Serve(context.Background(), provider.New(), opts)
+    if err != nil {
+        log.Fatal(err.Error())
+    }
+}
+```
+
+**For Mixed Provider** (SDK v2 + Framework):
+```go
+package main
+
+import (
+    "context"
+    "flag"
+    "log"
+
+    "github.com/hashicorp/terraform-plugin-framework/providerserver"
+    "github.com/hashicorp/terraform-plugin-mux/tf5to6server"
+    "github.com/hashicorp/terraform-plugin-mux/tf6muxserver"
+    
+    // SDK v2 provider (existing)
+    sdkProvider "github.com/ubiquiti-community/terraform-provider-unifi/internal/provider"
+    // Plugin Framework provider (new)
+    frameworkProvider "github.com/ubiquiti-community/terraform-provider-unifi/unifi"
+)
+
+func main() {
+    var debug bool
+    flag.BoolVar(&debug, "debug", false, "set to true to run the provider with support for debuggers")
+    flag.Parse()
+
+    ctx := context.Background()
+
+    // Upgrade SDK v2 provider to protocol version 6
+    upgradedSdkProvider, err := tf5to6server.UpgradeServer(
+        ctx,
+        sdkProvider.New().GRPCProvider,
+    )
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    // Create muxed provider
+    muxServer, err := tf6muxserver.NewMuxServer(ctx,
+        upgradedSdkProvider,
+        providerserver.NewProtocol6(frameworkProvider.New()),
+    )
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    err = muxServer.Serve(ctx, &tf6muxserver.ServeOpts{
+        Address: "registry.terraform.io/ubiquiti-community/unifi",
+        Debug:   debug,
+    })
+    if err != nil {
+        log.Fatal(err)
+    }
+}
+```
+
+### 4. Provider Implementation
+
+Create `unifi/provider.go`:
+```go
+package unifi
+
+import (
+    "context"
+    "github.com/hashicorp/terraform-plugin-framework/datasource"
+    "github.com/hashicorp/terraform-plugin-framework/provider"
+    "github.com/hashicorp/terraform-plugin-framework/provider/schema"
+    "github.com/hashicorp/terraform-plugin-framework/resource"
+    "github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+type unifiProvider struct {
+    version string
+}
+
+type unifiProviderModel struct {
+    Username      types.String `tfsdk:"username"`
+    Password      types.String `tfsdk:"password"`
+    APIUrl        types.String `tfsdk:"api_url"`
+    AllowInsecure types.Bool   `tfsdk:"allow_insecure"`
+}
+
+func New() provider.Provider {
+    return &unifiProvider{}
+}
+
+func (p *unifiProvider) Schema(ctx context.Context, req provider.SchemaRequest, resp *provider.SchemaResponse) {
+    resp.Schema = schema.Schema{
+        Attributes: map[string]schema.Attribute{
+            "username": schema.StringAttribute{
+                Optional:    true,
+                Description: "Username for UniFi controller",
+            },
+            "password": schema.StringAttribute{
+                Optional:    true,
+                Sensitive:   true,
+                Description: "Password for UniFi controller",
+            },
+            "api_url": schema.StringAttribute{
+                Optional:    true,
+                Description: "URL of the UniFi controller",
+            },
+            "allow_insecure": schema.BoolAttribute{
+                Optional:    true,
+                Description: "Allow insecure connections",
+            },
+        },
+    }
+}
+
+func (p *unifiProvider) Configure(ctx context.Context, req provider.ConfigureRequest, resp *provider.ConfigureResponse) {
+    var config unifiProviderModel
+    diags := req.Config.Get(ctx, &config)
+    resp.Diagnostics.Append(diags...)
+    if resp.Diagnostics.HasError() {
+        return
+    }
+
+    // Configure your UniFi client here
+    // Store client in resp.DataSourceData and resp.ResourceData
+}
+
+func (p *unifiProvider) Resources(ctx context.Context) []func() resource.Resource {
+    return []func() resource.Resource{
+        // Add your new framework resources here
+        // NewWifiNetworkResource,
+    }
+}
+
+func (p *unifiProvider) DataSources(ctx context.Context) []func() datasource.DataSource {
+    return []func() datasource.DataSource{
+        // Add your new framework data sources here
+    }
+}
+
+func (p *unifiProvider) Metadata(ctx context.Context, req provider.MetadataRequest, resp *provider.MetadataResponse) {
+    resp.TypeName = "unifi"
+    resp.Version = p.version
+}
+```
+
+### 5. Resource Migration Pattern
+
+For each SDK v2 resource, create a new Plugin Framework version:
+
+**Example: WiFi Network Resource** (`unifi/resource_wifi_network.go`):
+```go
+package unifi
+
+import (
+    "context"
+    "github.com/hashicorp/terraform-plugin-framework/resource"
+    "github.com/hashicorp/terraform-plugin-framework/resource/schema"
+    "github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+type wifiNetworkResource struct {
+    client *unifi.Client // Your UniFi client
+}
+
+type wifiNetworkResourceModel struct {
+    ID       types.String `tfsdk:"id"`
+    Name     types.String `tfsdk:"name"`
+    SSID     types.String `tfsdk:"ssid"`
+    Security types.String `tfsdk:"security"`
+    Password types.String `tfsdk:"password"`
+    VLANId   types.Int64  `tfsdk:"vlan_id"`
+}
+
+func NewWifiNetworkResource() resource.Resource {
+    return &wifiNetworkResource{}
+}
+
+func (r *wifiNetworkResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+    resp.Schema = schema.Schema{
+        Description: "Manages a WiFi network in UniFi controller",
+        Attributes: map[string]schema.Attribute{
+            "id": schema.StringAttribute{
+                Computed:    true,
+                Description: "The ID of the WiFi network",
+            },
+            "name": schema.StringAttribute{
+                Required:    true,
+                Description: "The name of the WiFi network",
+            },
+            "ssid": schema.StringAttribute{
+                Required:    true,
+                Description: "The SSID of the WiFi network",
+            },
+            "security": schema.StringAttribute{
+                Optional:    true,
+                Computed:    true,
+                Description: "Security type (open, wep, wpa, wpa2, wpa3)",
+            },
+            "password": schema.StringAttribute{
+                Optional:    true,
+                Sensitive:   true,
+                Description: "WiFi password",
+            },
+            "vlan_id": schema.Int64Attribute{
+                Optional:    true,
+                Description: "VLAN ID for the network",
+            },
+        },
+    }
+}
+
+// Implement CRUD operations...
+func (r *wifiNetworkResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+    var plan wifiNetworkResourceModel
+    diags := req.Plan.Get(ctx, &plan)
+    resp.Diagnostics.Append(diags...)
+    if resp.Diagnostics.HasError() {
+        return
+    }
+
+    // Create the resource via UniFi API
+    // Handle the response and update the plan
+    
+    diags = resp.State.Set(ctx, plan)
+    resp.Diagnostics.Append(diags...)
+}
+
+// Implement Read, Update, Delete, ImportState methods...
+func (r *wifiNetworkResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+    var state wifiNetworkResourceModel
+    diags := req.State.Get(ctx, &state)
+    resp.Diagnostics.Append(diags...)
+    if resp.Diagnostics.HasError() {
+        return
+    }
+
+    // Read from API and update state
+    // Critical: Handle null vs empty values consistently
+    if apiResponse.Field == "" {
+        state.Field = types.StringNull()
+    } else {
+        state.Field = types.StringValue(apiResponse.Field)
+    }
+
+    diags = resp.State.Set(ctx, state)
+    resp.Diagnostics.Append(diags...)
+}
+
+func (r *wifiNetworkResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+    // Implementation similar to Create
+}
+
+func (r *wifiNetworkResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+    var state wifiNetworkResourceModel
+    diags := req.State.Get(ctx, &state)
+    resp.Diagnostics.Append(diags...)
+    if resp.Diagnostics.HasError() {
+        return
+    }
+
+    // Delete via API
+}
+
+func (r *wifiNetworkResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+    resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+}
+
+func (r *wifiNetworkResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+    resp.TypeName = req.ProviderTypeName + "_wifi_network"
+}
+
+func (r *wifiNetworkResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+    if req.ProviderData == nil {
+        return
+    }
+
+    client, ok := req.ProviderData.(*unifi.Client)
+    if !ok {
+        resp.Diagnostics.AddError(
+            "Unexpected Resource Configure Type",
+            "Expected *unifi.Client, got something else",
+        )
+        return
+    }
+
+    r.client = client
+}
+```
+
+### 6. Data Source Migration
+
+Create corresponding data sources following similar patterns to resources.
+
+### 7. Testing Migration
+
+Update tests to use the new test patterns:
+```go
+func TestAccWifiNetwork_basic(t *testing.T) {
+    resource.Test(t, resource.TestCase{
+        PreCheck:                 func() { testAccPreCheck(t) },
+        ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+        Steps: []resource.TestStep{
+            {
+                Config: testAccWifiNetworkConfig_basic(),
+                Check: resource.ComposeTestCheckFunc(
+                    resource.TestCheckResourceAttr("unifi_wifi_network.test", "name", "test-network"),
+                ),
+            },
+            {
+                ResourceName:      "unifi_wifi_network.test",
+                ImportState:       true,
+                ImportStateVerify: true,
+            },
+        },
+    })
+}
+```
+
+## Critical Migration Considerations
+
+### 1. State Compatibility
+- **Issue**: Plugin Framework handles state differently than SDK v2
+- **Solution**: Implement proper state upgrade logic if needed
+- **Test**: Ensure existing Terraform states work with new provider
+
+### 2. Type Conversion Patterns
+Based on ironic provider experience:
+```go
+// Handle null vs empty consistently
+if apiResponse.Field == "" {
+    model.Field = types.StringNull()
+} else {
+    model.Field = types.StringValue(apiResponse.Field)
+}
+
+// Lists should be null when empty
+if len(apiResponse.Items) > 0 {
+    itemValues := make([]attr.Value, len(apiResponse.Items))
+    for i, item := range apiResponse.Items {
+        itemValues[i] = types.StringValue(item)
+    }
+    model.Items, diags = types.ListValue(types.StringType, itemValues)
+} else {
+    model.Items = types.ListNull(types.StringType)
+}
+```
+
+### 3. Import Functionality
+- Ensure no-op plans after import
+- Handle computed vs configured attributes properly
+- Test import scenarios thoroughly
+
+### 4. Validation Migration
+```go
+// SDK v2
+validateFunc: validation.StringInSlice([]string{"option1", "option2"}, false)
+
+// Plugin Framework
+Validators: []validator.String{
+    stringvalidator.OneOf("option1", "option2"),
+}
+```
+
+## UniFi-Specific Migration Strategy
+
+### Phase 1: Infrastructure Setup
+1. Update `terraform-provider-mux` branch with Plugin Framework provider
+2. Set up muxing in `main.go`
+3. Create basic provider structure in `unifi/` directory
+
+### Phase 2: Core Resource Migration
+Prioritize these resources for initial migration:
+1. `unifi_wifi_network` - Core WiFi network management
+2. `unifi_user` - User management
+3. `unifi_port_profile` - Port profile configuration
+
+### Phase 3: Advanced Features
+1. Complex nested resources
+2. Advanced validation patterns
+3. Custom plan modifiers
+
+### Phase 4: Testing & Documentation
+1. Comprehensive acceptance tests
+2. Import testing
+3. Documentation updates
+
+## Common Pitfalls & Solutions
+
+### 1. Schema Definition Differences
+- **Issue**: Attribute syntax differs between SDK v2 and Framework
+- **Solution**: Use schema validation tools and reference examples
+
+### 2. Client Configuration
+- **Issue**: Provider configuration handling changes
+- **Solution**: Store client in provider data, access in resources via `req.ProviderData`
+
+### 3. State Management
+- **Issue**: Framework handles null/unknown differently
+- **Solution**: Always check for null/unknown before operations, use consistent patterns
+
+### 4. Complex Nested Attributes
+- **Issue**: Framework requires explicit nested attribute schemas
+- **Solution**: Define nested object schemas explicitly, avoid interface{} types
+
+### 5. Import State Mismatches
+- **Issue**: Plan shows changes after importing a resource
+- **Solution**: Ensure consistent null handling in read functions
+```go
+// ❌ Wrong: Always setting values
+model.LastError = types.StringValue(apiResponse.LastError)
+
+// ✅ Correct: Handle empty strings as null
+if apiResponse.LastError == "" {
+    model.LastError = types.StringNull()
+} else {
+    model.LastError = types.StringValue(apiResponse.LastError)
+}
+```
+
+## Validation Checklist
+
+- [ ] All existing resources have Framework equivalents
+- [ ] State compatibility maintained
+- [ ] Import functionality works
+- [ ] Tests pass with both providers
+- [ ] Documentation updated
+- [ ] No-op plans after apply/import
+- [ ] Error handling follows Framework patterns
+- [ ] Performance impact assessed
+
+## Resources for Reference
+
+- [Ironic Provider Example](https://github.com/appkins-org/terraform-provider-ironic) - Complete migration example
+- [Framework Migration Guide](https://developer.hashicorp.com/terraform/plugin/framework/migrating)
+- [Muxing Documentation](https://developer.hashicorp.com/terraform/plugin/mux)
+- [Framework Testing](https://developer.hashicorp.com/terraform/plugin/framework/testing)
+
+This migration approach allows for gradual transition while maintaining backward compatibility through provider muxing.

--- a/.github/instructions/plugin-framework-migration-guide.instructions.md
+++ b/.github/instructions/plugin-framework-migration-guide.instructions.md
@@ -1,0 +1,554 @@
+# Terraform Plugin Framework Development Guide
+
+A comprehensive guide for developing Terraform providers using the terraform-plugin-framework, based on real-world experience with complex resource management scenarios.
+
+## Table of Contents
+
+1. [Project Structure & Setup](#project-structure--setup)
+2. [Resource Model Design](#resource-model-design)  
+3. [Schema Definition Best Practices](#schema-definition-best-practices)
+4. [State Management & Import](#state-management--import)
+5. [Type Conversion & Dynamic Data](#type-conversion--dynamic-data)
+6. [Validation & Plan Modifiers](#validation--plan-modifiers)
+7. [Error Handling](#error-handling)
+8. [Testing Strategies](#testing-strategies)
+9. [Common Pitfalls](#common-pitfalls)
+
+## Project Structure & Setup
+
+### Directory Layout
+```
+terraform-provider-{name}/
+├── main.go                          # Provider entry point
+├── {provider}/                      # Provider-specific code
+│   ├── provider.go                  # Provider definition
+│   ├── clients.go                   # API client management
+│   ├── resource_{name}.go           # Resource implementations
+│   ├── data_source_{name}.go        # Data source implementations
+│   └── util/                        # Utility functions
+│       ├── dynamic.go               # Type conversion utilities
+│       └── update_opt.go            # API update option helpers
+├── docs/                            # Auto-generated documentation
+├── examples/                        # Example configurations
+└── testhelper/                      # Test utilities
+```
+
+### Essential Imports
+```go
+import (
+    "context"
+    "fmt"
+    
+    "github.com/hashicorp/terraform-plugin-framework/resource"
+    "github.com/hashicorp/terraform-plugin-framework/resource/schema"
+    "github.com/hashicorp/terraform-plugin-framework/types"
+    "github.com/hashicorp/terraform-plugin-framework/diag"
+    "github.com/hashicorp/terraform-plugin-framework/path"
+    
+    // Validators
+    "github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
+    "github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+    
+    // Plan modifiers
+    "github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+    "github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+    "github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
+)
+```
+
+## Resource Model Design
+
+### Model Structure
+```go
+type resourceModel struct {
+    ID             types.String  `tfsdk:"id"`
+    Name           types.String  `tfsdk:"name"`
+    RequiredField  types.String  `tfsdk:"required_field"`
+    OptionalList   types.List    `tfsdk:"optional_list"`
+    ComputedField  types.String  `tfsdk:"computed_field"`
+    DynamicData    types.Dynamic `tfsdk:"dynamic_data"`
+}
+```
+
+### Interface Implementation
+```go
+// Ensure your resource satisfies required interfaces
+var (
+    _ resource.Resource                = &myResource{}
+    _ resource.ResourceWithConfigure   = &myResource{}
+    _ resource.ResourceWithImportState = &myResource{}
+)
+```
+
+## Schema Definition Best Practices
+
+### Field Types & Attributes
+```go
+func (r *myResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+    resp.Schema = schema.Schema{
+        MarkdownDescription: "Manages a resource with comprehensive examples.",
+        Attributes: map[string]schema.Attribute{
+            // Required fields
+            "required_field": schema.StringAttribute{
+                MarkdownDescription: "A required string field.",
+                Required:            true,
+            },
+            
+            // Optional fields with validation
+            "optional_field": schema.StringAttribute{
+                MarkdownDescription: "An optional field with validation.",
+                Optional:            true,
+                Validators: []validator.String{
+                    stringvalidator.LengthAtLeast(1),
+                },
+            },
+            
+            // Computed fields
+            "computed_field": schema.StringAttribute{
+                MarkdownDescription: "A computed field set by the API.",
+                Computed:            true,
+            },
+            
+            // Optional + Computed (state can be set by user OR API)
+            "optional_computed": schema.StringAttribute{
+                MarkdownDescription: "Field that can be set by user or computed.",
+                Optional:            true,
+                Computed:            true,
+            },
+            
+            // Lists with validation
+            "list_field": schema.ListAttribute{
+                MarkdownDescription: "A list of strings with conflict validation.",
+                ElementType:         types.StringType,
+                Optional:            true,
+                Computed:            true,
+                Validators: []validator.List{
+                    listvalidator.ConflictsWith(path.MatchRoot("other_field")),
+                },
+                PlanModifiers: []planmodifier.List{
+                    listplanmodifier.RequiresReplace(),
+                },
+            },
+            
+            // Dynamic fields for flexible data
+            "extra": schema.DynamicAttribute{
+                MarkdownDescription: "Extra metadata as key-value pairs.",
+                Optional:            true,
+                PlanModifiers: []planmodifier.Dynamic{
+                    dynamicplanmodifier.RequiresReplace(),
+                },
+            },
+        },
+    }
+}
+```
+
+### Plan Modifiers
+- **RequiresReplace**: Forces resource recreation when field changes
+- **UseStateForUnknown**: Preserves current state value when new value is unknown
+- **RequiresReplaceIf**: Conditional replacement based on custom logic
+
+## State Management & Import
+
+### Critical: Consistent Null Handling
+The most common cause of import issues is inconsistent handling of null vs empty values.
+
+```go
+func (r *myResource) readResourceData(ctx context.Context, model *resourceModel, diagnostics *diag.Diagnostics) {
+    // ❌ WRONG: Always setting string values
+    model.LastError = types.StringValue(apiResponse.LastError)
+    
+    // ✅ CORRECT: Handle empty strings as null
+    if apiResponse.LastError == "" {
+        model.LastError = types.StringNull()
+    } else {
+        model.LastError = types.StringValue(apiResponse.LastError)
+    }
+    
+    // ❌ WRONG: Setting empty lists as values
+    if len(apiResponse.Items) > 0 {
+        // ... populate list
+    } else {
+        model.Items = types.ListValueMust(types.StringType, []attr.Value{})
+    }
+    
+    // ✅ CORRECT: Use null for empty lists
+    if len(apiResponse.Items) > 0 {
+        // ... populate list
+    } else {
+        model.Items = types.ListNull(types.StringType)
+    }
+}
+```
+
+### Import State Implementation
+```go
+func (r *myResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+    // Pass through the ID for simple imports
+    resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+    
+    // For complex imports, parse the import identifier
+    // Example: "project/resource_id" format
+    parts := strings.Split(req.ID, "/")
+    if len(parts) != 2 {
+        resp.Diagnostics.AddError(
+            "Invalid Import ID",
+            "Import ID must be in format 'project/resource_id'",
+        )
+        return
+    }
+    
+    resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("project"), parts[0])...)
+    resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), parts[1])...)
+}
+```
+
+### Read Function Best Practices
+```go
+func (r *myResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+    var state resourceModel
+    
+    diags := req.State.Get(ctx, &state)
+    resp.Diagnostics.Append(diags...)
+    if resp.Diagnostics.HasError() {
+        return
+    }
+    
+    // Use a helper function for consistency
+    r.readResourceData(ctx, &state, &resp.Diagnostics)
+    if resp.Diagnostics.HasError() {
+        return
+    }
+    
+    // Always set the state back
+    resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
+}
+```
+
+## Type Conversion & Dynamic Data
+
+### Dynamic Type Handling
+```go
+// Utility for converting maps to Dynamic types
+func StringMapToDynamic(ctx context.Context, input map[string]string) (types.Dynamic, error) {
+    if input == nil {
+        return types.DynamicNull(), nil
+    }
+    
+    if len(input) == 0 {
+        // Empty map - create an empty object
+        objectType := types.ObjectType{AttrTypes: map[string]attr.Type{}}
+        objectValue := types.ObjectValueMust(objectType.AttrTypes, map[string]attr.Value{})
+        return types.DynamicValue(objectValue), nil
+    }
+    
+    // Convert all values to string types
+    attrTypes := make(map[string]attr.Type)
+    attrValues := make(map[string]attr.Value)
+    
+    for key, value := range input {
+        attrTypes[key] = types.StringType
+        attrValues[key] = types.StringValue(value)
+    }
+    
+    objectValue, diags := types.ObjectValue(attrTypes, attrValues)
+    if diags.HasError() {
+        return types.DynamicNull(), fmt.Errorf("error creating object: %v", diags)
+    }
+    
+    return types.DynamicValue(objectValue), nil
+}
+
+// Converting Dynamic back to Go types
+func DynamicToStringMap(ctx context.Context, dynamic types.Dynamic) (map[string]string, error) {
+    if dynamic.IsNull() || dynamic.IsUnknown() {
+        return nil, nil
+    }
+    
+    // Handle the conversion based on underlying type
+    // Implementation depends on your specific needs
+}
+```
+
+### List Handling
+```go
+// Creating lists from API responses
+if len(apiResponse.Items) > 0 {
+    itemValues := make([]attr.Value, len(apiResponse.Items))
+    for i, item := range apiResponse.Items {
+        itemValues[i] = types.StringValue(item)
+    }
+    itemsList, diags := types.ListValue(types.StringType, itemValues)
+    diagnostics.Append(diags...)
+    if diagnostics.HasError() {
+        return
+    }
+    model.Items = itemsList
+} else {
+    model.Items = types.ListNull(types.StringType)
+}
+
+// Extracting lists to Go slices
+if !plan.Items.IsNull() && !plan.Items.IsUnknown() {
+    var items []string
+    diags := plan.Items.ElementsAs(ctx, &items, false)
+    resp.Diagnostics.Append(diags...)
+    if resp.Diagnostics.HasError() {
+        return
+    }
+    // Use items slice...
+}
+```
+
+## Validation & Plan Modifiers
+
+### Custom Validators
+```go
+// Conflict validation
+schema.StringAttribute{
+    Validators: []validator.String{
+        stringvalidator.ConflictsWith(path.MatchRoot("other_field")),
+    },
+}
+
+// Length validation
+schema.StringAttribute{
+    Validators: []validator.String{
+        stringvalidator.LengthBetween(1, 255),
+    },
+}
+
+// List validation
+schema.ListAttribute{
+    Validators: []validator.List{
+        listvalidator.SizeAtLeast(1),
+        listvalidator.ConflictsWith(path.MatchRoot("alternative_field")),
+    },
+}
+```
+
+### Plan Modifiers for Immutable Resources
+```go
+// Fields that require replacement when changed
+"immutable_field": schema.StringAttribute{
+    PlanModifiers: []planmodifier.String{
+        stringplanmodifier.RequiresReplace(),
+    },
+},
+
+// Lists that require replacement
+"immutable_list": schema.ListAttribute{
+    PlanModifiers: []planmodifier.List{
+        listplanmodifier.RequiresReplace(),
+    },
+},
+```
+
+## Error Handling
+
+### Structured Error Reporting
+```go
+// Attribute-specific errors
+resp.Diagnostics.AddAttributeError(
+    path.Root("field_name"),
+    "Error Title",
+    "Detailed error message explaining what went wrong and how to fix it.",
+)
+
+// General errors
+resp.Diagnostics.AddError(
+    "API Error",
+    fmt.Sprintf("Could not perform operation: %s", err),
+)
+
+// Warning (non-blocking)
+resp.Diagnostics.AddWarning(
+    "Deprecation Warning",
+    "This field is deprecated and will be removed in a future version.",
+)
+```
+
+### API Error Handling
+```go
+// Check for specific HTTP status codes
+if gophercloud.ResponseCodeIs(err, http.StatusNotFound) {
+    // Resource doesn't exist - this is OK for delete operations
+    return
+}
+
+// Handle different error types
+switch e := err.(type) {
+case gophercloud.ErrDefault404:
+    // Handle 404 specifically
+case gophercloud.ErrDefault409:
+    // Handle conflict errors
+default:
+    // Generic error handling
+}
+```
+
+## Testing Strategies
+
+### Acceptance Tests
+```go
+func TestAccResource_basic(t *testing.T) {
+    resource.Test(t, resource.TestCase{
+        PreCheck:                 func() { testAccPreCheck(t) },
+        ProtoV5ProviderFactories: protoV5ProviderFactories(),
+        CheckDestroy:             testAccResourceDestroy,
+        Steps: []resource.TestStep{
+            {
+                Config: testAccResourceConfig_basic(),
+                Check: resource.ComposeTestCheckFunc(
+                    resource.TestCheckResourceAttr("myresource.test", "name", "test"),
+                    resource.TestCheckResourceAttrSet("myresource.test", "id"),
+                ),
+            },
+        },
+    })
+}
+
+// Test imports specifically
+func TestAccResource_import(t *testing.T) {
+    resource.Test(t, resource.TestCase{
+        PreCheck:                 func() { testAccPreCheck(t) },
+        ProtoV5ProviderFactories: protoV5ProviderFactories(),
+        CheckDestroy:             testAccResourceDestroy,
+        Steps: []resource.TestStep{
+            {
+                Config: testAccResourceConfig_basic(),
+            },
+            {
+                ResourceName:      "myresource.test",
+                ImportState:       true,
+                ImportStateVerify: true,
+                // ImportStateVerifyIgnore: []string{"field_not_in_api"},
+            },
+        },
+    })
+}
+```
+
+## Common Pitfalls
+
+### 1. State Mismatch After Import
+**Problem**: Plan shows changes after importing a resource.
+
+**Solution**:
+- Ensure consistent null handling in read functions
+- Match computed field behavior between create and read
+- Handle empty vs null values consistently
+
+```go
+// ❌ Inconsistent handling
+model.Field = types.StringValue(apiResponse.Field) // Always sets a value
+
+// ✅ Consistent handling  
+if apiResponse.Field == "" {
+    model.Field = types.StringNull()
+} else {
+    model.Field = types.StringValue(apiResponse.Field)
+}
+```
+
+### 2. Type Conversion Errors
+**Problem**: Dynamic types failing to convert properly.
+
+**Solution**:
+- Always check for null/unknown before conversion
+- Handle empty collections as null, not empty values
+- Use utility functions for consistent conversion
+
+### 3. Plan Modifier Misuse
+**Problem**: Unexpected replacement or diff behavior.
+
+**Solution**:
+- Use `RequiresReplace` sparingly, only for truly immutable fields
+- Test plan behavior thoroughly with imports
+- Consider `UseStateForUnknown` for computed fields
+
+### 4. Validation Conflicts
+**Problem**: Validators preventing valid configurations.
+
+**Solution**:
+- Test edge cases thoroughly
+- Use `ConflictsWith` carefully - ensure mutual exclusivity is correct
+- Document validation requirements clearly
+
+### 5. Concurrent Modification Issues
+**Problem**: Resources getting modified during Terraform operations.
+
+**Solution**:
+- Implement proper error handling for concurrent modifications
+- Use appropriate timeouts for long-running operations
+- Consider implementing retry logic for transient failures
+
+## Advanced Patterns
+
+### Wait Functions for Async Resources
+```go
+func (r *myResource) waitForCompletion(ctx context.Context, id string, model *resourceModel, diagnostics *diag.Diagnostics) error {
+    timeout := 5 * time.Minute
+    checkInterval := 10 * time.Second
+    
+    for {
+        r.readResourceData(ctx, model, diagnostics)
+        if diagnostics.HasError() {
+            return fmt.Errorf("error reading resource during wait")
+        }
+        
+        state := model.State.ValueString()
+        switch state {
+        case "active", "complete":
+            return nil
+        case "error", "failed":
+            return fmt.Errorf("resource entered error state: %s", model.LastError.ValueString())
+        default:
+            time.Sleep(checkInterval)
+            timeout -= checkInterval
+            if timeout <= 0 {
+                return fmt.Errorf("timeout waiting for resource completion")
+            }
+        }
+    }
+}
+```
+
+### Conditional Logic in CRUD Operations
+```go
+func (r *myResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+    var plan resourceModel
+    diags := req.Plan.Get(ctx, &plan)
+    resp.Diagnostics.Append(diags...)
+    if resp.Diagnostics.HasError() {
+        return
+    }
+    
+    // Handle mutually exclusive fields
+    if !plan.FieldA.IsNull() && !plan.FieldB.IsNull() {
+        resp.Diagnostics.AddError(
+            "Conflicting Configuration",
+            "Cannot specify both field_a and field_b",
+        )
+        return
+    }
+    
+    // Build API request based on what's provided
+    createOpts := &CreateOpts{}
+    
+    if !plan.FieldA.IsNull() {
+        createOpts.FieldA = plan.FieldA.ValueString()
+    } else if !plan.FieldB.IsNull() {
+        createOpts.FieldB = plan.FieldB.ValueString()  
+    } else {
+        resp.Diagnostics.AddError(
+            "Missing Required Field",
+            "Must specify either field_a or field_b",
+        )
+        return
+    }
+    
+    // Continue with creation...
+}
+```
+

--- a/.github/instructions/styleguide.instructions.md
+++ b/.github/instructions/styleguide.instructions.md
@@ -1,0 +1,314 @@
+---
+description: 'Terraform plugin framework migration guide.'
+tools: ['changes', 'codebase', 'editFiles', 'extensions', 'fetch', 'findTestFiles', 'githubRepo', 'new', 'openSimpleBrowser', 'problems', 'readCellOutput', 'runCommands', 'runNotebooks', 'runTasks', 'runTests', 'search', 'searchResults', 'terminalLastCommand', 'terminalSelection', 'testFailure', 'usages', 'vscodeAPI', 'GistPad', 'activePullRequest', 'copilotCodingAgent']
+---
+## Style Guide for Terraform Plugin Framework Migration
+
+Refer to the [Terraform Plugin Framework](https://developer.hashicorp.com/terraform/docs/plugin-framework) documentation for detailed guidelines.
+
+Use the styleguide.md file as a reference for best practices and conventions when migrating to the Terraform Plugin Framework.
+
+This document outlines the key principles and practices to follow during the migration process.
+
+## Directory and File Structure
+
+- **Package organization**: Avoid package sprawl; group related functionality appropriately
+- **Utility packages**: Avoid generic "util" packages - use descriptive names (e.g., `wait.Poll` instead of `util.Poll`)
+- **Naming conventions**: 
+  - All filenames lowercase
+  - Use underscores in Go source files/directories (not dashes)
+  - Package directories avoid separators when possible
+  - Use nested subdirectories for multi-word package names
+
+## Project Structure
+
+- **Directory layout**: `{provider}/` for main code, `util/` for type conversion, `testhelper/` for test utilities
+- **File naming**: `resource_{name}.go`, `data_source_{name}.go` for clear identification
+- **Essential imports**: Always include context, framework types, validators, and plan modifiers
+- **Interface compliance**: Declare interface satisfaction with compile-time checks:
+  ```go
+  var (
+      _ resource.Resource                = &myResource{}
+      _ resource.ResourceWithConfigure   = &myResource{}
+      _ resource.ResourceWithImportState = &myResource{}
+  )
+  ```
+
+## Resource Model Design
+- **Struct tags**: Use `tfsdk:"field_name"` tags matching schema attribute names
+- **Type selection**: `types.String`, `types.List`, `types.Dynamic` for complex data
+- **Required vs Optional vs Computed**: Match API behavior - required for user input, computed for API-generated values
+- **Null handling**: Always use null types (`types.StringNull()`) for empty/unset values
+
+## Schema Definition Patterns
+- **Field attributes**: 
+  - `Required: true` for mandatory user input
+  - `Optional: true, Computed: true` for fields that can be set by user OR API
+  - `Computed: true` for read-only API values
+- **Validation**: Use framework validators (`stringvalidator.ConflictsWith`, `listvalidator.SizeAtLeast`)
+- **Plan modifiers**: `RequiresReplace()` only for truly immutable fields
+- **Conflict handling**: Use `ConflictsWith(path.MatchRoot("other_field"))` for mutually exclusive options
+
+## State Management (Critical for Import Success)
+- **Null vs Empty**: Always use `types.StringNull()` for empty strings, `types.ListNull()` for empty lists
+- **Read function consistency**: Must handle API responses identically in Create and Read operations
+- **Import verification**: Test with `ImportStateVerify: true` to catch state mismatches
+- **Critical pattern for strings**:
+  ```go
+  if apiResponse.Field == "" {
+      model.Field = types.StringNull()
+  } else {
+      model.Field = types.StringValue(apiResponse.Field)
+  }
+  ```
+- **Critical pattern for lists**:
+  ```go
+  if len(apiResponse.Items) > 0 {
+      // Create list with values
+  } else {
+      model.Items = types.ListNull(types.StringType)
+  }
+  ```
+
+## Type Conversion Best Practices
+- **Dynamic types**: Check `IsNull()` and `IsUnknown()` before conversion
+- **Empty maps**: Use `len(input) > 0` check, return `types.DynamicNull()` for empty
+- **List extraction**: Use `ElementsAs(ctx, &slice, false)` to convert to Go slices
+- **Map to Dynamic**: Create utility functions for consistent conversion patterns
+- **Go slice to List**: Pre-allocate slice with `make([]attr.Value, len(source))`
+
+## Error Handling Patterns
+- **Attribute errors**: Use `AddAttributeError(path.Root("field"), title, detail)` for field-specific issues
+- **API errors**: Check specific HTTP codes with `gophercloud.ResponseCodeIs(err, http.StatusNotFound)`
+- **Diagnostics flow**: Always check `resp.Diagnostics.HasError()` before continuing
+- **Resource cleanup**: Delete created resources in Create function if post-creation steps fail
+
+## Resource Model Design
+- **Struct tags**: Use `tfsdk:"field_name"` tags matching schema attribute names
+- **Type selection**: `types.String`, `types.List`, `types.Dynamic` for complex data
+- **Required vs Optional vs Computed**: Match API behavior - required for user input, computed for API-generated values
+- **Null handling**: Always use null types (`types.StringNull()`) for empty/unset values
+
+## Schema Definition Patterns
+- **Field attributes**: 
+  - `Required: true` for mandatory user input
+  - `Optional: true, Computed: true` for fields that can be set by user OR API
+  - `Computed: true` for read-only API values
+- **Validation**: Use framework validators (`stringvalidator.ConflictsWith`, `listvalidator.SizeAtLeast`)
+- **Plan modifiers**: `RequiresReplace()` only for truly immutable fields
+- **Conflict handling**: Use `ConflictsWith(path.MatchRoot("other_field"))` for mutually exclusive options
+
+## State Management (Critical for Import Success)
+- **Null vs Empty**: Always use `types.StringNull()` for empty strings, `types.ListNull()` for empty lists
+- **Read function consistency**: Must handle API responses identically in Create and Read operations
+- **Import verification**: Test with `ImportStateVerify: true` to catch state mismatches
+- **Critical pattern for strings**:
+  ```go
+  if apiResponse.Field == "" {
+      model.Field = types.StringNull()
+  } else {
+      model.Field = types.StringValue(apiResponse.Field)
+  }
+  ```
+- **Critical pattern for lists**:
+  ```go
+  if len(apiResponse.Items) > 0 {
+      // Create list with values
+  } else {
+      model.Items = types.ListNull(types.StringType)
+  }
+  ```
+
+## Type Conversion Best Practices
+- **Dynamic types**: Check `IsNull()` and `IsUnknown()` before conversion
+- **Empty maps**: Use `len(input) > 0` check, return `types.DynamicNull()` for empty
+- **List extraction**: Use `ElementsAs(ctx, &slice, false)` to convert to Go slices
+- **Map to Dynamic**: Create utility functions for consistent conversion patterns
+- **Go slice to List**: Pre-allocate slice with `make([]attr.Value, len(source))`
+
+## Testing Strategies
+
+### Acceptance Tests
+```go
+func TestAccResource_basic(t *testing.T) {
+    resource.Test(t, resource.TestCase{
+        PreCheck:                 func() { testAccPreCheck(t) },
+        ProtoV5ProviderFactories: protoV5ProviderFactories(),
+        CheckDestroy:             testAccResourceDestroy,
+        Steps: []resource.TestStep{
+            {
+                Config: testAccResourceConfig_basic(),
+                Check: resource.ComposeTestCheckFunc(
+                    resource.TestCheckResourceAttr("myresource.test", "name", "test"),
+                    resource.TestCheckResourceAttrSet("myresource.test", "id"),
+                ),
+            },
+        },
+    })
+}
+
+// Test imports specifically
+func TestAccResource_import(t *testing.T) {
+    resource.Test(t, resource.TestCase{
+        PreCheck:                 func() { testAccPreCheck(t) },
+        ProtoV5ProviderFactories: protoV5ProviderFactories(),
+        CheckDestroy:             testAccResourceDestroy,
+        Steps: []resource.TestStep{
+            {
+                Config: testAccResourceConfig_basic(),
+            },
+            {
+                ResourceName:      "myresource.test",
+                ImportState:       true,
+                ImportStateVerify: true,
+                // ImportStateVerifyIgnore: []string{"field_not_in_api"},
+            },
+        },
+    })
+}
+```
+
+## Common Pitfalls
+
+### 1. State Mismatch After Import
+**Problem**: Plan shows changes after importing a resource.
+
+**Solution**:
+- Ensure consistent null handling in read functions
+- Match computed field behavior between create and read
+- Handle empty vs null values consistently
+
+```go
+// ❌ Inconsistent handling
+model.Field = types.StringValue(apiResponse.Field) // Always sets a value
+
+// ✅ Consistent handling  
+if apiResponse.Field == "" {
+    model.Field = types.StringNull()
+} else {
+    model.Field = types.StringValue(apiResponse.Field)
+}
+```
+
+### 2. Type Conversion Errors
+**Problem**: Dynamic types failing to convert properly.
+
+**Solution**:
+- Always check for null/unknown before conversion
+- Handle empty collections as null, not empty values
+- Use utility functions for consistent conversion
+
+### 3. Plan Modifier Misuse
+**Problem**: Unexpected replacement or diff behavior.
+
+**Solution**:
+- Use `RequiresReplace` sparingly, only for truly immutable fields
+- Test plan behavior thoroughly with imports
+- Consider `UseStateForUnknown` for computed fields
+
+### 4. Validation Conflicts
+**Problem**: Validators preventing valid configurations.
+
+**Solution**:
+- Test edge cases thoroughly
+- Use `ConflictsWith` carefully - ensure mutual exclusivity is correct
+- Document validation requirements clearly
+
+### 5. Concurrent Modification Issues
+**Problem**: Resources getting modified during Terraform operations.
+
+**Solution**:
+- Implement proper error handling for concurrent modifications
+- Use appropriate timeouts for long-running operations
+- Consider implementing retry logic for transient failures
+
+## Advanced Patterns
+
+### Wait Functions for Async Resources
+```go
+func (r *myResource) waitForCompletion(ctx context.Context, id string, model *resourceModel, diagnostics *diag.Diagnostics) error {
+    timeout := 5 * time.Minute
+    checkInterval := 10 * time.Second
+    
+    for {
+        r.readResourceData(ctx, model, diagnostics)
+        if diagnostics.HasError() {
+            return fmt.Errorf("error reading resource during wait")
+        }
+        
+        state := model.State.ValueString()
+        switch state {
+        case "active", "complete":
+            return nil
+        case "error", "failed":
+            return fmt.Errorf("resource entered error state: %s", model.LastError.ValueString())
+        default:
+            time.Sleep(checkInterval)
+            timeout -= checkInterval
+            if timeout <= 0 {
+                return fmt.Errorf("timeout waiting for resource completion")
+            }
+        }
+    }
+}
+```
+
+### Conditional Logic in CRUD Operations
+```go
+func (r *myResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+    var plan resourceModel
+    diags := req.Plan.Get(ctx, &plan)
+    resp.Diagnostics.Append(diags...)
+    if resp.Diagnostics.HasError() {
+        return
+    }
+    
+    // Handle mutually exclusive fields
+    if !plan.FieldA.IsNull() && !plan.FieldB.IsNull() {
+        resp.Diagnostics.AddError(
+            "Conflicting Configuration",
+            "Cannot specify both field_a and field_b",
+        )
+        return
+    }
+    
+    // Build API request based on what's provided
+    createOpts := &CreateOpts{}
+    
+    if !plan.FieldA.IsNull() {
+        createOpts.FieldA = plan.FieldA.ValueString()
+    } else if !plan.FieldB.IsNull() {
+        createOpts.FieldB = plan.FieldB.ValueString()  
+    } else {
+        resp.Diagnostics.AddError(
+            "Missing Required Field",
+            "Must specify either field_a or field_b",
+        )
+        return
+    }
+    
+    // Continue with creation...
+}
+```
+
+## Code Organization
+
+- **New libraries**: Place in `pkg/util` subdirectories if no better home exists
+- **Third-party code**: Manage Go dependencies with modules; other code goes in `third_party/`
+
+## Testing Requirements
+
+- **Unit tests**: Required for all new packages and significant functionality
+- **Test style**: Prefer table-driven tests for multiple scenarios
+- **Integration tests**: Required for significant features and kubectl commands
+- **Cross-platform**: Tests must pass on macOS and Windows
+- **Async testing**: Use wait/retry patterns instead of fixed delays
+- **Dependencies**: Use Google Cloud Artifact Registry instead of Docker Hub
+
+## Key Principles
+
+- Prioritize descriptive naming over generic utilities
+- Ensure cross-platform compatibility
+- Write comprehensive tests at multiple levels
+- Follow established patterns for package organization
+```

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,10 @@ require (
 	github.com/golangci/golangci-lint v1.56.1
 	github.com/hashicorp/go-version v1.7.0
 	github.com/hashicorp/terraform-plugin-docs v0.16.0
+	github.com/hashicorp/terraform-plugin-framework v1.15.0
+	github.com/hashicorp/terraform-plugin-go v0.28.0
+	github.com/hashicorp/terraform-plugin-log v0.9.0
+	github.com/hashicorp/terraform-plugin-mux v0.20.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.37.0
 	github.com/hashicorp/terraform-plugin-testing v1.3.0
 	github.com/testcontainers/testcontainers-go v0.32.0
@@ -182,8 +186,6 @@ require (
 	github.com/hashicorp/logutils v1.0.0 // indirect
 	github.com/hashicorp/terraform-exec v0.23.0 // indirect
 	github.com/hashicorp/terraform-json v0.25.0 // indirect
-	github.com/hashicorp/terraform-plugin-go v0.27.0 // indirect
-	github.com/hashicorp/terraform-plugin-log v0.9.0 // indirect
 	github.com/hashicorp/terraform-registry-address v0.2.5 // indirect
 	github.com/hashicorp/terraform-svchost v0.1.1 // indirect
 	github.com/hashicorp/yamux v0.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -587,10 +587,14 @@ github.com/hashicorp/terraform-json v0.25.0 h1:rmNqc/CIfcWawGiwXmRuiXJKEiJu1ntGo
 github.com/hashicorp/terraform-json v0.25.0/go.mod h1:sMKS8fiRDX4rVlR6EJUMudg1WcanxCMoWwTLkgZP/vc=
 github.com/hashicorp/terraform-plugin-docs v0.16.0 h1:UmxFr3AScl6Wged84jndJIfFccGyBZn52KtMNsS12dI=
 github.com/hashicorp/terraform-plugin-docs v0.16.0/go.mod h1:M3ZrlKBJAbPMtNOPwHicGi1c+hZUh7/g0ifT/z7TVfA=
-github.com/hashicorp/terraform-plugin-go v0.27.0 h1:ujykws/fWIdsi6oTUT5Or4ukvEan4aN9lY+LOxVP8EE=
-github.com/hashicorp/terraform-plugin-go v0.27.0/go.mod h1:FDa2Bb3uumkTGSkTFpWSOwWJDwA7bf3vdP3ltLDTH6o=
+github.com/hashicorp/terraform-plugin-framework v1.15.0 h1:LQ2rsOfmDLxcn5EeIwdXFtr03FVsNktbbBci8cOKdb4=
+github.com/hashicorp/terraform-plugin-framework v1.15.0/go.mod h1:hxrNI/GY32KPISpWqlCoTLM9JZsGH3CyYlir09bD/fI=
+github.com/hashicorp/terraform-plugin-go v0.28.0 h1:zJmu2UDwhVN0J+J20RE5huiF3XXlTYVIleaevHZgKPA=
+github.com/hashicorp/terraform-plugin-go v0.28.0/go.mod h1:FDa2Bb3uumkTGSkTFpWSOwWJDwA7bf3vdP3ltLDTH6o=
 github.com/hashicorp/terraform-plugin-log v0.9.0 h1:i7hOA+vdAItN1/7UrfBqBwvYPQ9TFvymaRGZED3FCV0=
 github.com/hashicorp/terraform-plugin-log v0.9.0/go.mod h1:rKL8egZQ/eXSyDqzLUuwUYLVdlYeamldAHSxjUFADow=
+github.com/hashicorp/terraform-plugin-mux v0.20.0 h1:3QpBnI9uCuL0Yy2Rq/kR9cOdmOFNhw88A2GoZtk5aXM=
+github.com/hashicorp/terraform-plugin-mux v0.20.0/go.mod h1:wSIZwJjSYk86NOTX3fKUlThMT4EAV1XpBHz9SAvjQr4=
 github.com/hashicorp/terraform-plugin-sdk/v2 v2.37.0 h1:NFPMacTrY/IdcIcnUB+7hsore1ZaRWU9cnB6jFoBnIM=
 github.com/hashicorp/terraform-plugin-sdk/v2 v2.37.0/go.mod h1:QYmYnLfsosrxjCnGY1p9c7Zj6n9thnEE+7RObeYs3fA=
 github.com/hashicorp/terraform-plugin-testing v1.3.0 h1:4Pn8fSspPCRUc5zRGPNZYc00VhQmQPEH6y6Pv4e/42M=

--- a/internal/provider/data_network.go
+++ b/internal/provider/data_network.go
@@ -146,6 +146,11 @@ func dataNetwork() *schema.Resource {
 				Type:        schema.TypeBool,
 				Computed:    true,
 			},
+			"ip_subnet": {
+				Description: "The IPv4 subnet of the network in CIDR notation.",
+				Type:        schema.TypeString,
+				Computed:    true,
+			},
 			"ipv6_interface_type": {
 				Description: "Specifies which type of IPv6 connection to use. Must be one of either `static`, `pd`, or `none`.",
 				Type:        schema.TypeString,
@@ -690,6 +695,7 @@ func dataNetworkRead(ctx context.Context, d *schema.ResourceData, meta any) diag
 			_ = d.Set("dhcpd_boot_server", n.DHCPDBootServer)
 			_ = d.Set("dhcpd_boot_filename", n.DHCPDBootFilename)
 			_ = d.Set("domain_name", n.DomainName)
+			_ = d.Set("ip_subnet", n.IPSubnet)
 			_ = d.Set("igmp_snooping", n.IGMPSnooping)
 			_ = d.Set("ipv6_interface_type", n.IPV6InterfaceType)
 			_ = d.Set("ipv6_static_subnet", n.IPV6Subnet)

--- a/internal/provider/data_network_test.go
+++ b/internal/provider/data_network_test.go
@@ -9,6 +9,10 @@ import (
 )
 
 func TestAccDataNetwork_byName(t *testing.T) {
+	if testClient == nil {
+		testClient = NewTestClient(t.Context())
+	}
+
 	defaultName := "Default"
 	v, err := version.NewVersion(testClient.Version())
 	if err != nil {

--- a/internal/provider/provider_framework.go
+++ b/internal/provider/provider_framework.go
@@ -1,0 +1,212 @@
+package provider
+
+import (
+	"context"
+	"os"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/ephemeral"
+	"github.com/hashicorp/terraform-plugin-framework/provider"
+	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+const (
+	ApiKeyDescription = "API key for the Unifi controller. Can be specified with the `UNIFI_API_KEY` " +
+		"environment variable. If this is set, the `username` and `password` fields are ignored."
+	UserNameDescription = "Local user name for the Unifi controller API. Can be specified with the `UNIFI_USERNAME` " +
+		"environment variable."
+	PasswordDescription = "Password for the user accessing the API. Can be specified with the `UNIFI_PASSWORD` " +
+		"environment variable."
+	ApiUrlDescription = "URL of the controller API. Can be specified with the `UNIFI_API` environment variable. " +
+		"You should **NOT** supply the path (`/api`), the SDK will discover the appropriate paths. This is " +
+		"to support UDM Pro style API paths as well as more standard controller paths."
+	SiteDescription = "The site in the Unifi controller this provider will manage. Can be specified with " +
+		"the `UNIFI_SITE` environment variable. Default: `default`"
+	AllowInsecureDescription = "Skip verification of TLS certificates of API requests. You may need to set this to `true` " +
+		"if you are using your local API without setting up a signed certificate. Can be specified with the " +
+		"`UNIFI_INSECURE` environment variable."
+)
+
+// frameworkProvider is a type that implements the terraform-plugin-framework
+// provider.Provider interface. Someday, this will probably encompass the entire
+// behavior of the unifi provider. Today, it is a small but growing subset.
+type frameworkProvider struct {
+	defaultSiteName *string
+}
+
+var (
+	_ provider.Provider                       = &frameworkProvider{}
+	_ provider.ProviderWithEphemeralResources = &frameworkProvider{}
+)
+
+// FrameworkProviderConfig is a helper type for extracting the provider
+// configuration from the provider block.
+type FrameworkProviderConfig struct {
+	ApiKey        types.String `tfsdk:"api_key"`
+	User          types.String `tfsdk:"username"`
+	Password      types.String `tfsdk:"password"`
+	ApiUrl        types.String `tfsdk:"api_url"`
+	Site          types.String `tfsdk:"site"`
+	AllowInsecure types.Bool   `tfsdk:"allow_insecure"`
+}
+
+// NewFrameworkProvider is a helper function for initializing the portion of
+// the unifi provider implemented via the terraform-plugin-framework.
+func NewFrameworkProvider() provider.Provider {
+	return &frameworkProvider{}
+}
+
+// NewFrameworkProviderWithDefaultOrg is a helper function for
+// initializing a framework provider with a default site name.
+func NewFrameworkProviderWithDefaultSite(defaultSiteName string) provider.Provider {
+	return &frameworkProvider{defaultSiteName: &defaultSiteName}
+}
+
+// Metadata (a Provider interface function) lets the provider identify itself.
+// Resources and data sources can access this information from their request
+// objects.
+func (p *frameworkProvider) Metadata(
+	_ context.Context,
+	_ provider.MetadataRequest,
+	res *provider.MetadataResponse,
+) {
+	res.TypeName = "unifi"
+}
+
+// Schema (a Provider interface function) returns the schema for the Terraform
+// block that configures the provider itself.
+func (p *frameworkProvider) Schema(
+	_ context.Context,
+	_ provider.SchemaRequest,
+	res *provider.SchemaResponse,
+) {
+	res.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"api_key": schema.StringAttribute{
+				MarkdownDescription: ApiKeyDescription,
+				Optional:            true,
+				// Sensitive:           true,
+			},
+			"username": schema.StringAttribute{
+				MarkdownDescription: UserNameDescription,
+				Optional:            true,
+				// Sensitive:           true,
+			},
+			"password": schema.StringAttribute{
+				MarkdownDescription: PasswordDescription,
+				Optional:            true,
+				// Sensitive:           true,
+			},
+			"api_url": schema.StringAttribute{
+				MarkdownDescription: ApiUrlDescription,
+				Required:            true,
+			},
+			"site": schema.StringAttribute{
+				MarkdownDescription: SiteDescription,
+				Optional:            true,
+			},
+			"allow_insecure": schema.BoolAttribute{
+				MarkdownDescription: AllowInsecureDescription,
+				Optional:            true,
+			},
+		},
+	}
+}
+
+// Configure (a Provider interface function) sets up the HCP Terraform client per the
+// specified provider configuration block and env vars.
+func (p *frameworkProvider) Configure(
+	ctx context.Context,
+	req provider.ConfigureRequest,
+	res *provider.ConfigureResponse,
+) {
+	var data FrameworkProviderConfig
+	diags := req.Config.Get(ctx, &data)
+
+	res.Diagnostics.Append(diags...)
+	if res.Diagnostics.HasError() {
+		return
+	}
+
+	tflog.Info(ctx, "Configuring Synology provider")
+
+	res.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if res.Diagnostics.HasError() {
+		return
+	}
+	apiUrl := data.ApiUrl.ValueString()
+	if apiUrl == "" {
+		if v := os.Getenv("UNIFI_API"); v != "" {
+			apiUrl = v
+		}
+	}
+	user := data.User.ValueString()
+	if user == "" {
+		if v := os.Getenv("UNIFI_USERNAME"); v != "" {
+			user = v
+		}
+	}
+	pass := data.Password.ValueString()
+	if pass == "" {
+		if v := os.Getenv("UNIFI_PASSWORD"); v != "" {
+			pass = v
+		}
+	}
+	apikey := data.ApiKey.ValueString()
+	if apikey == "" {
+		if v := os.Getenv("UNIFI_API_KEY"); v != "" {
+			apikey = v
+		}
+	}
+	insecure := data.AllowInsecure.ValueBool()
+	if !insecure {
+		if v := os.Getenv("UNIFI_INSECURE"); v != "" {
+			insecure = v == "true"
+		}
+	}
+	site := data.Site.ValueString()
+	if site == "" {
+		if v := os.Getenv("UNIFI_SITE"); v != "" {
+			site = v
+		}
+	}
+	if site == "" {
+		if p.defaultSiteName != nil {
+			site = *p.defaultSiteName
+		} else {
+			site = "default"
+		}
+	}
+
+	configuredClient := &client{
+		c: &lazyClient{
+			user:     user,
+			pass:     pass,
+			apikey:   apikey,
+			baseURL:  apiUrl,
+			insecure: insecure,
+		},
+		site: site,
+	}
+
+	res.DataSourceData = configuredClient
+	res.ResourceData = configuredClient
+	res.EphemeralResourceData = configuredClient
+}
+
+func (p *frameworkProvider) DataSources(ctx context.Context) []func() datasource.DataSource {
+	return []func() datasource.DataSource{}
+}
+
+func (p *frameworkProvider) Resources(ctx context.Context) []func() resource.Resource {
+	return []func() resource.Resource{}
+}
+
+func (p *frameworkProvider) EphemeralResources(
+	ctx context.Context,
+) []func() ephemeral.EphemeralResource {
+	return []func() ephemeral.EphemeralResource{}
+}

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -36,6 +36,25 @@ func TestMain(m *testing.M) {
 	os.Exit(runAcceptanceTests(m))
 }
 
+func NewTestClient(ctx context.Context) *unifi.Client {
+	var user, password, endpoint, apikey string
+
+	user = os.Getenv("UNIFI_USERNAME")
+	password = os.Getenv("UNIFI_PASSWORD")
+	endpoint = os.Getenv("UNIFI_API")
+	apikey = os.Getenv("UNIFI_API_KEY")
+
+	testClient = &unifi.Client{}
+	setHTTPClient(testClient, true, "unifi")
+	testClient.SetBaseURL(endpoint)
+	testClient.SetAPIKey(apikey)
+	if err := testClient.Login(ctx, user, password); err != nil {
+		panic(err)
+	}
+
+	return testClient
+}
+
 func runAcceptanceTests(m *testing.M) int {
 	dc, err := compose.NewDockerCompose("../../docker-compose.yaml")
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -1,39 +1,66 @@
-package main // import "github.com/ubiquiti-community/terraform-provider-unifi"
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package main
 
 import (
+	"context"
 	"flag"
+	"log"
+	"os"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/plugin"
+	"github.com/hashicorp/terraform-plugin-framework/providerserver"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6/tf6server"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/hashicorp/terraform-plugin-mux/tf5to6server"
+	"github.com/hashicorp/terraform-plugin-mux/tf6muxserver"
 	"github.com/ubiquiti-community/terraform-provider-unifi/internal/provider"
 )
 
-// Generate docs for website
-//go:generate go run github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs
-
-// these will be set by the goreleaser configuration
-// to appropriate values for the compiled binary.
-var version string = "dev"
-
-// goreleaser can also pass the specific commit if you want
-// commit  string = "".
+const (
+	unifiProviderName = "registry.terraform.io/ubiquiti-community/unifi"
+)
 
 func main() {
-	var debugMode bool
+	ctx := context.Background()
 
-	flag.BoolVar(
-		&debugMode,
-		"debug",
-		false,
-		"set to true to run the provider with support for debuggers like delve",
-	)
+	// Remove any date and time prefix in log package function output to
+	// prevent duplicate timestamp and incorrect log level setting
+	log.SetFlags(log.Flags() &^ (log.Ldate | log.Ltime))
+
+	debugFlag := flag.Bool("debug", false, "Start provider in debug mode.")
 	flag.Parse()
 
-	opts := &plugin.ServeOpts{ProviderFunc: provider.New(version)}
+	var serveOpts []tf6server.ServeOpt
 
-	if debugMode {
-		opts.Debug = true
-		opts.ProviderAddr = "registry.terraform.io/paultyng/unifi"
+	if *debugFlag {
+		serveOpts = append(serveOpts, tf6server.WithManagedDebug())
 	}
 
-	plugin.Serve(opts)
+	upgradedSdkProvider, err := tf5to6server.UpgradeServer(
+		context.Background(),
+		provider.Provider().GRPCProvider,
+	)
+
+	providers := []func() tfprotov6.ProviderServer{
+		func() tfprotov6.ProviderServer {
+			return upgradedSdkProvider
+		},
+		providerserver.NewProtocol6(provider.NewFrameworkProvider()),
+	}
+
+	muxServer, err := tf6muxserver.NewMuxServer(ctx, providers...)
+	if err != nil {
+		tflog.Error(ctx, "Failed to create MuxServer", map[string]any{
+			"error": err,
+		})
+		os.Exit(1)
+	}
+
+	err = tf6server.Serve(unifiProviderName, muxServer.ProviderServer, serveOpts...)
+	if err != nil {
+		log.Printf("[ERROR] Could not start serving the ProviderServer: %v", err)
+		os.Exit(1)
+	}
 }


### PR DESCRIPTION
This pull request introduces significant updates to the Terraform provider codebase, focusing on improving style guides, adding new features, and enhancing configuration flexibility. It includes the addition of a comprehensive migration style guide, new dependencies, and updates to data sources and provider configuration.

### Style Guide and Documentation Enhancements:
* Added a detailed migration guide for the Terraform Plugin Framework, covering directory structure, schema design, state management, type conversion, error handling, testing strategies, and common pitfalls. (`.github/instructions/styleguide.instructions.md`)

### Dependency Updates:
* Added new dependencies for the Terraform Plugin Framework, Plugin Go, Plugin Log, and Plugin Mux to support advanced functionality. (`go.mod`) [[1]](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6R17-R20) [[2]](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L185-L186)

### Data Source Improvements:
* Added an `ip_subnet` field to the `data_network` resource, enabling support for IPv4 subnet information in CIDR notation. (`internal/provider/data_network.go`) [[1]](diffhunk://#diff-fc8adda4ce1550ddd73b80707ec0936df5979d721338c914819962d226036472R149-R153) [[2]](diffhunk://#diff-fc8adda4ce1550ddd73b80707ec0936df5979d721338c914819962d226036472R698)

### Provider Configuration Enhancements:
* Updated the provider to allow environment variables as fallback values for configuration fields (e.g., `username`, `password`, `api_key`, `api_url`, `site`, `allow_insecure`), improving flexibility and usability. (`internal/provider/provider.go`) [[1]](diffhunk://#diff-58d6a027753b50994deb7e11e4a99dde423f35844986019bd9cea5e0c94aba22R29-R71) [[2]](diffhunk://#diff-58d6a027753b50994deb7e11e4a99dde423f35844986019bd9cea5e0c94aba22R117-R162)

### Testing Utilities:
* Added initialization logic for the `testClient` in `data_network_test.go` to ensure proper setup for acceptance tests. (`internal/provider/data_network_test.go`)