### PR TITLE
fix: reconcile client state on create; fix network field handling

### DIFF
--- a/unifi/client_resource.go
+++ b/unifi/client_resource.go
@@ -391,18 +391,17 @@ func (r *clientResource) Create(
 			)
 		}
 
-		// Implement merge pattern for existing client
-		mergedClient := r.mergeClient(existingClient, pclient)
-		tflog.Info(ctx, "Merged Client: ")
-		updatedClient, err := r.client.UpdateClient(ctx, site, mergedClient)
-		if err != nil {
-			resp.Diagnostics.AddError(
-				"Error Updating Existing Client",
-				"Could not update existing client: "+err.Error(),
-			)
-			return
+		if pclient != nil {
+			createdClient = pclient
+		} else {
+			createdClient = existingClient
 		}
-		createdClient = updatedClient
+	}
+
+	createdClient, diags = r.reconcileCreatedClient(ctx, site, createdClient, client)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
 	}
 
 	// Convert response back to model
@@ -620,6 +619,12 @@ func (r *clientResource) Update(
 					"Error Recreating Client",
 					"Could not recreate client: "+err.Error(),
 				)
+				return
+			}
+
+			createdClient, diags = r.reconcileCreatedClient(ctx, site, createdClient, planClient)
+			resp.Diagnostics.Append(diags...)
+			if resp.Diagnostics.HasError() {
 				return
 			}
 
@@ -902,6 +907,57 @@ func (r *clientResource) planToClient(
 	}
 
 	return client, diags
+}
+
+func (r *clientResource) reconcileCreatedClient(
+	ctx context.Context,
+	site string,
+	currentClient *unifi.Client,
+	plannedClient *unifi.Client,
+) (*unifi.Client, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	if currentClient == nil || currentClient.ID == "" {
+		existingClient, err := r.client.GetClientByMAC(ctx, site, plannedClient.MAC)
+		if err != nil {
+			diags.AddError(
+				"Error Reading Created Client",
+				"Could not read created client with MAC "+plannedClient.MAC+": "+err.Error(),
+			)
+			return nil, diags
+		}
+
+		fullClient, err := r.client.GetClient(ctx, site, existingClient.ID)
+		if err == nil {
+			currentClient = fullClient
+		} else {
+			currentClient = existingClient
+		}
+	}
+
+	mergedClient := r.mergeClient(currentClient, plannedClient)
+	tflog.Debug(ctx, "Merging created client", map[string]any{
+		"site":        site,
+		"mac":         plannedClient.MAC,
+		"merged_id":   mergedClient.ID,
+	})
+	updatedClient, err := r.client.UpdateClient(ctx, site, mergedClient)
+	if err != nil {
+		diags.AddError(
+			"Error Updating Created Client",
+			"Could not update created client: "+err.Error(),
+		)
+		return nil, diags
+	}
+
+	if updatedClient != nil && updatedClient.ID != "" {
+		freshClient, err := r.client.GetClient(ctx, site, updatedClient.ID)
+		if err == nil {
+			return freshClient, diags
+		}
+	}
+
+	return updatedClient, diags
 }
 
 func (r *clientResource) clientToModel(

--- a/unifi/network_resource.go
+++ b/unifi/network_resource.go
@@ -878,7 +878,7 @@ func (r *networkResource) modelToNetwork(
 		GatewayType:             model.GatewayType.ValueStringPointer(),
 		IPV6InterfaceType:       model.IPv6InterfaceType.ValueStringPointer(),
 		LteLanEnabled:           model.LteLan.ValueBool(),
-		VLANEnabled:             true,
+		VLANEnabled:             !model.Vlan.IsNull() && !model.Vlan.IsUnknown(),
 		Enabled:                 model.Enabled.ValueBool(),
 		IGMPSnooping:            model.IgmpSnooping.ValueBool(),
 		IPAliases:               []string{},
@@ -1278,9 +1278,13 @@ func (r *networkResource) networkToModel(
 			return types.StringValue(*ptr)
 		}
 
+		bootServer := types.StringNull()
+		if network.DHCPDBootServer != "" {
+			bootServer = types.StringValue(network.DHCPDBootServer)
+		}
 		dhcpBootValue := dhcpBootModel{
 			Enabled:  types.BoolValue(network.DHCPDBootEnabled),
-			Server:   types.StringValue(network.DHCPDBootServer),
+			Server:   bootServer,
 			Filename: strPtrToType(network.DHCPDBootFilename),
 		}
 


### PR DESCRIPTION
Two independent bug fixes.

### fix(client): reconcile state after create

The UniFi API returns a sparse object after provisioning. After Create, look up the client by MAC, merge the plan into the API state, then re-read so computed fields (IP, hostname, etc.) appear in Terraform state immediately rather than on the next refresh.                                                                                                                                                                                                                                                                

Apply the same `reconcileCreatedClient` pattern during Update when the client already exists, keeping state consistent across both operations.

### fix(network): VLANEnabled and DHCPDBootServer field handling

- `VLANEnabled` was hardcoded to `true`, treating every network as VLAN-enabled regardless of whether a VLAN ID was configured. Now set only when the `vlan` attribute is present and known.                
- `DHCPDBootServer`: an empty API response was converted to an empty string, causing phantom drift on plans where the field is unset. Now correctly maps to null.

No new go-unifi APIs required.