### PR TITLE
fix(network): make subnet optional (not required for vlan_only)

### DIFF
--- a/docs/resources/network.md
+++ b/docs/resources/network.md
@@ -44,7 +44,6 @@ resource "unifi_network" "third_party" {
 ### Required
 
 - `name` (String) The name of the network.
-- `subnet` (String) The IP subnet of the network in CIDR notation.
 
 ### Optional
 
@@ -66,6 +65,7 @@ resource "unifi_network" "third_party" {
 - `network_isolation` (Boolean) Specifies whether network isolation is enabled.
 - `setting_preference` (String) Setting preference. Must be one of `auto` or `manual`.
 - `site` (String) The name of the site to associate the network with.
+- `subnet` (String) The IPv4 subnet of the network in CIDR notation. Optional: it is not required for `vlan_only` networks (`third_party_gateway = true`), where the UniFi controller does not manage the subnet.
 - `third_party_gateway` (Boolean) Specifies whether this network uses a third-party gateway. When enabled, the network purpose is set to `vlan-only` and only VLAN ID, DHCP guarding, and basic network settings are configured.
 - `vlan` (Number) The VLAN ID for the network.
 

--- a/unifi/network_resource.go
+++ b/unifi/network_resource.go
@@ -305,9 +305,11 @@ func (r *networkResource) Schema(
 				Default:             booldefault.StaticBool(true),
 			},
 			"subnet": schema.StringAttribute{
-				MarkdownDescription: "The IP subnet of the network in CIDR notation.",
-				Required:            true,
-				CustomType:          cidrtypes.IPv4PrefixType{},
+				MarkdownDescription: "The IPv4 subnet of the network in CIDR notation. Optional: it is " +
+					"not required for `vlan_only` networks (`third_party_gateway = true`), where the " +
+					"UniFi controller does not manage the subnet.",
+				Optional:   true,
+				CustomType: cidrtypes.IPv4PrefixType{},
 			},
 			"domain_name": schema.StringAttribute{
 				MarkdownDescription: "The domain name for the network.",
@@ -1213,8 +1215,11 @@ func (r *networkResource) networkToModel(
 		model.DomainName = types.StringPointerValue(network.DomainName)
 	}
 
-	// Determine if this is an import (name/ID is set but required field Subnet is null)
-	isImport := previousModel != nil && previousModel.Subnet.IsNull()
+	// Determine if this is an import. On import only the ID/identity is seeded into
+	// state, so the computed network_isolation field is still null; in every other
+	// flow (create/read/update) networkToModel always assigns it above. We can no
+	// longer use Subnet for this since it is now optional (e.g. vlan_only networks).
+	isImport := previousModel != nil && previousModel.NetworkIsolation.IsNull()
 
 	// Build dhcp_guarding from API fields
 	shouldPopulateDhcpGuarding := false


### PR DESCRIPTION
## Summary

`subnet` was `Required`, forcing a CIDR even when the UniFi controller does not manage the subnet. As reported in #124 this is wrong for at least `vlan_only` networks (`third_party_gateway = true`), where the IP range is irrelevant.

## Change

- Make `subnet` **Optional**. A null subnet was already handled at build time (`model.Subnet.ValueStringPointer()` yields `nil`), so nothing is sent to the API when omitted.
- **Harden import detection.** The `isImport` heuristic previously relied on `subnet` being null only during import — only valid while `subnet` was Required. It now keys off the computed `network_isolation` field, which `networkToModel` always assigns unconditionally (before the vlan_only branch) and which is therefore null only right after `ImportState` seeds the ID. As a side effect this also fixes a latent bug where **vlan_only imports kept being treated as imports on every subsequent read** (their subnet stayed null), which could cause spurious `dhcp_*` drift.
- Docs regenerated (`subnet` moved Required → Optional).

## Scope / follow-up

This addresses the **vlan_only** case (the concrete, reproducible complaint). The issue also mentions **IPv6-only** networks: that remains a separate follow-up because `subnet` is still typed as an IPv4 CIDR (`cidrtypes.IPv4PrefixType`), and supporting IPv6 means retyping the model field and its ~5 use sites.

## Testing

- [ ] CI (build / vet / lint / generate-diff)
- ⚠️ Worth validating with the network acceptance tests on a controller, in particular **import of a corporate network** and **create/read of a vlan_only network without `subnet`**, since this touches the shared import-detection path used by `dhcp_guarding` / `dhcp_server` / `dhcp_relay`.

Fixes #124