### PR TITLE
Preserve AllowAdoption and ForgetOnDestroy in device Update

### DIFF
--- a/unifi/device_resource.go
+++ b/unifi/device_resource.go
@@ -1158,6 +1158,11 @@ func (r *deviceResource) Update(
 		state.RadioTable = plan.RadioTable
 	}
 
+	// Preserve config-only fields that don't exist in the API.
+	// These must always come from the plan, not from API state.
+	state.AllowAdoption = plan.AllowAdoption
+	state.ForgetOnDestroy = plan.ForgetOnDestroy
+
 	// Update the resource
 	diags = r.updateDevice(ctx, &state)
 	resp.Diagnostics.Append(diags...)


### PR DESCRIPTION
## Summary

The `allow_adoption` and `forget_on_destroy` fields are config-only (they don't exist in the UniFi API) and must be preserved from the plan during updates. Without this fix, updating a device after import would lose these values, causing unexpected behavior on the next apply.

## Changes

Add preservation of `AllowAdoption` and `ForgetOnDestroy` from plan to state in the Update function, similar to how other config-only fields like `RadioTable` are preserved.

## Testing

Tested on UDM SE running UniFi Network 10.1.83.