### PR TITLE
fix(wlan): stop mac_filter drift and null schedule_with_duration

### DIFF
--- a/unifi/wlan_resource.go
+++ b/unifi/wlan_resource.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/setdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
@@ -271,6 +272,9 @@ func (r *wlanFrameworkResource) Schema(
 				MarkdownDescription: "MAC address filtering configuration.",
 				Optional:            true,
 				Computed:            true,
+				PlanModifiers: []planmodifier.Object{
+					objectplanmodifier.UseStateForUnknown(),
+				},
 				Attributes: map[string]schema.Attribute{
 					"enabled": schema.BoolAttribute{
 						MarkdownDescription: "Indicates whether or not the MAC filter is turned on for the network.",
@@ -1108,6 +1112,13 @@ func (r *wlanFrameworkResource) planToWLAN(
 			)
 		}
 		wlan.ScheduleEnabled = len(wlan.ScheduleWithDuration) > 0
+	}
+
+	// The go-unifi schedule_with_duration field has no omitempty, so a nil slice
+	// marshals as `null`, which the controller rejects with api.err.InvalidPayload.
+	// Always send an empty list instead of null when there are no schedules.
+	if wlan.ScheduleWithDuration == nil {
+		wlan.ScheduleWithDuration = []unifi.WLANScheduleWithDuration{}
 	}
 
 	return wlan, diags


### PR DESCRIPTION
## Summary

After importing an existing `unifi_wlan`, two bugs made the resource unusable (see #143):

### 1. Perpetual `mac_filter` drift

Every `plan` re-marked the whole nested block as "known after apply" even when the config matched the controller:

```
~ mac_filter = {
    ~ enabled = false -> (known after apply)
    + list    = (known after apply)
    ~ policy  = "allow" -> (known after apply)
  } -> (known after apply)
```

`mac_filter` is `Optional+Computed` but had no `UseStateForUnknown` plan modifier, so it went unknown on every plan.

### 2. `api.err.InvalidPayload (400)` on apply

The PUT payload contained `"schedule_with_duration": null`. The go-unifi field `ScheduleWithDuration []WLANScheduleWithDuration` has **no `omitempty`** (verified at the pinned commit), so a nil slice marshals as `null`, which the controller rejects.

## Change

- Add `objectplanmodifier.UseStateForUnknown()` to `mac_filter` so the prior state is preserved when the block is unchanged (kills the perpetual drift, and with it the spurious no-op update that triggered the 400).
- Always send an empty list instead of `null` for `schedule_with_duration` when no schedules are configured.

## Testing

- [ ] CI (build / vet / lint)
- ⚠️ Recommend validating on a controller: import a WLAN with no schedule, confirm a clean plan, and confirm an update no longer 400s.

Fixes #143