### PR TITLE
fix: Remove local replace directive from go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -281,5 +281,3 @@ require (
 )
 
 tool github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs
-
-replace github.com/ubiquiti-community/go-unifi => ../go-unifi

--- a/go.sum
+++ b/go.sum
@@ -668,6 +668,8 @@ github.com/tonistiigi/units v0.0.0-20180711220420-6950e57a87ea h1:SXhTLE6pb6eld/
 github.com/tonistiigi/units v0.0.0-20180711220420-6950e57a87ea/go.mod h1:WPnis/6cRcDZSUvVmezrxJPkiO87ThFYsoUiMwWNDJk=
 github.com/tonistiigi/vt100 v0.0.0-20240514184818-90bafcd6abab h1:H6aJ0yKQ0gF49Qb2z5hI1UHxSQt4JMyxebFR15KnApw=
 github.com/tonistiigi/vt100 v0.0.0-20240514184818-90bafcd6abab/go.mod h1:ulncasL3N9uLrVann0m+CDlJKWsIAP34MPcOJF6VRvc=
+github.com/ubiquiti-community/go-unifi v1.33.43-0.20260308125445-23b12452846a h1:Kkr2MYzguZlAUPNNpsfAh9QzIW4I1jCXt+dQkj03UCU=
+github.com/ubiquiti-community/go-unifi v1.33.43-0.20260308125445-23b12452846a/go.mod h1:lOld3iJD/7eXE5+phOVWz3Y45qTlb73g24tPipLIkac=
 github.com/vbatts/tar-split v0.12.2 h1:w/Y6tjxpeiFMR47yzZPlPj/FcPLpXbTUi/9H7d3CPa4=
 github.com/vbatts/tar-split v0.12.2/go.mod h1:eF6B6i6ftWQcDqEn3/iGFRFRo8cBIMSJVOpnNdfTMFA=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=


### PR DESCRIPTION
I assume this was done on accident. Should fix the Acceptance Tests workflow.