### PR TITLE
fix(firewall-rule): persist src_mac and fix attribute consistency

### DIFF
--- a/docs/resources/firewall_rule.md
+++ b/docs/resources/firewall_rule.md
@@ -49,7 +49,9 @@ resource "unifi_firewall_rule" "drop_all" {
 - `ip_sec` (String) Specify whether the rule matches on IPsec packets. Can be one of `match-ipset` or `match-none`.
 - `logging` (Boolean) Enable logging for the firewall rule.
 - `protocol` (String) The protocol of the rule.
+- `protocol_match_excepted` (Boolean) Match packets that do NOT match the specified protocol (protocol negation).
 - `protocol_v6` (String) The IPv6 protocol of the rule.
+- `setting_preference` (String) Whether the rule is managed automatically by the controller or manually. Can be one of `auto` or `manual`.
 - `site` (String) The name of the site to associate the firewall rule with.
 - `src_address` (String) The source address for the firewall rule.
 - `src_address_ipv6` (String) The IPv6 source address for the firewall rule.

--- a/unifi/firewall_rule_resource.go
+++ b/unifi/firewall_rule_resource.go
@@ -63,6 +63,8 @@ type firewallRuleResourceModel struct {
 	StateNew            types.Bool   `tfsdk:"state_new"`
 	StateRelated        types.Bool   `tfsdk:"state_related"`
 	IPSec               types.String `tfsdk:"ip_sec"`
+	SettingPreference   types.String `tfsdk:"setting_preference"`
+	ProtocolMatchExcept types.Bool   `tfsdk:"protocol_match_excepted"`
 }
 
 func (r *firewallRuleResource) Metadata(
@@ -224,22 +226,32 @@ func (r *firewallRuleResource) Schema(
 			"logging": schema.BoolAttribute{
 				MarkdownDescription: "Enable logging for the firewall rule.",
 				Optional:            true,
+				Computed:            true,
+				Default:             booldefault.StaticBool(false),
 			},
 			"state_established": schema.BoolAttribute{
 				MarkdownDescription: "Match where the state is established.",
 				Optional:            true,
+				Computed:            true,
+				Default:             booldefault.StaticBool(false),
 			},
 			"state_invalid": schema.BoolAttribute{
 				MarkdownDescription: "Match where the state is invalid.",
 				Optional:            true,
+				Computed:            true,
+				Default:             booldefault.StaticBool(false),
 			},
 			"state_new": schema.BoolAttribute{
 				MarkdownDescription: "Match where the state is new.",
 				Optional:            true,
+				Computed:            true,
+				Default:             booldefault.StaticBool(false),
 			},
 			"state_related": schema.BoolAttribute{
 				MarkdownDescription: "Match where the state is related.",
 				Optional:            true,
+				Computed:            true,
+				Default:             booldefault.StaticBool(false),
 			},
 			"ip_sec": schema.StringAttribute{
 				MarkdownDescription: "Specify whether the rule matches on IPsec packets. Can be one of `match-ipset` or `match-none`.",
@@ -247,6 +259,20 @@ func (r *firewallRuleResource) Schema(
 				Validators: []validator.String{
 					stringvalidator.OneOf("match-ipsec", "match-none"),
 				},
+			},
+			"setting_preference": schema.StringAttribute{
+				MarkdownDescription: "Whether the rule is managed automatically by the controller or manually. Can be one of `auto` or `manual`.",
+				Optional:            true,
+				Computed:            true,
+				Validators: []validator.String{
+					stringvalidator.OneOf("auto", "manual"),
+				},
+			},
+			"protocol_match_excepted": schema.BoolAttribute{
+				MarkdownDescription: "Match packets that do NOT match the specified protocol (protocol negation).",
+				Optional:            true,
+				Computed:            true,
+				Default:             booldefault.StaticBool(false),
 			},
 		},
 	}
@@ -532,6 +558,12 @@ func (r *firewallRuleResource) applyPlanToState(
 	if !plan.IPSec.IsNull() && !plan.IPSec.IsUnknown() {
 		state.IPSec = plan.IPSec
 	}
+	if !plan.SettingPreference.IsNull() && !plan.SettingPreference.IsUnknown() {
+		state.SettingPreference = plan.SettingPreference
+	}
+	if !plan.ProtocolMatchExcept.IsNull() && !plan.ProtocolMatchExcept.IsUnknown() {
+		state.ProtocolMatchExcept = plan.ProtocolMatchExcept
+	}
 }
 
 func (r *firewallRuleResource) modelToFirewallRule(
@@ -579,6 +611,9 @@ func (r *firewallRuleResource) modelToFirewallRule(
 	if !model.SrcPort.IsNull() {
 		firewallRule.SrcPort = model.SrcPort.ValueString()
 	}
+	if !model.SrcMac.IsNull() {
+		firewallRule.SrcMACAddress = model.SrcMac.ValueString()
+	}
 
 	if !model.DstNetworkID.IsNull() {
 		firewallRule.DstNetworkID = model.DstNetworkID.ValueString()
@@ -619,6 +654,10 @@ func (r *firewallRuleResource) modelToFirewallRule(
 	if !model.IPSec.IsNull() {
 		firewallRule.IPSec = model.IPSec.ValueString()
 	}
+	if !model.SettingPreference.IsNull() {
+		firewallRule.SettingPreference = model.SettingPreference.ValueString()
+	}
+	firewallRule.ProtocolMatchExcepted = model.ProtocolMatchExcept.ValueBool()
 
 	return firewallRule
 }
@@ -698,7 +737,11 @@ func (r *firewallRuleResource) firewallRuleToModel(
 		model.SrcPort = types.StringNull()
 	}
 
-	model.SrcMac = types.StringNull()
+	if firewallRule.SrcMACAddress != "" {
+		model.SrcMac = types.StringValue(firewallRule.SrcMACAddress)
+	} else {
+		model.SrcMac = types.StringNull()
+	}
 
 	if firewallRule.DstNetworkID != "" {
 		model.DstNetworkID = types.StringValue(firewallRule.DstNetworkID)
@@ -748,4 +791,12 @@ func (r *firewallRuleResource) firewallRuleToModel(
 	} else {
 		model.IPSec = types.StringNull()
 	}
+
+	if firewallRule.SettingPreference != "" {
+		model.SettingPreference = types.StringValue(firewallRule.SettingPreference)
+	} else {
+		model.SettingPreference = types.StringNull()
+	}
+
+	model.ProtocolMatchExcept = types.BoolValue(firewallRule.ProtocolMatchExcepted)
 }

--- a/unifi/firewall_rule_resource_test.go
+++ b/unifi/firewall_rule_resource_test.go
@@ -381,6 +381,51 @@ func TestAccFirewallRule_guestRuleset(t *testing.T) {
 	})
 }
 
+func TestAccFirewallRule_withSrcMac(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { preCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFirewallRuleConfig_withSrcMac(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("unifi_firewall_rule.test", "id"),
+					resource.TestCheckResourceAttr(
+						"unifi_firewall_rule.test",
+						"src_mac",
+						"00:11:22:33:44:55",
+					),
+					resource.TestCheckResourceAttr(
+						"unifi_firewall_rule.test",
+						"protocol_match_excepted",
+						"true",
+					),
+				),
+			},
+			{
+				ResourceName:      "unifi_firewall_rule.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccFirewallRuleConfig_withSrcMac() string {
+	return `
+resource "unifi_firewall_rule" "test" {
+  name       = "tfacc-firewall-rule-src-mac"
+  action     = "drop"
+  ruleset    = "LAN_IN"
+  rule_index = 2020
+
+  protocol                = "tcp"
+  protocol_match_excepted = true
+  src_mac                 = "00:11:22:33:44:55"
+}
+`
+}
+
 func testAccFirewallRuleConfig_basic() string {
 	return `
 resource "unifi_firewall_rule" "test" {


### PR DESCRIPTION
## Context
`src_mac` was written to plan/state but never sent to the controller (missing in `modelToFirewallRule`) and was always forced to null on refresh, causing permanent drift and broken imports for rules matching a source MAC. Separately, `logging` and the `state_*` match flags were Optional-only yet always set from the API on read, producing "inconsistent result after apply" when omitted from config.

## Changes
- Map `src_mac` to `FirewallRule.SrcMACAddress` in both directions.
- Make `logging`/`state_established`/`state_invalid`/`state_new`/`state_related` Optional+Computed with a false default.
- Expose `setting_preference` (auto|manual) and `protocol_match_excepted`, already supported by go-unifi.
- Regenerate docs.

## Tests
14 acceptance tests pass (containerized controller), including a new `src_mac`/`protocol_match_excepted` round-trip with import verification.

## Risks
Low. Defaults preserve existing behavior.