### PR TITLE
fix(radius-user): allow tunnel_type 13 (VLAN)

### DIFF
--- a/docs/resources/account.md
+++ b/docs/resources/account.md
@@ -36,7 +36,7 @@ NOTE: MAC-based authentication accounts can only be used for wireless and wired 
 - `site` (String) The name of the site to associate the account with.
 - `tunnel_config_type` (String) The tunnel configuration type. Can be `vpn`, `802.1x`, or `custom`.
 - `tunnel_medium_type` (Number) See [RFC 2868](https://www.rfc-editor.org/rfc/rfc2868) section 3.2
-- `tunnel_type` (Number) See [RFC 2868](https://www.rfc-editor.org/rfc/rfc2868) section 3.1
+- `tunnel_type` (Number) See [RFC 2868](https://www.rfc-editor.org/rfc/rfc2868) section 3.1. Valid values are 1-13; `13` (VLAN) is the most common.
 - `vlan` (Number) VLAN assigned to the account. If unset, the client falls back to the untagged VLAN.
 
 ### Read-Only

--- a/docs/resources/radius_user.md
+++ b/docs/resources/radius_user.md
@@ -36,7 +36,7 @@ NOTE: MAC-based authentication accounts can only be used for wireless and wired 
 - `site` (String) The name of the site to associate the account with.
 - `tunnel_config_type` (String) The tunnel configuration type. Can be `vpn`, `802.1x`, or `custom`.
 - `tunnel_medium_type` (Number) See [RFC 2868](https://www.rfc-editor.org/rfc/rfc2868) section 3.2
-- `tunnel_type` (Number) See [RFC 2868](https://www.rfc-editor.org/rfc/rfc2868) section 3.1
+- `tunnel_type` (Number) See [RFC 2868](https://www.rfc-editor.org/rfc/rfc2868) section 3.1. Valid values are 1-13; `13` (VLAN) is the most common.
 - `vlan` (Number) VLAN assigned to the account. If unset, the client falls back to the untagged VLAN.
 
 ### Read-Only

--- a/unifi/radius_user_resource.go
+++ b/unifi/radius_user_resource.go
@@ -96,12 +96,13 @@ NOTE: MAC-based authentication accounts can only be used for wireless and wired 
 				Sensitive:           true,
 			},
 			"tunnel_type": schema.Int64Attribute{
-				MarkdownDescription: "See [RFC 2868](https://www.rfc-editor.org/rfc/rfc2868) section 3.1",
-				Optional:            true,
-				Computed:            true,
-				Default:             int64default.StaticInt64(3),
+				MarkdownDescription: "See [RFC 2868](https://www.rfc-editor.org/rfc/rfc2868) section 3.1. " +
+					"Valid values are 1-13; `13` (VLAN) is the most common.",
+				Optional: true,
+				Computed: true,
+				Default:  int64default.StaticInt64(3),
 				Validators: []validator.Int64{
-					int64validator.Between(1, 12),
+					int64validator.Between(1, 13),
 				},
 			},
 			"tunnel_medium_type": schema.Int64Attribute{

--- a/unifi/radius_user_resource_test.go
+++ b/unifi/radius_user_resource_test.go
@@ -88,3 +88,36 @@ resource "unifi_radius_user" "vlan" {
 }
 `
 }
+
+// TestAccRadiusUser_tunnelType13 verifies that tunnel_type accepts 13 (VLAN),
+// which the controller allows (1-13) but the provider previously capped at 12.
+func TestAccRadiusUser_tunnelType13(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { preCheck(t) },
+		ProtoV6ProviderFactories: providerFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRadiusUserConfig_tunnelType13(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("unifi_radius_user.tt13", "tunnel_type", "13"),
+				),
+			},
+			{
+				ResourceName:            "unifi_radius_user.tt13",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"password"},
+			},
+		},
+	})
+}
+
+func testAccRadiusUserConfig_tunnelType13() string {
+	return `
+resource "unifi_radius_user" "tt13" {
+	name        = "test-account-tt13"
+	password    = "test-password"
+	tunnel_type = 13
+}
+`
+}


### PR DESCRIPTION
## Problem
Closes #133.

The controller accepts `tunnel_type` values **1-13** (RFC 2868; `13` = VLAN, one of the most commonly used values), but the provider's validator was capped at `1-12`. Since v0.41.25 this made `tunnel_type = 13` fail at plan time with an `Invalid Attribute Value` error, even though it was valid on earlier versions and is accepted by the controller. The go-unifi model documents the constraint as `[1-9]|1[0-3]` (i.e. 1-13).

## Fix
- Widen the `tunnel_type` validator to `Between(1, 13)`.
- This also fixes the deprecated `unifi_account` resource, which reuses this schema.

## Tests
Live acceptance test creating an account with `tunnel_type = 13` (applies and imports cleanly). Verified against a real controller. Build/lint/generate clean.