### PR TITLE
feat(radius-user): expose vlan and tunnel_config_type

### DIFF
--- a/docs/resources/radius_user.md
+++ b/docs/resources/radius_user.md
@@ -34,8 +34,10 @@ NOTE: MAC-based authentication accounts can only be used for wireless and wired 
 
 - `network_id` (String) ID of the network for this account
 - `site` (String) The name of the site to associate the account with.
+- `tunnel_config_type` (String) The tunnel configuration type. Can be `vpn`, `802.1x`, or `custom`.
 - `tunnel_medium_type` (Number) See [RFC 2868](https://www.rfc-editor.org/rfc/rfc2868) section 3.2
 - `tunnel_type` (Number) See [RFC 2868](https://www.rfc-editor.org/rfc/rfc2868) section 3.1
+- `vlan` (Number) VLAN assigned to the account. If unset, the client falls back to the untagged VLAN.
 
 ### Read-Only
 

--- a/unifi/radius_user_resource.go
+++ b/unifi/radius_user_resource.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -41,6 +42,8 @@ type radiusUserResourceModel struct {
 	TunnelType       types.Int64  `tfsdk:"tunnel_type"`
 	TunnelMediumType types.Int64  `tfsdk:"tunnel_medium_type"`
 	NetworkID        types.String `tfsdk:"network_id"`
+	VLAN             types.Int64  `tfsdk:"vlan"`
+	TunnelConfigType types.String `tfsdk:"tunnel_config_type"`
 }
 
 func (r *radiusUserResource) Metadata(
@@ -113,6 +116,20 @@ NOTE: MAC-based authentication accounts can only be used for wireless and wired 
 			"network_id": schema.StringAttribute{
 				MarkdownDescription: "ID of the network for this account",
 				Optional:            true,
+			},
+			"vlan": schema.Int64Attribute{
+				MarkdownDescription: "VLAN assigned to the account. If unset, the client falls back to the untagged VLAN.",
+				Optional:            true,
+				Validators: []validator.Int64{
+					int64validator.Between(2, 4009),
+				},
+			},
+			"tunnel_config_type": schema.StringAttribute{
+				MarkdownDescription: "The tunnel configuration type. Can be `vpn`, `802.1x`, or `custom`.",
+				Optional:            true,
+				Validators: []validator.String{
+					stringvalidator.OneOf("vpn", "802.1x", "custom"),
+				},
 			},
 		},
 	}
@@ -349,6 +366,12 @@ func (r *radiusUserResource) applyPlanToState(
 	if !plan.NetworkID.IsNull() && !plan.NetworkID.IsUnknown() {
 		state.NetworkID = plan.NetworkID
 	}
+	if !plan.VLAN.IsNull() && !plan.VLAN.IsUnknown() {
+		state.VLAN = plan.VLAN
+	}
+	if !plan.TunnelConfigType.IsNull() && !plan.TunnelConfigType.IsUnknown() {
+		state.TunnelConfigType = plan.TunnelConfigType
+	}
 }
 
 // modelToRadiusUser converts the Terraform model to the API struct.
@@ -367,6 +390,12 @@ func (r *radiusUserResource) modelToRadiusUser(
 
 	if !model.NetworkID.IsNull() {
 		account.NetworkID = model.NetworkID.ValueString()
+	}
+	if !model.VLAN.IsNull() {
+		account.VLAN = model.VLAN.ValueInt64Pointer()
+	}
+	if !model.TunnelConfigType.IsNull() {
+		account.TunnelConfigType = model.TunnelConfigType.ValueString()
 	}
 
 	return account
@@ -390,5 +419,13 @@ func (r *radiusUserResource) radiusUserToModel(
 		model.NetworkID = types.StringValue(account.NetworkID)
 	} else {
 		model.NetworkID = types.StringNull()
+	}
+
+	model.VLAN = types.Int64PointerValue(account.VLAN)
+
+	if account.TunnelConfigType != "" {
+		model.TunnelConfigType = types.StringValue(account.TunnelConfigType)
+	} else {
+		model.TunnelConfigType = types.StringNull()
 	}
 }

--- a/unifi/radius_user_resource_test.go
+++ b/unifi/radius_user_resource_test.go
@@ -51,3 +51,40 @@ resource "unifi_radius_user" "test" {
 }
 `
 }
+
+func TestAccRadiusUser_vlan(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { preCheck(t) },
+		ProtoV6ProviderFactories: providerFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRadiusUserConfig_vlan(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("unifi_radius_user.vlan", "vlan", "100"),
+					resource.TestCheckResourceAttr(
+						"unifi_radius_user.vlan",
+						"tunnel_config_type",
+						"802.1x",
+					),
+				),
+			},
+			{
+				ResourceName:            "unifi_radius_user.vlan",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"password"},
+			},
+		},
+	})
+}
+
+func testAccRadiusUserConfig_vlan() string {
+	return `
+resource "unifi_radius_user" "vlan" {
+	name               = "test-account-vlan"
+	password           = "test-password"
+	vlan               = 100
+	tunnel_config_type = "802.1x"
+}
+`
+}


### PR DESCRIPTION
## Context
The `unifi_radius_user` resource did not expose the VLAN assignment, even though the resource docs already mention VLAN fallback behavior. Dynamic VLAN assignment is a common RADIUS use case.

## Changes
- `vlan` (number) — VLAN assigned to the account (RFC 3580 dynamic VLAN).
- `tunnel_config_type` (string, `vpn`|`802.1x`|`custom`).
- Regenerate docs.

## Tests
Acceptance suite passes, including a new test setting `vlan` and `tunnel_config_type` with import verification.

## Risks
Low. Both attributes are Optional and omitted when unset.