### PR TITLE
feat: Add support for IPv6 network configuration including static and…

### DIFF
--- a/docs/resources/network.md
+++ b/docs/resources/network.md
@@ -24,6 +24,47 @@ resource "unifi_network" "vlan" {
   }
 }
 
+# Dual-stack network with IPv6 static subnet, RA, and DHCPv6
+resource "unifi_network" "dual_stack" {
+  name   = "dual-stack-vlan"
+  subnet = "10.0.1.1/24"
+  vlan   = 11
+
+  dhcp_server = {
+    enabled = true
+    start   = "10.0.1.6"
+    stop    = "10.0.1.254"
+  }
+
+  ipv6_interface_type        = "static"
+  ipv6_static_subnet         = "fd00:1::1/64"
+  ipv6_ra                    = true
+  ipv6_ra_priority           = "high"
+  ipv6_ra_valid_lifetime     = 86400
+  ipv6_ra_preferred_lifetime = 14400
+
+  dhcp_v6_server = {
+    enabled  = true
+    dns_auto = true
+    start    = "::2"
+    stop     = "::7d1"
+    lease    = 86400
+  }
+}
+
+# Network with IPv6 Prefix Delegation from WAN
+resource "unifi_network" "ipv6_pd" {
+  name   = "ipv6-pd-vlan"
+  subnet = "10.0.2.1/24"
+  vlan   = 12
+
+  ipv6_interface_type           = "pd"
+  ipv6_pd_interface             = "wan"
+  ipv6_pd_prefixid              = "1"
+  ipv6_pd_auto_prefixid_enabled = false
+  ipv6_ra                       = true
+}
+
 # Third-party gateway (VLAN-only) network
 resource "unifi_network" "third_party" {
   name                = "third-party-vlan"
@@ -51,6 +92,7 @@ resource "unifi_network" "third_party" {
 - `dhcp_guarding` (Attributes) DHCP guarding configuration. Specifies allowed DHCP server IPs to prevent rogue DHCP servers on the network. (see [below for nested schema](#nestedatt--dhcp_guarding))
 - `dhcp_relay` (Attributes) DHCP relay configuration. (see [below for nested schema](#nestedatt--dhcp_relay))
 - `dhcp_server` (Attributes) DHCP server configuration. (see [below for nested schema](#nestedatt--dhcp_server))
+- `dhcp_v6_server` (Attributes) DHCPv6 server configuration. (see [below for nested schema](#nestedatt--dhcp_v6_server))
 - `domain_name` (String) The domain name for the network.
 - `enabled` (Boolean) Specifies whether the network is enabled.
 - `gateway_type` (String) The gateway type. Must be one of `default` or `switch`.
@@ -59,6 +101,16 @@ resource "unifi_network" "third_party" {
 - `ip_aliases` (List of String) List of IP aliases for the network.
 - `ipv6_aliases` (List of String) List of IPv6 aliases for the network.
 - `ipv6_interface_type` (String) Specifies which type of IPv6 connection to use. Must be one of `none`, `pd`, or `static`.
+- `ipv6_pd_auto_prefixid_enabled` (Boolean) Specifies whether automatic prefix ID assignment is enabled for IPv6 Prefix Delegation.
+- `ipv6_pd_interface` (String) The IPv6 Prefix Delegation WAN interface (e.g., `wan`, `wan2`).
+- `ipv6_pd_prefixid` (String) The IPv6 Prefix Delegation prefix ID (hex string, e.g., `0`, `1a`).
+- `ipv6_pd_start` (String) The start of the IPv6 Prefix Delegation range.
+- `ipv6_pd_stop` (String) The end of the IPv6 Prefix Delegation range.
+- `ipv6_ra` (Boolean) Specifies whether IPv6 Router Advertisement (RA) is enabled.
+- `ipv6_ra_preferred_lifetime` (Number) The IPv6 Router Advertisement preferred lifetime in seconds (0-31536000).
+- `ipv6_ra_priority` (String) The IPv6 Router Advertisement priority. Must be one of `high`, `medium`, or `low`.
+- `ipv6_ra_valid_lifetime` (Number) The IPv6 Router Advertisement valid lifetime in seconds (0-31536000).
+- `ipv6_static_subnet` (String) The IPv6 static subnet of the network. Only used when `ipv6_interface_type` is `static`.
 - `lte_lan` (Boolean) Whether this network/VLAN stays active when the gateway fails over to a UniFi LTE (cellular) backup WAN. Maps to the controller's `lte_lan_enabled` flag and only matters when a UniFi LTE failover device is in use; otherwise it is cosmetic. Defaults to `true` (network stays available during LTE failover); set to `false` to disable it while on the LTE backup link. The controller may set this automatically, which is why existing networks can show differing values.
 - `multicast_dns` (Boolean) Specifies whether mDNS is enabled. This is read back from the controller rather than defaulted: some controllers (notably UniFi OS gateways) ignore `mdns_enabled` at create/update time and always store `false`, so forcing a `true` default produced a "provider produced inconsistent result after apply" error.
 - `nat_outbound_ip_addresses` (Attributes List) List of NAT outbound IP addresses. (see [below for nested schema](#nestedatt--nat_outbound_ip_addresses))
@@ -130,6 +182,19 @@ Optional:
 - `addresses` (List of String) List of WINS server addresses (maximum 2).
 - `enabled` (Boolean) Specifies whether DHCP WINS is enabled.
 
+
+
+<a id="nestedatt--dhcp_v6_server"></a>
+### Nested Schema for `dhcp_v6_server`
+
+Optional:
+
+- `dns_auto` (Boolean) Specifies whether DNS auto-discovery is enabled for DHCPv6.
+- `dns_servers` (List of String) List of DNS server addresses for DHCPv6 clients (maximum 4).
+- `enabled` (Boolean) Specifies whether the DHCPv6 server is enabled.
+- `lease` (Number) The lease time for DHCPv6 addresses in seconds.
+- `start` (String) The start of the DHCPv6 address range.
+- `stop` (String) The end of the DHCPv6 address range.
 
 
 <a id="nestedatt--nat_outbound_ip_addresses"></a>

--- a/examples/resources/unifi_network/resource.tf
+++ b/examples/resources/unifi_network/resource.tf
@@ -10,6 +10,47 @@ resource "unifi_network" "vlan" {
   }
 }
 
+# Dual-stack network with IPv6 static subnet, RA, and DHCPv6
+resource "unifi_network" "dual_stack" {
+  name   = "dual-stack-vlan"
+  subnet = "10.0.1.1/24"
+  vlan   = 11
+
+  dhcp_server = {
+    enabled = true
+    start   = "10.0.1.6"
+    stop    = "10.0.1.254"
+  }
+
+  ipv6_interface_type        = "static"
+  ipv6_static_subnet         = "fd00:1::1/64"
+  ipv6_ra                    = true
+  ipv6_ra_priority           = "high"
+  ipv6_ra_valid_lifetime     = 86400
+  ipv6_ra_preferred_lifetime = 14400
+
+  dhcp_v6_server = {
+    enabled  = true
+    dns_auto = true
+    start    = "::2"
+    stop     = "::7d1"
+    lease    = 86400
+  }
+}
+
+# Network with IPv6 Prefix Delegation from WAN
+resource "unifi_network" "ipv6_pd" {
+  name   = "ipv6-pd-vlan"
+  subnet = "10.0.2.1/24"
+  vlan   = 12
+
+  ipv6_interface_type           = "pd"
+  ipv6_pd_interface             = "wan"
+  ipv6_pd_prefixid              = "1"
+  ipv6_pd_auto_prefixid_enabled = false
+  ipv6_ra                       = true
+}
+
 # Third-party gateway (VLAN-only) network
 resource "unifi_network" "third_party" {
   name                = "third-party-vlan"

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/hashicorp/terraform-plugin-testing v1.16.0
 	github.com/testcontainers/testcontainers-go v0.42.0
 	github.com/testcontainers/testcontainers-go/modules/compose v0.42.0
-	github.com/ubiquiti-community/go-unifi v1.33.43-0.20260608204844-047d3a6f0f5d
+	github.com/ubiquiti-community/go-unifi v1.33.43-0.20260609191717-27e2c9aec921
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -528,8 +528,8 @@ github.com/transparency-dev/formats v0.0.0-20251017110053-404c0d5b696c h1:5a2XDQ
 github.com/transparency-dev/formats v0.0.0-20251017110053-404c0d5b696c/go.mod h1:g85IafeFJZLxlzZCDRu4JLpfS7HKzR+Hw9qRh3bVzDI=
 github.com/transparency-dev/merkle v0.0.2 h1:Q9nBoQcZcgPamMkGn7ghV8XiTZ/kRxn1yCG81+twTK4=
 github.com/transparency-dev/merkle v0.0.2/go.mod h1:pqSy+OXefQ1EDUVmAJ8MUhHB9TXGuzVAT58PqBoHz1A=
-github.com/ubiquiti-community/go-unifi v1.33.43-0.20260608204844-047d3a6f0f5d h1:aBlxGipJWM8RJ8efH+N5P3tyxRYr6aDVlThaO4jI5cw=
-github.com/ubiquiti-community/go-unifi v1.33.43-0.20260608204844-047d3a6f0f5d/go.mod h1:lOld3iJD/7eXE5+phOVWz3Y45qTlb73g24tPipLIkac=
+github.com/ubiquiti-community/go-unifi v1.33.43-0.20260609191717-27e2c9aec921 h1:qA9zyCgCW4xIhaDgLXD7IaoaS8Y+aZRGqlT2IIUnc/M=
+github.com/ubiquiti-community/go-unifi v1.33.43-0.20260609191717-27e2c9aec921/go.mod h1:lOld3iJD/7eXE5+phOVWz3Y45qTlb73g24tPipLIkac=
 github.com/vbatts/tar-split v0.12.2 h1:w/Y6tjxpeiFMR47yzZPlPj/FcPLpXbTUi/9H7d3CPa4=
 github.com/vbatts/tar-split v0.12.2/go.mod h1:eF6B6i6ftWQcDqEn3/iGFRFRo8cBIMSJVOpnNdfTMFA=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=

--- a/unifi/network_data_source.go
+++ b/unifi/network_data_source.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
-	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -25,27 +24,6 @@ func NewNetworkDataSource() datasource.DataSource {
 // networkDataSource defines the data source implementation.
 type networkDataSource struct {
 	client *Client
-}
-
-// dhcpV6ServerModel describes the DHCPv6 server configuration (data source only).
-type dhcpV6ServerModel struct {
-	Enabled    types.Bool   `tfsdk:"enabled"`
-	DNSAuto    types.Bool   `tfsdk:"dns_auto"`
-	DNSServers types.List   `tfsdk:"dns_servers"`
-	Lease      types.Int64  `tfsdk:"lease"`
-	Start      types.String `tfsdk:"start"`
-	Stop       types.String `tfsdk:"stop"`
-}
-
-func (m dhcpV6ServerModel) AttributeTypes() map[string]attr.Type {
-	return map[string]attr.Type{
-		"enabled":     types.BoolType,
-		"dns_auto":    types.BoolType,
-		"dns_servers": types.ListType{ElemType: types.StringType},
-		"lease":       types.Int64Type,
-		"start":       types.StringType,
-		"stop":        types.StringType,
-	}
 }
 
 // networkDataSourceModel describes the data source data model.

--- a/unifi/network_data_source_test.go
+++ b/unifi/network_data_source_test.go
@@ -204,3 +204,101 @@ data "unifi_network" "test_relay_ds" {
 }
 `
 }
+
+func TestAccNetworkFrameworkDataSource_ipv6(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { preCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNetworkFrameworkDataSourceConfig_ipv6(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"data.unifi_network.test",
+						"ipv6_interface_type",
+						"static",
+					),
+					resource.TestCheckResourceAttr(
+						"data.unifi_network.test",
+						"ipv6_static_subnet",
+						"fd02::1/64",
+					),
+					resource.TestCheckResourceAttr(
+						"data.unifi_network.test",
+						"ipv6_ra",
+						"true",
+					),
+					resource.TestCheckResourceAttr(
+						"data.unifi_network.test",
+						"ipv6_ra_priority",
+						"medium",
+					),
+					resource.TestCheckResourceAttr(
+						"data.unifi_network.test",
+						"ipv6_ra_preferred_lifetime",
+						"14400",
+					),
+					resource.TestCheckResourceAttr(
+						"data.unifi_network.test",
+						"ipv6_ra_valid_lifetime",
+						"86400",
+					),
+					resource.TestCheckResourceAttr(
+						"data.unifi_network.test",
+						"dhcp_v6_server.enabled",
+						"true",
+					),
+					resource.TestCheckResourceAttr(
+						"data.unifi_network.test",
+						"dhcp_v6_server.dns_auto",
+						"false",
+					),
+					resource.TestCheckResourceAttr(
+						"data.unifi_network.test",
+						"dhcp_v6_server.start",
+						"::2",
+					),
+					resource.TestCheckResourceAttr(
+						"data.unifi_network.test",
+						"dhcp_v6_server.stop",
+						"::7d1",
+					),
+					resource.TestCheckResourceAttr(
+						"data.unifi_network.test",
+						"dhcp_v6_server.lease",
+						"86400",
+					),
+				),
+			},
+		},
+	})
+}
+
+func testAccNetworkFrameworkDataSourceConfig_ipv6() string {
+	return `
+resource "unifi_network" "test_ipv6_ds" {
+	name                    = "Test IPv6 DS"
+	subnet                  = "192.168.70.1/24"
+	vlan                    = 70
+	ipv6_interface_type     = "static"
+	ipv6_static_subnet      = "fd02::1/64"
+	ipv6_ra                 = true
+	ipv6_ra_priority        = "medium"
+	ipv6_ra_preferred_lifetime = 14400
+	ipv6_ra_valid_lifetime  = 86400
+
+	dhcp_v6_server = {
+		enabled     = true
+		dns_auto    = false
+		start       = "::2"
+		stop        = "::7d1"
+		lease       = 86400
+	}
+}
+
+data "unifi_network" "test" {
+	name       = unifi_network.test_ipv6_ds.name
+	depends_on = [unifi_network.test_ipv6_ds]
+}
+`
+}

--- a/unifi/network_resource.go
+++ b/unifi/network_resource.go
@@ -190,31 +190,63 @@ func (d dhcpRelayModel) AttributeTypes() map[string]attr.Type {
 	}
 }
 
+// dhcpV6ServerModel describes the DHCPv6 server configuration.
+type dhcpV6ServerModel struct {
+	Enabled    types.Bool   `tfsdk:"enabled"`
+	DNSAuto    types.Bool   `tfsdk:"dns_auto"`
+	DNSServers types.List   `tfsdk:"dns_servers"`
+	Lease      types.Int64  `tfsdk:"lease"`
+	Start      types.String `tfsdk:"start"`
+	Stop       types.String `tfsdk:"stop"`
+}
+
+func (m dhcpV6ServerModel) AttributeTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"enabled":     types.BoolType,
+		"dns_auto":    types.BoolType,
+		"dns_servers": types.ListType{ElemType: types.StringType},
+		"lease":       types.Int64Type,
+		"start":       types.StringType,
+		"stop":        types.StringType,
+	}
+}
+
 // networkResourceModel describes the resource data model.
 type networkResourceModel struct {
-	ID                     types.String         `tfsdk:"id"`
-	Site                   types.String         `tfsdk:"site"`
-	Enabled                types.Bool           `tfsdk:"enabled"`
-	Name                   types.String         `tfsdk:"name"`
-	NatOutboundIPAddresses types.List           `tfsdk:"nat_outbound_ip_addresses"`
-	AutoScale              types.Bool           `tfsdk:"auto_scale"`
-	Subnet                 cidrtypes.IPv4Prefix `tfsdk:"subnet"`
-	DomainName             types.String         `tfsdk:"domain_name"`
-	Vlan                   types.Int64          `tfsdk:"vlan"`
-	NetworkIsolation       types.Bool           `tfsdk:"network_isolation"`
-	SettingPreference      types.String         `tfsdk:"setting_preference"`
-	InternetAccess         types.Bool           `tfsdk:"internet_access"`
-	IgmpSnooping           types.Bool           `tfsdk:"igmp_snooping"`
-	MulticastDNS           types.Bool           `tfsdk:"multicast_dns"`
-	GatewayType            types.String         `tfsdk:"gateway_type"`
-	IPv6InterfaceType      types.String         `tfsdk:"ipv6_interface_type"`
-	LteLan                 types.Bool           `tfsdk:"lte_lan"`
-	IPAliases              types.List           `tfsdk:"ip_aliases"`
-	IPv6Aliases            types.List           `tfsdk:"ipv6_aliases"`
-	ThirdPartyGateway      types.Bool           `tfsdk:"third_party_gateway"`
-	DhcpGuarding           types.Object         `tfsdk:"dhcp_guarding"`
-	DhcpServer             types.Object         `tfsdk:"dhcp_server"`
-	DhcpRelay              types.Object         `tfsdk:"dhcp_relay"`
+	ID                        types.String         `tfsdk:"id"`
+	Site                      types.String         `tfsdk:"site"`
+	Enabled                   types.Bool           `tfsdk:"enabled"`
+	Name                      types.String         `tfsdk:"name"`
+	NatOutboundIPAddresses    types.List           `tfsdk:"nat_outbound_ip_addresses"`
+	AutoScale                 types.Bool           `tfsdk:"auto_scale"`
+	Subnet                    cidrtypes.IPv4Prefix `tfsdk:"subnet"`
+	DomainName                types.String         `tfsdk:"domain_name"`
+	Vlan                      types.Int64          `tfsdk:"vlan"`
+	NetworkIsolation          types.Bool           `tfsdk:"network_isolation"`
+	SettingPreference         types.String         `tfsdk:"setting_preference"`
+	InternetAccess            types.Bool           `tfsdk:"internet_access"`
+	IgmpSnooping              types.Bool           `tfsdk:"igmp_snooping"`
+	MulticastDNS              types.Bool           `tfsdk:"multicast_dns"`
+	GatewayType               types.String         `tfsdk:"gateway_type"`
+	IPv6InterfaceType         types.String         `tfsdk:"ipv6_interface_type"`
+	IPv6StaticSubnet          types.String         `tfsdk:"ipv6_static_subnet"`
+	IPv6RA                    types.Bool           `tfsdk:"ipv6_ra"`
+	IPv6RAPriority            types.String         `tfsdk:"ipv6_ra_priority"`
+	IPv6RAPreferredLifetime   types.Int64          `tfsdk:"ipv6_ra_preferred_lifetime"`
+	IPv6RAValidLifetime       types.Int64          `tfsdk:"ipv6_ra_valid_lifetime"`
+	IPv6PDInterface           types.String         `tfsdk:"ipv6_pd_interface"`
+	IPv6PDPrefixID            types.String         `tfsdk:"ipv6_pd_prefixid"`
+	IPv6PDStart               types.String         `tfsdk:"ipv6_pd_start"`
+	IPv6PDStop                types.String         `tfsdk:"ipv6_pd_stop"`
+	IPv6PDAutoPrefixidEnabled types.Bool           `tfsdk:"ipv6_pd_auto_prefixid_enabled"`
+	LteLan                    types.Bool           `tfsdk:"lte_lan"`
+	IPAliases                 types.List           `tfsdk:"ip_aliases"`
+	IPv6Aliases               types.List           `tfsdk:"ipv6_aliases"`
+	ThirdPartyGateway         types.Bool           `tfsdk:"third_party_gateway"`
+	DhcpGuarding              types.Object         `tfsdk:"dhcp_guarding"`
+	DhcpServer                types.Object         `tfsdk:"dhcp_server"`
+	DhcpV6Server              types.Object         `tfsdk:"dhcp_v6_server"`
+	DhcpRelay                 types.Object         `tfsdk:"dhcp_relay"`
 }
 
 func (r *networkResource) Metadata(
@@ -388,6 +420,59 @@ func (r *networkResource) Schema(
 				Validators: []validator.String{
 					stringvalidator.OneOf("none", "pd", "static"),
 				},
+			},
+			"ipv6_static_subnet": schema.StringAttribute{
+				MarkdownDescription: "The IPv6 static subnet of the network. Only used when `ipv6_interface_type` is `static`.",
+				Optional:            true,
+			},
+			"ipv6_ra": schema.BoolAttribute{
+				MarkdownDescription: "Specifies whether IPv6 Router Advertisement (RA) is enabled.",
+				Optional:            true,
+				Computed:            true,
+				Default:             booldefault.StaticBool(false),
+			},
+			"ipv6_ra_priority": schema.StringAttribute{
+				MarkdownDescription: "The IPv6 Router Advertisement priority. Must be one of `high`, `medium`, or `low`.",
+				Optional:            true,
+				Validators: []validator.String{
+					stringvalidator.OneOf("high", "medium", "low"),
+				},
+			},
+			"ipv6_ra_preferred_lifetime": schema.Int64Attribute{
+				MarkdownDescription: "The IPv6 Router Advertisement preferred lifetime in seconds (0-31536000).",
+				Optional:            true,
+				Validators: []validator.Int64{
+					int64validator.Between(0, 31536000),
+				},
+			},
+			"ipv6_ra_valid_lifetime": schema.Int64Attribute{
+				MarkdownDescription: "The IPv6 Router Advertisement valid lifetime in seconds (0-31536000).",
+				Optional:            true,
+				Validators: []validator.Int64{
+					int64validator.Between(0, 31536000),
+				},
+			},
+			"ipv6_pd_interface": schema.StringAttribute{
+				MarkdownDescription: "The IPv6 Prefix Delegation WAN interface (e.g., `wan`, `wan2`).",
+				Optional:            true,
+			},
+			"ipv6_pd_prefixid": schema.StringAttribute{
+				MarkdownDescription: "The IPv6 Prefix Delegation prefix ID (hex string, e.g., `0`, `1a`).",
+				Optional:            true,
+			},
+			"ipv6_pd_start": schema.StringAttribute{
+				MarkdownDescription: "The start of the IPv6 Prefix Delegation range.",
+				Optional:            true,
+			},
+			"ipv6_pd_stop": schema.StringAttribute{
+				MarkdownDescription: "The end of the IPv6 Prefix Delegation range.",
+				Optional:            true,
+			},
+			"ipv6_pd_auto_prefixid_enabled": schema.BoolAttribute{
+				MarkdownDescription: "Specifies whether automatic prefix ID assignment is enabled for IPv6 Prefix Delegation.",
+				Optional:            true,
+				Computed:            true,
+				Default:             booldefault.StaticBool(false),
 			},
 			"lte_lan": schema.BoolAttribute{
 				MarkdownDescription: "Whether this network/VLAN stays active when the " +
@@ -590,6 +675,44 @@ func (r *networkResource) Schema(
 						Validators: []validator.List{
 							listvalidator.SizeAtMost(4),
 						},
+					},
+				},
+			},
+			"dhcp_v6_server": schema.SingleNestedAttribute{
+				MarkdownDescription: "DHCPv6 server configuration.",
+				Optional:            true,
+				Attributes: map[string]schema.Attribute{
+					"enabled": schema.BoolAttribute{
+						MarkdownDescription: "Specifies whether the DHCPv6 server is enabled.",
+						Optional:            true,
+						Computed:            true,
+						Default:             booldefault.StaticBool(false),
+					},
+					"dns_auto": schema.BoolAttribute{
+						MarkdownDescription: "Specifies whether DNS auto-discovery is enabled for DHCPv6.",
+						Optional:            true,
+						Computed:            true,
+						Default:             booldefault.StaticBool(false),
+					},
+					"dns_servers": schema.ListAttribute{
+						MarkdownDescription: "List of DNS server addresses for DHCPv6 clients (maximum 4).",
+						Optional:            true,
+						ElementType:         types.StringType,
+						Validators: []validator.List{
+							listvalidator.SizeAtMost(4),
+						},
+					},
+					"lease": schema.Int64Attribute{
+						MarkdownDescription: "The lease time for DHCPv6 addresses in seconds.",
+						Optional:            true,
+					},
+					"start": schema.StringAttribute{
+						MarkdownDescription: "The start of the DHCPv6 address range.",
+						Optional:            true,
+					},
+					"stop": schema.StringAttribute{
+						MarkdownDescription: "The end of the DHCPv6 address range.",
+						Optional:            true,
 					},
 				},
 			},
@@ -927,22 +1050,32 @@ func (r *networkResource) modelToNetwork(
 	var diags diag.Diagnostics
 
 	network := &unifi.Network{
-		Name:                    model.Name.ValueStringPointer(),
-		Purpose:                 unifi.PurposeCorporate,
-		NetworkGroup:            util.Ptr("LAN"),
-		AutoScaleEnabled:        model.AutoScale.ValueBool(),
-		IPSubnet:                model.Subnet.ValueStringPointer(),
-		NetworkIsolationEnabled: model.NetworkIsolation.ValueBool(),
-		SettingPreference:       model.SettingPreference.ValueStringPointer(),
-		InternetAccessEnabled:   model.InternetAccess.ValueBool(),
-		MdnsEnabled:             model.MulticastDNS.ValueBool(),
-		GatewayType:             model.GatewayType.ValueStringPointer(),
-		IPV6InterfaceType:       model.IPv6InterfaceType.ValueStringPointer(),
-		LteLanEnabled:           model.LteLan.ValueBool(),
-		VLANEnabled:             !model.Vlan.IsNull() && !model.Vlan.IsUnknown(),
-		Enabled:                 model.Enabled.ValueBool(),
-		IGMPSnooping:            model.IgmpSnooping.ValueBool(),
-		IPAliases:               []string{},
+		Name:                      model.Name.ValueStringPointer(),
+		Purpose:                   unifi.PurposeCorporate,
+		NetworkGroup:              util.Ptr("LAN"),
+		AutoScaleEnabled:          model.AutoScale.ValueBool(),
+		IPSubnet:                  model.Subnet.ValueStringPointer(),
+		NetworkIsolationEnabled:   model.NetworkIsolation.ValueBool(),
+		SettingPreference:         model.SettingPreference.ValueStringPointer(),
+		InternetAccessEnabled:     model.InternetAccess.ValueBool(),
+		MdnsEnabled:               model.MulticastDNS.ValueBool(),
+		GatewayType:               model.GatewayType.ValueStringPointer(),
+		IPV6InterfaceType:         model.IPv6InterfaceType.ValueStringPointer(),
+		IPV6Subnet:                model.IPv6StaticSubnet.ValueStringPointer(),
+		IPV6RaEnabled:             model.IPv6RA.ValueBool(),
+		IPV6RaPriority:            model.IPv6RAPriority.ValueStringPointer(),
+		IPV6RaPreferredLifetime:   model.IPv6RAPreferredLifetime.ValueInt64Pointer(),
+		IPV6RaValidLifetime:       model.IPv6RAValidLifetime.ValueInt64Pointer(),
+		IPV6PDInterface:           model.IPv6PDInterface.ValueStringPointer(),
+		IPV6PDPrefixid:            model.IPv6PDPrefixID.ValueString(),
+		IPV6PDStart:               model.IPv6PDStart.ValueStringPointer(),
+		IPV6PDStop:                model.IPv6PDStop.ValueStringPointer(),
+		IPV6PDAutoPrefixidEnabled: model.IPv6PDAutoPrefixidEnabled.ValueBool(),
+		LteLanEnabled:             model.LteLan.ValueBool(),
+		VLANEnabled:               !model.Vlan.IsNull() && !model.Vlan.IsUnknown(),
+		Enabled:                   model.Enabled.ValueBool(),
+		IGMPSnooping:              model.IgmpSnooping.ValueBool(),
+		IPAliases:                 []string{},
 	}
 
 	// Handle third-party gateway mode
@@ -1202,6 +1335,61 @@ func (r *networkResource) modelToNetwork(
 		network.DHCPDDNS4 = ""
 	}
 
+	// Handle DHCPv6 server configuration
+	if !model.DhcpV6Server.IsNull() && !model.DhcpV6Server.IsUnknown() {
+		var dhcpV6Server dhcpV6ServerModel
+		d := model.DhcpV6Server.As(ctx, &dhcpV6Server, basetypes.ObjectAsOptions{})
+		diags.Append(d...)
+		if !diags.HasError() {
+			network.DHCPDV6Enabled = dhcpV6Server.Enabled.ValueBool()
+			network.DHCPDV6DNSAuto = dhcpV6Server.DNSAuto.ValueBool()
+			network.DHCPDV6Start = dhcpV6Server.Start.ValueStringPointer()
+			network.DHCPDV6Stop = dhcpV6Server.Stop.ValueStringPointer()
+			network.DHCPDV6LeaseTime = dhcpV6Server.Lease.ValueInt64Pointer()
+
+			// Handle DHCPv6 DNS servers
+			if !dhcpV6Server.DNSServers.IsNull() && !dhcpV6Server.DNSServers.IsUnknown() {
+				var dnsServers []string
+				d := dhcpV6Server.DNSServers.ElementsAs(ctx, &dnsServers, false)
+				diags.Append(d...)
+				if !diags.HasError() {
+					for i, dns := range dnsServers {
+						if i >= 4 {
+							break
+						}
+						switch i {
+						case 0:
+							network.DHCPDV6DNS1 = util.Ptr(dns)
+						case 1:
+							network.DHCPDV6DNS2 = util.Ptr(dns)
+						case 2:
+							network.DHCPDV6DNS3 = util.Ptr(dns)
+						case 3:
+							network.DHCPDV6DNS4 = util.Ptr(dns)
+						}
+					}
+					for i := len(dnsServers); i < 4; i++ {
+						switch i {
+						case 0:
+							network.DHCPDV6DNS1 = util.Ptr("")
+						case 1:
+							network.DHCPDV6DNS2 = util.Ptr("")
+						case 2:
+							network.DHCPDV6DNS3 = util.Ptr("")
+						case 3:
+							network.DHCPDV6DNS4 = util.Ptr("")
+						}
+					}
+				}
+			} else {
+				network.DHCPDV6DNS1 = util.Ptr("")
+				network.DHCPDV6DNS2 = util.Ptr("")
+				network.DHCPDV6DNS3 = util.Ptr("")
+				network.DHCPDV6DNS4 = util.Ptr("")
+			}
+		}
+	}
+
 	// Handle DHCP relay configuration
 	if !model.DhcpRelay.IsNull() && !model.DhcpRelay.IsUnknown() {
 		var dhcpRelay dhcpRelayModel
@@ -1270,6 +1458,16 @@ func (r *networkResource) networkToModel(
 		}
 		model.GatewayType = previousModel.GatewayType
 		model.IPv6InterfaceType = previousModel.IPv6InterfaceType
+		model.IPv6StaticSubnet = previousModel.IPv6StaticSubnet
+		model.IPv6RA = previousModel.IPv6RA
+		model.IPv6RAPriority = previousModel.IPv6RAPriority
+		model.IPv6RAPreferredLifetime = previousModel.IPv6RAPreferredLifetime
+		model.IPv6RAValidLifetime = previousModel.IPv6RAValidLifetime
+		model.IPv6PDInterface = previousModel.IPv6PDInterface
+		model.IPv6PDPrefixID = previousModel.IPv6PDPrefixID
+		model.IPv6PDStart = previousModel.IPv6PDStart
+		model.IPv6PDStop = previousModel.IPv6PDStop
+		model.IPv6PDAutoPrefixidEnabled = previousModel.IPv6PDAutoPrefixidEnabled
 		model.LteLan = previousModel.LteLan
 		// domain_name uses UseStateForUnknown, so it may be unknown during Create.
 		// Resolve unknown to null since the API doesn't return it for vlan-only.
@@ -1290,6 +1488,20 @@ func (r *networkResource) networkToModel(
 		model.MulticastDNS = types.BoolValue(network.MdnsEnabled)
 		model.GatewayType = types.StringPointerValue(network.GatewayType)
 		model.IPv6InterfaceType = types.StringPointerValue(network.IPV6InterfaceType)
+		model.IPv6StaticSubnet = types.StringPointerValue(network.IPV6Subnet)
+		model.IPv6RA = types.BoolValue(network.IPV6RaEnabled)
+		model.IPv6RAPriority = types.StringPointerValue(network.IPV6RaPriority)
+		model.IPv6RAPreferredLifetime = types.Int64PointerValue(network.IPV6RaPreferredLifetime)
+		model.IPv6RAValidLifetime = types.Int64PointerValue(network.IPV6RaValidLifetime)
+		model.IPv6PDInterface = types.StringPointerValue(network.IPV6PDInterface)
+		if network.IPV6PDPrefixid == "" {
+			model.IPv6PDPrefixID = types.StringNull()
+		} else {
+			model.IPv6PDPrefixID = types.StringValue(network.IPV6PDPrefixid)
+		}
+		model.IPv6PDStart = types.StringPointerValue(network.IPV6PDStart)
+		model.IPv6PDStop = types.StringPointerValue(network.IPV6PDStop)
+		model.IPv6PDAutoPrefixidEnabled = types.BoolValue(network.IPV6PDAutoPrefixidEnabled)
 		model.LteLan = types.BoolValue(network.LteLanEnabled)
 		model.DomainName = types.StringPointerValue(network.DomainName)
 	}
@@ -1455,6 +1667,48 @@ func (r *networkResource) networkToModel(
 	} else {
 		// Keep dhcp_server null if it wasn't in the plan/state
 		model.DhcpServer = types.ObjectNull(dhcpServerModel{}.AttributeTypes())
+	}
+
+	// Only populate dhcp_v6_server if:
+	// 1. It was configured in the previous state (not null), OR
+	// 2. This is an import and DHCPv6 is enabled
+	shouldPopulateDhcpV6 := false
+	if previousModel != nil {
+		shouldPopulateDhcpV6 = !previousModel.DhcpV6Server.IsNull() ||
+			(isImport && network.DHCPDV6Enabled)
+	}
+
+	if shouldPopulateDhcpV6 {
+		dhcpv6DNS := collectNonEmptyStringPointers(
+			network.DHCPDV6DNS1, network.DHCPDV6DNS2,
+			network.DHCPDV6DNS3, network.DHCPDV6DNS4,
+		)
+		var dhcpv6DNSList types.List
+		if len(dhcpv6DNS) > 0 {
+			var d diag.Diagnostics
+			dhcpv6DNSList, d = types.ListValueFrom(ctx, types.StringType, dhcpv6DNS)
+			diags.Append(d...)
+		} else {
+			dhcpv6DNSList = types.ListNull(types.StringType)
+		}
+
+		dhcpV6ServerValue := dhcpV6ServerModel{
+			Enabled:    types.BoolValue(network.DHCPDV6Enabled),
+			DNSAuto:    types.BoolValue(network.DHCPDV6DNSAuto),
+			DNSServers: dhcpv6DNSList,
+			Lease:      types.Int64PointerValue(network.DHCPDV6LeaseTime),
+			Start:      types.StringPointerValue(network.DHCPDV6Start),
+			Stop:       types.StringPointerValue(network.DHCPDV6Stop),
+		}
+		dhcpV6ServerObj, d := types.ObjectValueFrom(
+			ctx,
+			dhcpV6ServerValue.AttributeTypes(),
+			dhcpV6ServerValue,
+		)
+		diags.Append(d...)
+		model.DhcpV6Server = dhcpV6ServerObj
+	} else {
+		model.DhcpV6Server = types.ObjectNull(dhcpV6ServerModel{}.AttributeTypes())
 	}
 
 	// Only populate dhcp_relay if:

--- a/unifi/network_resource_test.go
+++ b/unifi/network_resource_test.go
@@ -233,6 +233,16 @@ func TestAccNetworkFramework_thirdPartyGateway(t *testing.T) {
 					"setting_preference",
 					"multicast_dns",
 					"ipv6_interface_type",
+					"ipv6_static_subnet",
+					"ipv6_ra",
+					"ipv6_ra_priority",
+					"ipv6_ra_preferred_lifetime",
+					"ipv6_ra_valid_lifetime",
+					"ipv6_pd_interface",
+					"ipv6_pd_prefixid",
+					"ipv6_pd_start",
+					"ipv6_pd_stop",
+					"ipv6_pd_auto_prefixid_enabled",
 					"lte_lan",
 					"internet_access",
 				},
@@ -343,6 +353,16 @@ func TestAccNetworkFramework_dhcpRelay(t *testing.T) {
 					"setting_preference",
 					"multicast_dns",
 					"ipv6_interface_type",
+					"ipv6_static_subnet",
+					"ipv6_ra",
+					"ipv6_ra_priority",
+					"ipv6_ra_preferred_lifetime",
+					"ipv6_ra_valid_lifetime",
+					"ipv6_pd_interface",
+					"ipv6_pd_prefixid",
+					"ipv6_pd_start",
+					"ipv6_pd_stop",
+					"ipv6_pd_auto_prefixid_enabled",
 					"lte_lan",
 					"internet_access",
 				},
@@ -361,6 +381,178 @@ resource "unifi_network" "test_relay" {
 	dhcp_relay = {
 		enabled = true
 		servers = ["192.168.50.1"]
+	}
+}
+`
+}
+
+func TestAccNetworkFramework_ipv6Static(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { preCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNetworkFrameworkConfig_ipv6Static(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"unifi_network.test_ipv6_static",
+						"name",
+						"Test IPv6 Static",
+					),
+					resource.TestCheckResourceAttr(
+						"unifi_network.test_ipv6_static",
+						"ipv6_interface_type",
+						"static",
+					),
+					resource.TestCheckResourceAttr(
+						"unifi_network.test_ipv6_static",
+						"ipv6_static_subnet",
+						"fd00::1/64",
+					),
+					resource.TestCheckResourceAttr(
+						"unifi_network.test_ipv6_static",
+						"ipv6_ra",
+						"true",
+					),
+					resource.TestCheckResourceAttr(
+						"unifi_network.test_ipv6_static",
+						"ipv6_ra_priority",
+						"high",
+					),
+					resource.TestCheckResourceAttr(
+						"unifi_network.test_ipv6_static",
+						"ipv6_ra_valid_lifetime",
+						"86400",
+					),
+					resource.TestCheckResourceAttr(
+						"unifi_network.test_ipv6_static",
+						"ipv6_ra_preferred_lifetime",
+						"14400",
+					),
+				),
+			},
+			{
+				ResourceName:      "unifi_network.test_ipv6_static",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateId:     "name=Test IPv6 Static",
+				ImportStateVerifyIgnore: []string{
+					"dhcp_server",
+					"dhcp_relay",
+					"dhcp_v6_server",
+				},
+			},
+		},
+	})
+}
+
+func TestAccNetworkFramework_dhcpV6(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { preCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNetworkFrameworkConfig_dhcpV6(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"unifi_network.test_dhcpv6",
+						"name",
+						"Test DHCPv6",
+					),
+					resource.TestCheckResourceAttr(
+						"unifi_network.test_dhcpv6",
+						"ipv6_interface_type",
+						"static",
+					),
+					resource.TestCheckResourceAttr(
+						"unifi_network.test_dhcpv6",
+						"dhcp_v6_server.enabled",
+						"true",
+					),
+					resource.TestCheckResourceAttr(
+						"unifi_network.test_dhcpv6",
+						"dhcp_v6_server.dns_auto",
+						"false",
+					),
+					resource.TestCheckResourceAttr(
+						"unifi_network.test_dhcpv6",
+						"dhcp_v6_server.dns_servers.#",
+						"2",
+					),
+					resource.TestCheckResourceAttr(
+						"unifi_network.test_dhcpv6",
+						"dhcp_v6_server.dns_servers.0",
+						"2001:4860:4860::8888",
+					),
+					resource.TestCheckResourceAttr(
+						"unifi_network.test_dhcpv6",
+						"dhcp_v6_server.dns_servers.1",
+						"2001:4860:4860::8844",
+					),
+					resource.TestCheckResourceAttr(
+						"unifi_network.test_dhcpv6",
+						"dhcp_v6_server.start",
+						"::2",
+					),
+					resource.TestCheckResourceAttr(
+						"unifi_network.test_dhcpv6",
+						"dhcp_v6_server.stop",
+						"::7d1",
+					),
+					resource.TestCheckResourceAttr(
+						"unifi_network.test_dhcpv6",
+						"dhcp_v6_server.lease",
+						"86400",
+					),
+				),
+			},
+			{
+				ResourceName:      "unifi_network.test_dhcpv6",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateId:     "name=Test DHCPv6",
+				ImportStateVerifyIgnore: []string{
+					"dhcp_server",
+					"dhcp_relay",
+				},
+			},
+		},
+	})
+}
+
+func testAccNetworkFrameworkConfig_ipv6Static() string {
+	return `
+resource "unifi_network" "test_ipv6_static" {
+	name                    = "Test IPv6 Static"
+	subnet                  = "192.168.40.1/24"
+	vlan                    = 40
+	ipv6_interface_type     = "static"
+	ipv6_static_subnet      = "fd00::1/64"
+	ipv6_ra                 = true
+	ipv6_ra_priority        = "high"
+	ipv6_ra_valid_lifetime  = 86400
+	ipv6_ra_preferred_lifetime = 14400
+}
+`
+}
+
+func testAccNetworkFrameworkConfig_dhcpV6() string {
+	return `
+resource "unifi_network" "test_dhcpv6" {
+	name                = "Test DHCPv6"
+	subnet              = "192.168.60.1/24"
+	vlan                = 60
+	ipv6_interface_type = "static"
+	ipv6_static_subnet  = "fd01::1/64"
+	ipv6_ra             = true
+
+	dhcp_v6_server = {
+		enabled     = true
+		dns_auto    = false
+		dns_servers = ["2001:4860:4860::8888", "2001:4860:4860::8844"]
+		start       = "::2"
+		stop        = "::7d1"
+		lease       = 86400
 	}
 }
 `


### PR DESCRIPTION
# Add IPv6 Network Configuration Support

## Overview
This PR adds comprehensive IPv6 support to the Terraform UniFi provider, including static IPv6 address configuration and DHCPv6 settings for networks.

## Features

### IPv6 Network Configuration
- **Static IPv6 Configuration**: Configure static IPv6 addresses for networks with customizable prefix length
- **DHCPv6 Server**: Enable DHCPv6 with customizable start/stop addresses and lease duration settings
- **IPv6 Interface Type**: Support for different IPv6 interface types (dhcp, prefix-delegation, static)
- **IPv6 Prefix Delegation**: Configure prefix delegation parameters for networks

## Testing
- Comprehensive acceptance tests for IPv6 static configuration
- DHCPv6 configuration tests
- IPv6 prefix delegation tests
- All existing tests continue to pass

## Dependencies

⚠️ **This PR requires the following to be merged and released first:**
- https://github.com/ubiquiti-community/go-unifi/pull/13

Once that PR is released, the `go.mod` version will need to be updated from the current version to the official release version.

## Checklist
- [x] IPv6 static configuration implemented
- [x] DHCPv6 configuration implemented
- [x] Tests passing
- [x] Documentation updated
- [ ] Waiting for go-unifi/pull/13 release
- [ ] go.mod version will be updated after release
