### PR TITLE
fix: allow 5-digit rule_index values for UDM

### DIFF
--- a/docs/resources/firewall_rule.md
+++ b/docs/resources/firewall_rule.md
@@ -32,7 +32,7 @@ resource "unifi_firewall_rule" "drop_all" {
 
 - `action` (String) The action of the firewall rule. Must be one of `drop`, `accept`, or `reject`.
 - `name` (String) The name of the firewall rule.
-- `rule_index` (Number) The index of the rule. Must be >= 2000 < 3000 or >= 4000 < 5000.
+- `rule_index` (Number) The index of the rule. Must be >= 2000 < 3000, >= 4000 < 5000, >= 20000 < 30000, or >= 40000 < 50000.
 - `ruleset` (String) The ruleset for the rule. This is from the perspective of the security gateway.
 
 ### Optional

--- a/unifi/firewall_rule_resource.go
+++ b/unifi/firewall_rule_resource.go
@@ -124,12 +124,14 @@ func (r *firewallRuleResource) Schema(
 				},
 			},
 			"rule_index": schema.Int64Attribute{
-				MarkdownDescription: "The index of the rule. Must be >= 2000 < 3000 or >= 4000 < 5000.",
+				MarkdownDescription: "The index of the rule. Must be >= 2000 < 3000, >= 4000 < 5000, >= 20000 < 30000, or >= 40000 < 50000.",
 				Required:            true,
 				Validators: []validator.Int64{
 					int64validator.Any(
 						int64validator.Between(2000, 2999),
 						int64validator.Between(4000, 4999),
+						int64validator.Between(20000, 29999),
+						int64validator.Between(40000, 49999),
 					),
 				},
 			},


### PR DESCRIPTION
The `rule_index` schema validator only accepts 4-digit values (`2000–2999`, `4000–4999`), but some controllers store and require 5-digit values (`20000–29999`, `40000–49999`), rejecting the 4-digit form with `api.err.FirewallRuleIndexOutOfRange`.

The go-unifi generated code already documents both forms as valid:
```
// 2[0-9]{3,4}|4[0-9]{3,4}
```

This fix adds the missing ranges to the schema validator.