### PR TITLE
fix(client): make unifi_client import/create zero-diff (blocked/groups/qos_rate)

### DIFF
--- a/unifi/client_resource.go
+++ b/unifi/client_resource.go
@@ -18,6 +18,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -198,6 +200,9 @@ Clients are created in the controller when observed on the network, so the resou
 				MarkdownDescription: "QoS rate limiting configuration. Controls the client group (usergroup) used for bandwidth limits.",
 				Optional:            true,
 				Computed:            true,
+				PlanModifiers: []planmodifier.Object{
+					objectplanmodifier.UseStateForUnknown(),
+				},
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						MarkdownDescription: "The ID of the client group (usergroup). If set, this group is used directly.",
@@ -258,6 +263,9 @@ Clients are created in the controller when observed on the network, so the resou
 				Optional:            true,
 				Computed:            true,
 				ElementType:         types.StringType,
+				PlanModifiers: []planmodifier.List{
+					listplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"blocked": schema.BoolAttribute{
 				MarkdownDescription: "Specifies whether this client should be blocked from the network.",
@@ -971,7 +979,11 @@ func (r *clientResource) clientToModel(
 		model.Groups = types.ListNull(types.StringType)
 	}
 
-	model.Blocked = types.BoolPointerValue(client.Blocked)
+	// Some controllers (e.g. UniFi OS 5.x / Network App 10.x) omit "blocked" for
+	// fixed-IP-only clients, so client.Blocked is nil. Store the documented default
+	// (false) instead of null; otherwise the schema's Default(false) makes the next
+	// plan propose false → a spurious diff on every create/import.
+	model.Blocked = types.BoolValue(client.Blocked != nil && *client.Blocked)
 	model.LocalDNSRecord = util.StringValueOrNull(client.LocalDNSRecord)
 
 	// Computed attributes

--- a/unifi/client_resource_test.go
+++ b/unifi/client_resource_test.go
@@ -1,10 +1,67 @@
 package unifi
 
 import (
+	"context"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/ubiquiti-community/go-unifi/unifi"
 )
+
+// TestClientToModel_DefaultsWhenAPIOmitsFields proves the fix for the spurious
+// in-place diff on every create/import: when the controller omits blocked / groups /
+// qos_rate (as UniFi OS 5.x / Network App 10.x does for fixed-IP-only clients),
+// Read must store the documented default (blocked=false) rather than null, and leave
+// groups / qos_rate null so the UseStateForUnknown plan modifiers can keep the plan
+// clean. For this minimal client clientToModel makes no API calls, so no live
+// controller (and no mock) is needed.
+func TestClientToModel_DefaultsWhenAPIOmitsFields(t *testing.T) {
+	r := &clientResource{}
+
+	client := &unifi.Client{
+		ID:                     "61d1...",
+		MAC:                    "02:00:00:de:ad:01",
+		Name:                   "tf-test",
+		FixedIP:                "192.168.40.251",
+		Blocked:                nil, // controller omitted "blocked"
+		UserGroupID:            "",  // no qos_rate / usergroup
+		NetworkMembersGroupIDs: nil, // no groups
+	}
+
+	var model clientResourceModel
+	diags := r.clientToModel(context.Background(), client, &model, "default")
+	if diags.HasError() {
+		t.Fatalf("clientToModel returned errors: %v", diags)
+	}
+
+	if model.Blocked.IsNull() || model.Blocked.IsUnknown() {
+		t.Errorf("blocked: want concrete value, got null/unknown (%#v)", model.Blocked)
+	}
+	if model.Blocked.ValueBool() != false {
+		t.Errorf("blocked: want false, got %v", model.Blocked.ValueBool())
+	}
+	if !model.Groups.IsNull() {
+		t.Errorf("groups: want null, got %#v", model.Groups)
+	}
+	if !model.QOSRate.IsNull() {
+		t.Errorf("qos_rate: want null, got %#v", model.QOSRate)
+	}
+}
+
+// TestClientToModel_PreservesBlockedTrue ensures a blocked client still round-trips.
+func TestClientToModel_PreservesBlockedTrue(t *testing.T) {
+	r := &clientResource{}
+	blocked := true
+	client := &unifi.Client{MAC: "02:00:00:de:ad:02", Blocked: &blocked}
+
+	var model clientResourceModel
+	if diags := r.clientToModel(context.Background(), client, &model, "default"); diags.HasError() {
+		t.Fatalf("clientToModel returned errors: %v", diags)
+	}
+	if model.Blocked.ValueBool() != true {
+		t.Errorf("blocked: want true, got %v", model.Blocked.ValueBool())
+	}
+}
 
 func TestAccClientFramework_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{

--- a/unifi/provider.go
+++ b/unifi/provider.go
@@ -254,8 +254,12 @@ func (p *unifiProvider) Configure(
 	})
 	if err != nil {
 		resp.Diagnostics.AddError(
-			"Unable to Create HTTP Client",
-			"An unexpected error occurred when creating the HTTP client. "+
+			"Unable to Connect to UniFi Controller",
+			"Could not create the UniFi API client. With username/password auth the "+
+				"controller may have rate-limited the login (UniFi throttles "+
+				"POST /api/auth/login under rapid or back-to-back runs); using API-key "+
+				"authentication (the `api_key` argument or `UNIFI_API_KEY`) skips the "+
+				"per-run login entirely and avoids this. Underlying error: "+
 				err.Error(),
 		)
 		return


### PR DESCRIPTION
## Problem

On UniFi OS 5.x / Network App 10.x (e.g. UDM-Pro) the controller stores **no** value for `blocked`, `groups`, or `qos_rate` on a fixed-IP-only `unifi_client`. The provider's `Read` (`clientToModel`) stored those as **null**, and because the attributes are `Optional+Computed`, the next `tofu/terraform plan` proposes a spurious in-place update on every **create** *and* **import**:

```hcl
  ~ resource "unifi_client" "x" {
      + blocked  = false
      + groups   = (known after apply)
      + qos_rate = (known after apply)
    }
```

A single `apply` converges it, but `import` is never zero-diff — which breaks adopt-before-manage / GitOps drift detection. `lifecycle { ignore_changes = [...] }` does not suppress the import-time diff.

## Fix

- `clientToModel`: store the documented default (`blocked = false`) instead of null when the API omits it. (`blocked` already has `Default(false)` + `UseStateForUnknown`, so the null state was the sole cause of its diff.)
- Add `UseStateForUnknown` plan modifiers to `groups` (`listplanmodifier`) and `qos_rate` (`objectplanmodifier`, already used elsewhere in this provider) so a null prior value is not re-proposed as `(known after apply)`.

This makes both create and import zero-diff (import's first `Read` goes through the same `clientToModel`).

Also (second commit): rename the generic `Unable to Create HTTP Client` diagnostic to explain that the failure often means the controller rate-limited `POST /api/auth/login`, and that API-key auth (`api_key` / `UNIFI_API_KEY`) skips the per-run login entirely. This complements ubiquiti-community/go-unifi#18, which makes the SDK ride out that rate-limit.

## Tests

- New unit tests for `clientToModel` (no live controller needed): `blocked` defaults to `false`, `groups`/`qos_rate` stay null when the API omits them, and a blocked client still round-trips.
- Existing `TestAccClientFramework_basic` / `_groups` (which already include import steps) remain valid regression guards.
- `go build ./...`, `go vet ./unifi`, `gofmt`, and `go test ./...` (unit) are clean.

> Note: the acceptance suite uses the old `jacobalberty/unifi` image, which does not reproduce the UDM-Pro field omission, so the plan-modifier behavior was verified end-to-end against a live UDM-Pro (import → `plan` shows **No changes**); the unit tests guard the blocked default.

## Relationship to existing work

Complementary to the create-time reconciliation in #139 / #151 (this targets the root cause in `Read` + plan modifiers, and also fixes the **import** path). Refs #145 (same UniFi OS 5.x / Net-App 10.x client behavior).
