### PR TITLE
fix(dns-record): make record_type required

### DIFF
--- a/docs/resources/dns_record.md
+++ b/docs/resources/dns_record.md
@@ -28,6 +28,7 @@ resource "unifi_dns_record" "test" {
 ### Required
 
 - `name` (String) The key of the DNS record.
+- `record_type` (String) The type of the DNS record. One of `A`, `AAAA`, `CNAME`, `MX`, `TXT`, `SRV` or `PTR`.
 - `value` (String) The value of the DNS record.
 
 ### Optional
@@ -35,7 +36,6 @@ resource "unifi_dns_record" "test" {
 - `enabled` (Boolean) Whether the DNS record is enabled.
 - `port` (Number) The port of the DNS record.
 - `priority` (Number) The priority of the DNS record.
-- `record_type` (String) The type of the DNS record.
 - `site` (String) The name of the site to associate the DNS record with.
 - `ttl` (Number) The TTL of the DNS record.
 - `weight` (Number) The weight of the DNS record.

--- a/unifi/dns_record_resource.go
+++ b/unifi/dns_record_resource.go
@@ -108,8 +108,8 @@ func (r *dnsRecordFrameworkResource) Schema(
 				},
 			},
 			"record_type": schema.StringAttribute{
-				MarkdownDescription: "The type of the DNS record.",
-				Optional:            true,
+				MarkdownDescription: "The type of the DNS record. One of `A`, `AAAA`, `CNAME`, `MX`, `TXT`, `SRV` or `PTR`.",
+				Required:            true,
 				Validators: []validator.String{
 					stringvalidator.OneOf("A", "AAAA", "CNAME", "MX", "TXT", "SRV", "PTR"),
 				},


### PR DESCRIPTION
## Summary

When `record_type` was omitted from a `unifi_dns_record`, the UniFi controller rejected the request with an opaque **500** error, because the record type is mandatory server-side. The attribute was declared `Optional`, so the provider accepted such configs and surfaced the 500 instead of a clear validation error (see #136).

## Change

Mark `record_type` as **Required** so Terraform validates its presence at plan time and enforces the allowed values (`A`, `AAAA`, `CNAME`, `MX`, `TXT`, `SRV`, `PTR`) up front. Docs regenerated.

> ⚠️ **Breaking change:** configurations that previously omitted `record_type` must now set it explicitly.

Fixes #137