### PR TITLE
fix: create fresh subsystem ctx per log call to avoid concurrent map …

### DIFF
--- a/unifi/logger.go
+++ b/unifi/logger.go
@@ -3,7 +3,6 @@ package unifi
 import (
 	"context"
 	"fmt"
-	"sync"
 
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
@@ -13,83 +12,78 @@ const (
 )
 
 type UnifiLogger struct {
-	ctx context.Context
-	mu  sync.Mutex
+	baseCtx context.Context
 }
 
 func NewLogger(ctx context.Context) *UnifiLogger {
 	return &UnifiLogger{
-		ctx: tflog.NewSubsystem(ctx, subsystem),
+		baseCtx: ctx,
 	}
 }
 
-// Factor the lock boilerplate into one place.
-func (l *UnifiLogger) log(fn func()) {
-	l.mu.Lock()
-	defer l.mu.Unlock()
-	fn()
+func (l *UnifiLogger) ctx() context.Context {
+	// Create a fresh subsystem context each time
+	return tflog.NewSubsystem(l.baseCtx, subsystem)
 }
 
 func (l *UnifiLogger) Error(msg string, keysAndValues ...any) {
-	l.log(func() {
-		fields, err := convertToFields(keysAndValues)
-		if err != nil {
-			tflog.SubsystemError(
-				l.ctx,
-				subsystem,
-				fmt.Sprintf("invalid log key-value pairs: %s", err),
-			)
-		}
-		tflog.SubsystemError(l.ctx, subsystem, msg, fields)
-	})
+	ctx := l.ctx()
+
+	fields, err := convertToFields(keysAndValues)
+	if err != nil {
+		tflog.SubsystemError(
+			ctx,
+			subsystem,
+			fmt.Sprintf("invalid log key-value pairs: %s", err),
+		)
+	}
+	tflog.SubsystemError(ctx, subsystem, msg, fields)
 }
 
 func (l *UnifiLogger) Printf(format string, v ...any) {
-	l.log(func() {
-		tflog.SubsystemInfo(l.ctx, subsystem, fmt.Sprintf(format, v...))
-	})
+	tflog.SubsystemInfo(l.ctx(), subsystem, fmt.Sprintf(format, v...))
 }
 
 func (l *UnifiLogger) Info(msg string, keysAndValues ...any) {
-	l.log(func() {
-		fields, err := convertToFields(keysAndValues)
-		if err != nil {
-			tflog.SubsystemError(
-				l.ctx,
-				subsystem,
-				fmt.Sprintf("invalid log key-value pairs: %s", err),
-			)
-		}
-		tflog.SubsystemInfo(l.ctx, subsystem, msg, fields)
-	})
+	ctx := l.ctx()
+
+	fields, err := convertToFields(keysAndValues)
+	if err != nil {
+		tflog.SubsystemError(
+			ctx,
+			subsystem,
+			fmt.Sprintf("invalid log key-value pairs: %s", err),
+		)
+	}
+	tflog.SubsystemInfo(ctx, subsystem, msg, fields)
 }
 
 func (l *UnifiLogger) Debug(msg string, keysAndValues ...any) {
-	l.log(func() {
-		fields, err := convertToFields(keysAndValues)
-		if err != nil {
-			tflog.SubsystemError(
-				l.ctx,
-				subsystem,
-				fmt.Sprintf("invalid log key-value pairs: %s", err),
-			)
-		}
-		tflog.SubsystemDebug(l.ctx, subsystem, msg, fields)
-	})
+	ctx := l.ctx()
+
+	fields, err := convertToFields(keysAndValues)
+	if err != nil {
+		tflog.SubsystemError(
+			ctx,
+			subsystem,
+			fmt.Sprintf("invalid log key-value pairs: %s", err),
+		)
+	}
+	tflog.SubsystemDebug(ctx, subsystem, msg, fields)
 }
 
 func (l *UnifiLogger) Warn(msg string, keysAndValues ...any) {
-	l.log(func() {
-		fields, err := convertToFields(keysAndValues)
-		if err != nil {
-			tflog.SubsystemError(
-				l.ctx,
-				subsystem,
-				fmt.Sprintf("invalid log key-value pairs: %s", err),
-			)
-		}
-		tflog.SubsystemWarn(l.ctx, subsystem, msg, fields)
-	})
+	ctx := l.ctx()
+
+	fields, err := convertToFields(keysAndValues)
+	if err != nil {
+		tflog.SubsystemError(
+			ctx,
+			subsystem,
+			fmt.Sprintf("invalid log key-value pairs: %s", err),
+		)
+	}
+	tflog.SubsystemWarn(ctx, subsystem, msg, fields)
 }
 
 func convertToFields(keysAndValues []any) (map[string]any, error) {


### PR DESCRIPTION
# Description

Hello, I uncovered a bug in this provider that causes it to panic when logging. Because tflog’s logger options include a map that is being mutated concurrently (masking options), something in this provider’s logging wrapper is making that concurrency bug show up.

Even though UnifiLogger has a mutex, it doesn’t protect the underlying Terraform logger’s global/shared state. If multiple goroutines log at once using the same underlying tflog context/options, terraform-plugin-log can hit concurrent map writes while applying masking.

## Stacktrace

**`fatal error: concurrent map writes stack trace`**
```txt
Error: Plugin did not respond
│ 
│ The plugin encountered an error, and failed to respond to the
│ plugin6.(*GRPCProvider).ApplyResourceChange call. The plugin logs may
│ contain more details.
╵

Stack trace from the terraform-provider-unifi_v0.41.25 plugin:

fatal error: concurrent map writes

goroutine 62 [running]:
internal/runtime/maps.fatal({0xf6c09a?, 0x199?})
        runtime/panic.go:1046 +0x18
github.com/hashicorp/terraform-plugin-log/internal/logging.LoggerOpts.ApplyMask({{0x0, 0x0}, 0x0, 0x0, 0x0, {0x0, 0x0}, 0x0, 0xc0004d65a0, 0x0, ...}, ...)
        github.com/hashicorp/terraform-plugin-log@v0.10.0/internal/logging/filtering.go:60 +0x60a
github.com/hashicorp/terraform-plugin-log/internal/logging.OmitOrMask({{0x0, 0x0}, 0x0, 0x0, 0x0, {0x0, 0x0}, 0x0, 0xc0004d65a0, 0x0, ...}, ...)
        github.com/hashicorp/terraform-plugin-log@v0.10.0/internal/logging/filtering.go:121 +0x230
github.com/hashicorp/terraform-plugin-log/tflog.Debug({0x10d8568, 0xc0004d65d0}, {0xf68feb, 0x12}, {0xc0003e0780, 0x1, 0x1})
        github.com/hashicorp/terraform-plugin-log@v0.10.0/tflog/provider.go:66 +0x118
github.com/ubiquiti-community/terraform-provider-unifi/unifi.(*UnifiLogger).Debug(0xc00033d760, {0xf68feb, 0x12}, {0xc00041e1c0?, 0x90?, 0x72087fb391b8?})
        github.com/ubiquiti-community/terraform-provider-unifi/unifi/logger.go:48 +0xc7
github.com/hashicorp/go-retryablehttp.(*Client).Do(0xc000480b80, 0xc00052c090)
        github.com/hashicorp/go-retryablehttp@v0.7.8/client.go:678 +0x19d4
github.com/ubiquiti-community/go-unifi/unifi.(*ApiClient).doRequest(0xc0004b8270, {0x10d8568, 0xc0005f4b70}, {0xf5c3b1, 0x4}, {0xc0003820c0, 0x18}, {0xe041a0?, 0xc0005aa060?}, {0xd722a0, ...}, ...)
        github.com/ubiquiti-community/go-unifi@v1.33.43-0.20260313175123-49c0cd8eedef/unifi/unifi.go:552 +0xc48
github.com/ubiquiti-community/go-unifi/unifi.(*ApiClient).do(0xc0004b8270?, {0x10d8568?, 0xc0005f4b70?}, {0xf5c3b1?, 0x4?}, {0xc0003820c0?, 0x18?}, {0xe041a0?, 0xc0005aa060?}, {0xd722a0, ...}, ...)
        github.com/ubiquiti-community/go-unifi@v1.33.43-0.20260313175123-49c0cd8eedef/unifi/unifi.go:483 +0x60d
github.com/ubiquiti-community/go-unifi/unifi.(*ApiClient).stamgr(0xc0004b8270, {0x10d8568, 0xc0005f4b70}, {0xc000012900, 0x7}, {0xf61d6e, 0xa}, 0xc0003e1050)
        github.com/ubiquiti-community/go-unifi@v1.33.43-0.20260313175123-49c0cd8eedef/unifi/client.go:46 +0x285
github.com/ubiquiti-community/go-unifi/unifi.(*ApiClient).DeleteClientByMAC(0xc0004b8270, {0x10d8568, 0xc0005f4b70}, {0xc000012900, 0x7}, {0xc000382030, 0x11})
        github.com/ubiquiti-community/go-unifi@v1.33.43-0.20260313175123-49c0cd8eedef/unifi/client.go:81 +0x1a5
github.com/ubiquiti-community/terraform-provider-unifi/unifi.(*clientResource).Delete(0xc00030ce40, {0x10d8568, 0xc0005f4b70}, {{{{0x10de010, 0xc00069f770}, {0xe06300, 0xc00069f440}}, {0x10e4630, 0xc0000ca280}}, 0xc0003cc810, ...}, ...)
        github.com/ubiquiti-community/terraform-provider-unifi/unifi/client_resource.go:773 +0x20c
github.com/hashicorp/terraform-plugin-framework/internal/fwserver.(*Server).DeleteResource(0xc00023e308, {0x10d8568, 0xc0005f4b70}, 0xc0003e1490, 0xc0003e1460)
        github.com/hashicorp/terraform-plugin-framework@v1.17.0/internal/fwserver/server_deleteresource.go:124 +0x8b8
github.com/hashicorp/terraform-plugin-framework/internal/fwserver.(*Server).ApplyResourceChange(0xc00023e308, {0x10d8568, 0xc0005f4b70}, 0xc0000d4460, 0xc0003e1638)
        github.com/hashicorp/terraform-plugin-framework@v1.17.0/internal/fwserver/server_applyresourcechange.go:91 +0x39b
github.com/hashicorp/terraform-plugin-framework/internal/proto6server.(*Server).ApplyResourceChange(0xc00023e308, {0x10d8568?, 0xc0006e4a80?}, 0xc0006e0370)
        github.com/hashicorp/terraform-plugin-framework@v1.17.0/internal/proto6server/server_applyresourcechange.go:71 +0x585
github.com/hashicorp/terraform-plugin-go/tfprotov6/tf6server.(*server).ApplyResourceChange(0xc0002388c0, {0x10d8568?, 0xc0005365d0?}, 0xc0001b2f00)
        github.com/hashicorp/terraform-plugin-go@v0.29.0/tfprotov6/tf6server/server.go:944 +0x3b9
github.com/hashicorp/terraform-plugin-go/tfprotov6/internal/tfplugin6._Provider_ApplyResourceChange_Handler({0xf27860, 0xc0002388c0}, {0x10d8568, 0xc0005365d0}, 0xc0001b2e80, 0x0)
        github.com/hashicorp/terraform-plugin-go@v0.29.0/tfprotov6/internal/tfplugin6/tfplugin6_grpc.pb.go:789 +0x1a6
google.golang.org/grpc.(*Server).processUnaryRPC(0xc000316248, {0x10d8568, 0xc000536540}, 0xc00031ab60, 0xc0003190e0, 0x17a2288, 0x0)
        google.golang.org/grpc@v1.78.0/server.go:1428 +0x1192
google.golang.org/grpc.(*Server).handleStream(0xc000316248, {0x10d8f98, 0xc0001776c0}, 0xc00031ab60)
        google.golang.org/grpc@v1.78.0/server.go:1832 +0xdc6
google.golang.org/grpc.(*Server).serveStreams.func2.1()
        google.golang.org/grpc@v1.78.0/server.go:1063 +0x7f
created by google.golang.org/grpc.(*Server).serveStreams.func2 in goroutine 27
        google.golang.org/grpc@v1.78.0/server.go:1074 +0x11d

goroutine 1 [select]:
github.com/hashicorp/go-plugin.Serve(0xc00022f1a0)
        github.com/hashicorp/go-plugin@v1.7.0/server.go:503 +0x1673
github.com/hashicorp/terraform-plugin-go/tfprotov6/tf6server.Serve({0xf8b008, 0x2e}, 0xc0001ff3b0, {0x0, 0x0, 0x0})
        github.com/hashicorp/terraform-plugin-go@v0.29.0/tfprotov6/tf6server/server.go:329 +0xdaa
github.com/hashicorp/terraform-plugin-framework/providerserver.Serve({0x10d8530?, 0x17d1e40?}, 0xfc5de8, {{0xf8b008?, 0x5?}, 0xfa?, 0x45?})
        github.com/hashicorp/terraform-plugin-framework@v1.17.0/providerserver/providerserver.go:114 +0x271
main.main()
        github.com/ubiquiti-community/terraform-provider-unifi/main.go:32 +0xce

goroutine 18 [select]:
github.com/hashicorp/go-plugin.(*gRPCBrokerServer).Recv(0x0?)
        github.com/hashicorp/go-plugin@v1.7.0/grpc_broker.go:126 +0x65
github.com/hashicorp/go-plugin.(*GRPCBroker).Run(0xc00013be40)
        github.com/hashicorp/go-plugin@v1.7.0/grpc_broker.go:581 +0x4c
created by github.com/hashicorp/go-plugin.(*GRPCServer).Init in goroutine 1
        github.com/hashicorp/go-plugin@v1.7.0/grpc_server.go:91 +0x576

goroutine 19 [IO wait]:
internal/poll.runtime_pollWait(0x72087fb04c00, 0x72)
        runtime/netpoll.go:351 +0x85
internal/poll.(*pollDesc).wait(0xc00022f800?, 0xc0000b6000?, 0x1)
        internal/poll/fd_poll_runtime.go:84 +0x27
internal/poll.(*pollDesc).waitRead(...)
        internal/poll/fd_poll_runtime.go:89
internal/poll.(*FD).Read(0xc00022f800, {0xc0000b6000, 0x1000, 0x1000})
        internal/poll/fd_unix.go:165 +0x279
os.(*File).read(...)
        os/file_posix.go:29
os.(*File).Read(0xc00011c490, {0xc0000b6000?, 0x400?, 0xd9f780?})
        os/file.go:144 +0x4f
bufio.(*Reader).Read(0xc000063720, {0xc0000a0400, 0x400, 0x0?})
        bufio/bufio.go:245 +0x197
github.com/hashicorp/go-plugin.copyChan({0x10f3db8, 0xc000143a40}, 0xc000230850, {0x10cf280, 0xc00011c490?})
        github.com/hashicorp/go-plugin@v1.7.0/grpc_stdio.go:184 +0x1c5
created by github.com/hashicorp/go-plugin.newGRPCStdioServer in goroutine 1
        github.com/hashicorp/go-plugin@v1.7.0/grpc_stdio.go:40 +0xcc

goroutine 20 [IO wait]:
internal/poll.runtime_pollWait(0x72087fb04800, 0x72)
        runtime/netpoll.go:351 +0x85
internal/poll.(*pollDesc).wait(0xc00022f8c0?, 0xc0000b7000?, 0x1)
        internal/poll/fd_poll_runtime.go:84 +0x27
internal/poll.(*pollDesc).waitRead(...)
        internal/poll/fd_poll_runtime.go:89
internal/poll.(*FD).Read(0xc00022f8c0, {0xc0000b7000, 0x1000, 0x1000})
        internal/poll/fd_unix.go:165 +0x279
os.(*File).read(...)
        os/file_posix.go:29
os.(*File).Read(0xc00011c4a0, {0xc0000b7000?, 0x400?, 0xd9f780?})
        os/file.go:144 +0x4f
bufio.(*Reader).Read(0xc000063f20, {0xc0000a0800, 0x400, 0x0?})
        bufio/bufio.go:245 +0x197
github.com/hashicorp/go-plugin.copyChan({0x10f3db8, 0xc000143a40}, 0xc0002308c0, {0x10cf280, 0xc00011c4a0?})
        github.com/hashicorp/go-plugin@v1.7.0/grpc_stdio.go:184 +0x1c5
created by github.com/hashicorp/go-plugin.newGRPCStdioServer in goroutine 1
        github.com/hashicorp/go-plugin@v1.7.0/grpc_stdio.go:41 +0x13e

Error: The terraform-provider-unifi_v0.41.25 plugin crashed!

This is always indicative of a bug within the plugin. It would be immensely
helpful if you could report the crash with the plugin's maintainers so that it
can be fixed. The output above should help diagnose the issue.

Operation failed: failed running terraform apply (exit 1)
```

## How to reproduce

1. Create a `unifi_client` resource
```terraform
resource "unifi_network" "<name>"{
  name = "<name>

  subnet        = "<subnet>"
  vlan          = 90
  multicast_dns = true
  auto_scale    = false
  setting_preference = "manual"

  domain_name = "<domain_name>"

  dhcp_server = {
    enabled = true
    start   = "<start_range>"
    stop    = "<stop_range>"

    dns_enabled = true
    dns_servers = ["<dns_server>"]
  }

  network_isolation = false
  internet_access   = true
}
```
2. Delete a `unifi_client` resource

## Execution Info

```
Execution Method: Terraform Cloud Agent
Platform: Azure
Arch: amd64
```