### PR TITLE
docs(network): clarify what lte_lan does

### DIFF
--- a/docs/resources/network.md
+++ b/docs/resources/network.md
@@ -60,7 +60,7 @@ resource "unifi_network" "third_party" {
 - `ip_aliases` (List of String) List of IP aliases for the network.
 - `ipv6_aliases` (List of String) List of IPv6 aliases for the network.
 - `ipv6_interface_type` (String) Specifies which type of IPv6 connection to use. Must be one of `none`, `pd`, or `static`.
-- `lte_lan` (Boolean) Specifies whether LTE LAN is enabled.
+- `lte_lan` (Boolean) Whether this network/VLAN stays active when the gateway fails over to a UniFi LTE (cellular) backup WAN. Maps to the controller's `lte_lan_enabled` flag and only matters when a UniFi LTE failover device is in use; otherwise it is cosmetic. Defaults to `true` (network stays available during LTE failover); set to `false` to disable it while on the LTE backup link. The controller may set this automatically, which is why existing networks can show differing values.
 - `multicast_dns` (Boolean) Specifies whether mDNS is enabled.
 - `nat_outbound_ip_addresses` (Attributes List) List of NAT outbound IP addresses. (see [below for nested schema](#nestedatt--nat_outbound_ip_addresses))
 - `network_isolation` (Boolean) Specifies whether network isolation is enabled.

--- a/unifi/network_resource.go
+++ b/unifi/network_resource.go
@@ -379,10 +379,17 @@ func (r *networkResource) Schema(
 				},
 			},
 			"lte_lan": schema.BoolAttribute{
-				MarkdownDescription: "Specifies whether LTE LAN is enabled.",
-				Optional:            true,
-				Computed:            true,
-				Default:             booldefault.StaticBool(true),
+				MarkdownDescription: "Whether this network/VLAN stays active when the " +
+					"gateway fails over to a UniFi LTE (cellular) backup WAN. Maps to " +
+					"the controller's `lte_lan_enabled` flag and only matters when a " +
+					"UniFi LTE failover device is in use; otherwise it is cosmetic. " +
+					"Defaults to `true` (network stays available during LTE failover); " +
+					"set to `false` to disable it while on the LTE backup link. The " +
+					"controller may set this automatically, which is why existing " +
+					"networks can show differing values.",
+				Optional: true,
+				Computed: true,
+				Default:  booldefault.StaticBool(true),
 			},
 			"ip_aliases": schema.ListAttribute{
 				MarkdownDescription: "List of IP aliases for the network.",


### PR DESCRIPTION
## Summary

The `lte_lan` attribute on `unifi_network` was documented only as "Specifies whether LTE LAN is enabled", which left users (see #130) unable to tell what it controls, its default, or the effect of toggling it — and confused by `terraform plan` showing it `true` on some networks and `false` on others.

## Change

Documentation-only. Clarifies that `lte_lan` maps to the controller's `lte_lan_enabled` flag (whether the network/VLAN stays active during UniFi LTE/cellular failover), that it defaults to `true`, that it only matters when a UniFi LTE failover device is in use, and that the controller may set it automatically — which explains the differing values across networks.

Fixes #130