### PR TITLE
fix(port-forward): accept "any" for wan.ip_address and destination_ip

### DIFF
--- a/docs/resources/account.md
+++ b/docs/resources/account.md
@@ -34,8 +34,10 @@ NOTE: MAC-based authentication accounts can only be used for wireless and wired 
 
 - `network_id` (String) ID of the network for this account
 - `site` (String) The name of the site to associate the account with.
+- `tunnel_config_type` (String) The tunnel configuration type. Can be `vpn`, `802.1x`, or `custom`.
 - `tunnel_medium_type` (Number) See [RFC 2868](https://www.rfc-editor.org/rfc/rfc2868) section 3.2
 - `tunnel_type` (Number) See [RFC 2868](https://www.rfc-editor.org/rfc/rfc2868) section 3.1
+- `vlan` (Number) VLAN assigned to the account. If unset, the client falls back to the untagged VLAN.
 
 ### Read-Only
 

--- a/unifi/port_forward_resource.go
+++ b/unifi/port_forward_resource.go
@@ -159,7 +159,7 @@ func (r *portForwardResource) Schema(
 						MarkdownDescription: "The WAN IP address for the port forwarding rule. Use `any` for all addresses.",
 						Optional:            true,
 						Validators: []validator.String{
-							validators.IPv4Validator(),
+							validators.IPv4OrAnyValidator(),
 						},
 					},
 					"port": schema.StringAttribute{
@@ -224,7 +224,7 @@ func (r *portForwardResource) Schema(
 							MarkdownDescription: "The destination IPv4 address. Use `any` for all addresses.",
 							Optional:            true,
 							Validators: []validator.String{
-								validators.IPv4Validator(),
+								validators.IPv4OrAnyValidator(),
 							},
 						},
 						"interface": schema.StringAttribute{

--- a/unifi/port_forward_resource_test.go
+++ b/unifi/port_forward_resource_test.go
@@ -381,6 +381,55 @@ resource "unifi_port_forward" "test_dst" {
 `
 }
 
+// TestAccPortForward_anyIP verifies that `any` is accepted for wan.ip_address
+// (the UniFi API returns "any" verbatim for rules with no destination IP
+// filter, so the provider must accept it instead of rejecting it as a
+// non-IPv4 value).
+func TestAccPortForward_anyIP(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { preCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPortForwardConfig_anyIP(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("unifi_port_forward.any", "id"),
+					resource.TestCheckResourceAttr(
+						"unifi_port_forward.any",
+						"wan.ip_address",
+						"any",
+					),
+				),
+			},
+			{
+				ResourceName:            "unifi_port_forward.any",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"enabled"},
+			},
+		},
+	})
+}
+
+func testAccPortForwardConfig_anyIP() string {
+	return `
+resource "unifi_port_forward" "any" {
+  name     = "tfacc-any-ip"
+  protocol = "tcp"
+
+  wan = {
+    ip_address = "any"
+    port       = "8081"
+  }
+
+  forward = {
+    ip   = "192.168.1.30"
+    port = "8081"
+  }
+}
+`
+}
+
 func testAccPortForwardConfig_basic() string {
 	return `
 resource "unifi_port_forward" "test" {

--- a/unifi/validators/ipv4.go
+++ b/unifi/validators/ipv4.go
@@ -13,14 +13,27 @@ func IPv4Validator() validator.String {
 	return &ipv4Validator{}
 }
 
-type ipv4Validator struct{}
+// IPv4OrAnyValidator validates that a string is either a valid IPv4 address or
+// the literal "any". The UniFi controller uses "any" to represent "no specific
+// IP filter" (e.g. a port forward applying to all WAN addresses), and returns
+// it verbatim from the API, so it must be accepted as a valid value.
+func IPv4OrAnyValidator() validator.String {
+	return &ipv4Validator{allowAny: true}
+}
+
+type ipv4Validator struct {
+	allowAny bool
+}
 
 func (v ipv4Validator) Description(ctx context.Context) string {
+	if v.allowAny {
+		return `value must be a valid IPv4 address or "any"`
+	}
 	return "value must be a valid IPv4 address"
 }
 
 func (v ipv4Validator) MarkdownDescription(ctx context.Context) string {
-	return "value must be a valid IPv4 address"
+	return v.Description(ctx)
 }
 
 func (v ipv4Validator) ValidateString(
@@ -33,12 +46,20 @@ func (v ipv4Validator) ValidateString(
 	}
 
 	value := req.ConfigValue.ValueString()
+	if v.allowAny && value == "any" {
+		return
+	}
+
 	ip := net.ParseIP(value)
 	if ip == nil || ip.To4() == nil {
+		detail := fmt.Sprintf("Value %q is not a valid IPv4 address.", value)
+		if v.allowAny {
+			detail = fmt.Sprintf("Value %q is not a valid IPv4 address or \"any\".", value)
+		}
 		resp.Diagnostics.AddAttributeError(
 			req.Path,
 			"Invalid IPv4 Address",
-			fmt.Sprintf("Value %q is not a valid IPv4 address.", value),
+			detail,
 		)
 	}
 }

--- a/unifi/validators/ipv4_test.go
+++ b/unifi/validators/ipv4_test.go
@@ -1,0 +1,74 @@
+package validators
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func runIPv4Validator(v validator.String, value types.String) bool {
+	resp := &validator.StringResponse{}
+	v.ValidateString(context.Background(), validator.StringRequest{
+		Path:        path.Root("test"),
+		ConfigValue: value,
+	}, resp)
+	return !resp.Diagnostics.HasError()
+}
+
+func TestIPv4Validator(t *testing.T) {
+	v := IPv4Validator()
+
+	cases := []struct {
+		name  string
+		value types.String
+		valid bool
+	}{
+		{"valid IPv4", types.StringValue("192.168.1.1"), true},
+		{"any rejected", types.StringValue("any"), false},
+		{"IPv6 rejected", types.StringValue("fe80::1"), false},
+		{"garbage", types.StringValue("not-an-ip"), false},
+		{"empty", types.StringValue(""), false},
+		{"null skips", types.StringNull(), true},
+		{"unknown skips", types.StringUnknown(), true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := runIPv4Validator(v, tc.value)
+			if got != tc.valid {
+				t.Fatalf("got valid=%v, want %v for %q", got, tc.valid, tc.value.ValueString())
+			}
+		})
+	}
+}
+
+func TestIPv4OrAnyValidator(t *testing.T) {
+	v := IPv4OrAnyValidator()
+
+	cases := []struct {
+		name  string
+		value types.String
+		valid bool
+	}{
+		{"valid IPv4", types.StringValue("203.0.113.4"), true},
+		{"any accepted", types.StringValue("any"), true},
+		// controller stores/returns lowercase "any"; uppercase must be rejected
+		{"uppercase ANY rejected", types.StringValue("ANY"), false},
+		{"IPv6 rejected", types.StringValue("fe80::1"), false},
+		{"garbage", types.StringValue("not-an-ip"), false},
+		{"null skips", types.StringNull(), true},
+		{"unknown skips", types.StringUnknown(), true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := runIPv4Validator(v, tc.value)
+			if got != tc.valid {
+				t.Fatalf("got valid=%v, want %v for %q", got, tc.valid, tc.value.ValueString())
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

The UniFi controller uses the literal `"any"` to represent a port forward with **no specific destination IP filter**, and returns it verbatim from the API. The `wan.ip_address` and `destination_ips.destination_ip` attributes were validated with `IPv4Validator()`, which calls `net.ParseIP()` and rejects `"any"` at plan time — even though both attributes document *"Use `any` for all addresses"*. This caused `plan`/`apply` to fail for any rule with no destination IP filter.

## Change

- Add `IPv4OrAnyValidator()` accepting a valid IPv4 address **or** the literal `"any"`.
- Use it for `wan.ip_address` and `destination_ips.destination_ip`. `forward.ip` keeps the strict IPv4 validator (must point to a real host).
- Unit tests covering both validators.

Fixes #162.

## Testing

- [ ] CI (build / vet / gofmt)
- Added `unifi/validators/ipv4_test.go` (`go test ./unifi/validators/`)