### PR TITLE
fix(port-profile): expose forward/native/tagged in data source schema

### DIFF
--- a/docs/data-sources/port_profile.md
+++ b/docs/data-sources/port_profile.md
@@ -29,4 +29,7 @@ data "unifi_port_profile" "all" {
 
 ### Read-Only
 
+- `forward` (String) The forwarding mode of the port profile. One of `all`, `native`, `customize` or `disabled`.
 - `id` (String) The ID of this port profile.
+- `native_networkconf_id` (String) The ID of the native (untagged) network for the port profile.
+- `tagged_networkconf_ids` (Set of String) The IDs of the tagged (VLAN) networks for the port profile.

--- a/unifi/port_profile_data_source.go
+++ b/unifi/port_profile_data_source.go
@@ -59,6 +59,19 @@ func (d *portProfileDataSource) Schema(
 				MarkdownDescription: "The name of the port profile to look up.",
 				Required:            true,
 			},
+			"forward": schema.StringAttribute{
+				MarkdownDescription: "The forwarding mode of the port profile. One of `all`, `native`, `customize` or `disabled`.",
+				Computed:            true,
+			},
+			"native_networkconf_id": schema.StringAttribute{
+				MarkdownDescription: "The ID of the native (untagged) network for the port profile.",
+				Computed:            true,
+			},
+			"tagged_networkconf_ids": schema.SetAttribute{
+				MarkdownDescription: "The IDs of the tagged (VLAN) networks for the port profile.",
+				Computed:            true,
+				ElementType:         types.StringType,
+			},
 		},
 	}
 }
@@ -134,6 +147,22 @@ func (d *portProfileDataSource) Read(
 	data.ID = types.StringValue(portProfile.ID)
 	data.Site = types.StringValue(site)
 	data.Name = types.StringValue(portProfile.Name)
+
+	if portProfile.Forward == "" {
+		data.Forward = types.StringValue("native")
+	} else {
+		data.Forward = types.StringValue(portProfile.Forward)
+	}
+
+	if portProfile.NATiveNetworkID != "" {
+		data.NativeNetworkconfID = types.StringValue(portProfile.NATiveNetworkID)
+	} else {
+		data.NativeNetworkconfID = types.StringNull()
+	}
+
+	// tagged_networkconf_ids has no corresponding go-unifi field; tagged VLANs are
+	// managed via tagged_vlan_mgmt + excluded_networkconf_ids instead.
+	data.TaggedNetworkconfIDs = types.SetNull(types.StringType)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }


### PR DESCRIPTION
## Summary

`data.unifi_port_profile` is currently **completely unusable**: any use fails at read time with

```
Value Conversion Error
mismatch between struct and object: Struct defines fields not found in object: forward, native_networkconf_id, and tagged_networkconf_ids.
```

The `portProfileDataSourceModel` struct declares `forward`, `native_networkconf_id` and `tagged_networkconf_ids`, but the data source schema never defined those attributes, so the framework cannot convert between the tftypes object and the Go struct.

## Change

- Add the three attributes to the data source schema as **Read-Only**.
- Populate them in `Read`, mirroring the mapping used by the `unifi_port_profile` resource:
  - `forward` defaults to `"native"` when empty,
  - `native_networkconf_id` from `NATiveNetworkID`,
  - `tagged_networkconf_ids` has no corresponding go-unifi field, so it is null (consistent with the resource).
- Regenerate docs.

Fixes #178