### PR TITLE
fix: serialize concurrent tflog calls in UnifiLogger to prevent map race

### DIFF
--- a/unifi/logger.go
+++ b/unifi/logger.go
@@ -3,12 +3,14 @@ package unifi
 import (
 	"context"
 	"fmt"
+	"sync"
 
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
 type UnifiLogger struct {
 	ctx context.Context
+	mu  sync.Mutex
 }
 
 func NewLogger(ctx context.Context) *UnifiLogger {
@@ -18,6 +20,8 @@ func NewLogger(ctx context.Context) *UnifiLogger {
 }
 
 func (l *UnifiLogger) Error(msg string, keysAndValues ...any) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
 	additionalFields, err := l.convertToAdditionalFields(keysAndValues)
 	if err != nil {
 		tflog.Error(l.ctx, fmt.Sprintf("Error converting keys and values: %v", err))
@@ -27,10 +31,14 @@ func (l *UnifiLogger) Error(msg string, keysAndValues ...any) {
 }
 
 func (l *UnifiLogger) Printf(format string, v ...any) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
 	tflog.Info(l.ctx, fmt.Sprintf(format, v...))
 }
 
 func (l *UnifiLogger) Info(msg string, keysAndValues ...any) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
 	additionalFields, err := l.convertToAdditionalFields(keysAndValues)
 	if err != nil {
 		tflog.Error(l.ctx, fmt.Sprintf("Error converting keys and values: %v", err))
@@ -40,6 +48,8 @@ func (l *UnifiLogger) Info(msg string, keysAndValues ...any) {
 }
 
 func (l *UnifiLogger) Debug(msg string, keysAndValues ...any) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
 	additionalFields, err := l.convertToAdditionalFields(keysAndValues)
 	if err != nil {
 		tflog.Error(l.ctx, fmt.Sprintf("Error converting keys and values: %v", err))
@@ -49,6 +59,8 @@ func (l *UnifiLogger) Debug(msg string, keysAndValues ...any) {
 }
 
 func (l *UnifiLogger) Warn(msg string, keysAndValues ...any) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
 	additionalFields, err := l.convertToAdditionalFields(keysAndValues)
 	if err != nil {
 		tflog.Error(l.ctx, fmt.Sprintf("Error converting keys and values: %v", err))


### PR DESCRIPTION
## Summary

Fixes #125 — `fatal error: concurrent map iteration and map write`

`UnifiLogger` stores a single `context.Context` shared across all goroutines. The `terraform-plugin-log` library's `ApplyMask` method [explicitly mutates the `Fields` map from the context in-place](https://github.com/hashicorp/terraform-plugin-log/blob/v0.10.0/internal/logging/filtering.go#L52-L53). When masking is configured for sensitive fields (e.g. `unifi_password`, `unifi_api_key`), concurrent HTTP requests via `go-retryablehttp` trigger simultaneous logging calls — one goroutine writes to the `Fields` map via `ApplyMask` while another iterates over it in `MergeFieldMaps`.

The fix adds a `sync.Mutex` to `UnifiLogger` to serialize all `tflog` calls, preventing concurrent access to the shared `Fields` map.

## Testing

The race can be reproduced with the following test (run with `go test -race`):

```go
func TestUnifiLoggerConcurrentAccess(t *testing.T) {
    ctx := tflogtest.RootLogger(context.Background(), &bytes.Buffer{})
    ctx = tflog.SetField(ctx, "unifi_username", "admin")
    ctx = tflog.SetField(ctx, "unifi_password", "secret")
    // Masking causes ApplyMask to write to the shared Fields map in-place,
    // which triggers the race when logging is called concurrently.
    ctx = tflog.MaskFieldValuesWithFieldKeys(ctx, "unifi_password")

    logger := NewLogger(ctx)

    var wg sync.WaitGroup
    for i := 0; i < 100; i++ {
        wg.Add(1)
        go func() {
            defer wg.Done()
            logger.Debug("performing request", "method", "GET", "url", "https://unifi.example.com/api")
        }()
    }
    wg.Wait()
}
```

I chose not to include this test in the PR because the existing CI runs tests without the `-race` flag, and the race detector requires `CGO_ENABLED=1` (the CI currently sets `CGO_ENABLED=0`). Both would need to be addressed for the test to be meaningful in CI. Happy to include it if the CI setup is updated accordingly.