### PR TITLE
fix(port-forward): stop source_limiting drift on omitted block

### DIFF
--- a/unifi/port_forward_resource.go
+++ b/unifi/port_forward_resource.go
@@ -476,7 +476,10 @@ func (r *portForwardResource) applyPlanToState(
 	if !plan.Forward.IsNull() && !plan.Forward.IsUnknown() {
 		state.Forward = plan.Forward
 	}
-	if !plan.SourceLimiting.IsNull() && !plan.SourceLimiting.IsUnknown() {
+	// Track the plan exactly, including a null (omitted block): leaving a stale
+	// non-null state here would re-send and re-flatten source limiting, producing
+	// an "inconsistent result after apply" when the block was removed/omitted.
+	if !plan.SourceLimiting.IsUnknown() {
 		state.SourceLimiting = plan.SourceLimiting
 	}
 	if !plan.DestinationIPs.IsNull() && !plan.DestinationIPs.IsUnknown() {
@@ -649,25 +652,23 @@ func (r *portForwardResource) portForwardToModel(
 		model.Forward = types.ObjectNull(portForwardForwardModel{}.AttributeTypes())
 	}
 
-	// Source limiting nested object
-	if portForward.Src != "" || portForward.SrcLimitingEnabled ||
+	// Source limiting nested object.
+	//
+	// The controller returns Src="any" with limiting disabled even when no source
+	// limiting is configured, so that default alone must not produce a non-null
+	// object — otherwise an omitted source_limiting block plans as null but apply
+	// yields a non-null object ("Provider produced inconsistent result after
+	// apply"). Populate only when source limiting is genuinely configured on the
+	// controller, or when the prior plan/state already carried the block.
+	srcConfigured := portForward.SrcLimitingEnabled ||
 		portForward.SrcFirewallGroupID != "" ||
-		portForward.SrcLimitingType != "" {
+		(portForward.Src != "" && portForward.Src != "any")
+	if srcConfigured || !model.SourceLimiting.IsNull() {
 		srcValue := portForwardSourceLimitingModel{
 			IP:              stringValueOrNull(portForward.Src),
 			FirewallGroupID: stringValueOrNull(portForward.SrcFirewallGroupID),
 			Enabled:         types.BoolValue(portForward.SrcLimitingEnabled),
 			Type:            stringValueOrNull(portForward.SrcLimitingType),
-		}
-		srcObj, d := types.ObjectValueFrom(ctx, srcValue.AttributeTypes(), srcValue)
-		diags.Append(d...)
-		model.SourceLimiting = srcObj
-	} else if !model.SourceLimiting.IsNull() {
-		srcValue := portForwardSourceLimitingModel{
-			IP:              types.StringNull(),
-			FirewallGroupID: types.StringNull(),
-			Enabled:         types.BoolValue(false),
-			Type:            types.StringNull(),
 		}
 		srcObj, d := types.ObjectValueFrom(ctx, srcValue.AttributeTypes(), srcValue)
 		diags.Append(d...)


### PR DESCRIPTION
## Summary

Importing a pre-existing `unifi_port_forward` that has no source limiting produced a perpetual diff (`source_limiting = {...} -> null`) that then failed on apply with:

```
Provider produced inconsistent result after apply
... .source_limiting: was null, but now cty.ObjectVal(... "enabled":false, "ip":"any", "type":"ip" ...)
```

### Root cause

The controller always returns `Src="any"` with limiting disabled, even when no source limiting is configured. The flatten logic treated any non-empty `Src` as "configured" and always built a non-null `source_limiting` object. Combined with `applyPlanToState` only propagating a **non-null** plan value, an omitted block planned as `null` but applied as `{enabled=false, ip="any", type="ip"}`.

## Change

- Populate `source_limiting` only when it is genuinely configured on the controller (limiting enabled, a firewall group set, or a specific **non-`any`** IP), or when the prior plan/state already carried the block; otherwise emit a null object.
- Propagate a **null** plan value into state so removing/omitting the block converges instead of leaving a stale object.

Configured source limiting (enabled, firewall group, or specific IP) is unaffected — `TestAccPortForward_sourceLimitingIP` / `_sourceLimitingFirewallGroup` both use `enabled = true` and keep hitting the populate path.

## Testing

- [ ] CI (build / vet / lint)
- ⚠️ Recommend running the acceptance tests on a controller, plus a manual **import of a port forward with no source limiting** to confirm a clean (no-op) plan.

Fixes #187