### PR TITLE
fix(test): bind-mount demo-mode init script for Podman compatibility

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -15,31 +15,17 @@ services:
       timeout: 10s
       retries: 3
       start_period: 90s
-    configs:
-      - source: unifi-init
-        target: /unifi/init.d/demo-mode
-        mode: 0757
-        uid: "1000"
-        gid: "1000"
+    # Bind-mount the init script instead of a compose `configs:` entry: the
+    # testcontainers compose-go runtime does not materialize inline config
+    # content under Podman, which left the controller out of simulation mode
+    # (no seeded admin account -> login 400). A bind mount is portable across
+    # Docker and Podman. The :Z suffix relabels for SELinux and is a no-op on
+    # hosts without it.
+    volumes:
+      - ./scripts/init.d/demo-mode:/unifi/init.d/demo-mode:Z
     ports:
       - 8443:8443
       - 3478:3478/udp
       - 10001:10001/udp
       - 8080:8080
     restart: unless-stopped
-
-configs:
-  unifi-init:
-    content: |
-      #!/bin/sh
-
-      write_config() {
-        echo "$${1}=$${2}" >> /usr/lib/unifi/data/system.properties
-      }
-
-      write_config is_simulation true
-
-      # Increase the number of demo devices to allow more concurrent tests to be executed simultaneously.
-      write_config demo.num_uap 3
-      write_config demo.num_ugw 1
-      write_config demo.num_usw 5

--- a/scripts/init.d/demo-mode
+++ b/scripts/init.d/demo-mode
@@ -7,6 +7,6 @@ write_config() {
 write_config is_simulation true
 
 # Increase the number of demo devices to allow more concurrent tests to be executed simultaneously.
-write_config demo.num_uap 0
+write_config demo.num_uap 3
 write_config demo.num_ugw 1
-write_config demo.num_usw 20
+write_config demo.num_usw 5


### PR DESCRIPTION
The compose `configs:` inline content was not materialized by the testcontainers compose-go runtime under Podman, so the controller started without is_simulation=true: no demo admin account was seeded and every acceptance run failed at login with api.err.Invalid (400).

Bind-mount the existing scripts/init.d/demo-mode file instead, which is portable across Docker and Podman, and drop the duplicated inline content. The script's demo device counts are kept identical to the previous inline values to preserve test behavior.