### PR TITLE
Add dhcp_dns_enabled attribute to network resource

### DIFF
--- a/unifi/network_resource.go
+++ b/unifi/network_resource.go
@@ -56,6 +56,7 @@ type networkResourceModel struct {
 	DhcpEnabled      types.Bool   `tfsdk:"dhcp_enabled"`
 	DhcpLease        types.Int64  `tfsdk:"dhcp_lease"`
 	DhcpDNS          types.List   `tfsdk:"dhcp_dns"`
+	DhcpDNSEnabled   types.Bool   `tfsdk:"dhcp_dns_enabled"`
 	DhcpRelayEnabled types.Bool   `tfsdk:"dhcp_relay_enabled"`
 
 	// DHCPD Boot Settings
@@ -211,6 +212,11 @@ func (r *networkResource) Schema(
 				Validators: []validator.List{
 					listvalidator.SizeAtMost(4),
 				},
+			},
+			"dhcp_dns_enabled": schema.BoolAttribute{
+				MarkdownDescription: "Specifies whether to use the custom DNS servers specified in `dhcp_dns`. When `true`, clients receive the custom DNS servers. When `false`, clients receive auto-assigned DNS.",
+				Optional:            true,
+				Computed:            true,
 			},
 			"dhcpd_boot_enabled": schema.BoolAttribute{
 				MarkdownDescription: "Toggles on the DHCP boot options. Should be set to true when you want to have dhcpd_boot_filename, and dhcpd_boot_server to take effect.",
@@ -927,6 +933,9 @@ func (r *networkResource) modelToNetwork(
 	if !model.DhcpEnabled.IsNull() {
 		network.DHCPDEnabled = model.DhcpEnabled.ValueBool()
 	}
+	if !model.DhcpDNSEnabled.IsNull() {
+		network.DHCPDDNSEnabled = model.DhcpDNSEnabled.ValueBool()
+	}
 	network.DHCPDLeaseTime = model.DhcpLease.ValueInt64Pointer()
 
 	// Convert DHCP DNS list
@@ -997,6 +1006,7 @@ func (r *networkResource) networkToModel(
 	model.DhcpStop = types.StringPointerValue(network.DHCPDStop)
 
 	model.DhcpEnabled = types.BoolValue(network.DHCPDEnabled)
+	model.DhcpDNSEnabled = types.BoolValue(network.DHCPDDNSEnabled)
 
 	model.DhcpLease = types.Int64PointerValue(network.DHCPDLeaseTime)
 


### PR DESCRIPTION
## Summary

Add the `dhcp_dns_enabled` boolean attribute to control whether custom DNS servers specified in `dhcp_dns` are sent to DHCP clients.

## Changes

- Add `DhcpDNSEnabled` field to network resource model
- Add `dhcp_dns_enabled` schema attribute (Optional + Computed)
- Add field mapping in `modelToNetwork` (Terraform → API)
- Add field mapping in `networkToModel` (API → Terraform)

## Behavior

- When `true`: clients receive the custom DNS servers from `dhcp_dns`
- When `false`: clients receive auto-assigned DNS

This attribute maps to the `dhcpd_dns_enabled` field in the UniFi API.

## Testing

Tested on UDM SE running UniFi Network 10.1.83.