### PR TITLE
fix(wlan): populate wlangroup_id and stabilize minimum_data_rate

### DIFF
--- a/unifi/wlan_resource.go
+++ b/unifi/wlan_resource.go
@@ -586,6 +586,37 @@ func (r *wlanFrameworkResource) Configure(
 	r.client = client
 }
 
+// setDefaultWLANGroupID populates wlan.WLANGroupID when it is empty. go-unifi
+// serializes WLANGroupID without `omitempty`, so leaving it blank sends
+// `"wlangroup_id":""` in every POST/PUT, which UniFi Network 10.x rejects with
+// api.err.InvalidPayload. Default to the site's default WLAN group (mirrors the
+// AP-group handling in Create).
+func (r *wlanFrameworkResource) setDefaultWLANGroupID(
+	ctx context.Context,
+	site string,
+	wlan *unifi.WLAN,
+) error {
+	if wlan.WLANGroupID != "" {
+		return nil
+	}
+	groups, err := r.client.ListWLANGroup(ctx, site)
+	if err != nil {
+		return err
+	}
+	// The default WLAN group reports attr_hidden_id "Default" (note the casing
+	// differs from AP groups, which use "default"); match case-insensitively.
+	for _, group := range groups {
+		if strings.EqualFold(group.HiddenID, "default") {
+			wlan.WLANGroupID = group.ID
+			return nil
+		}
+	}
+	if len(groups) > 0 {
+		wlan.WLANGroupID = groups[0].ID
+	}
+	return nil
+}
+
 func (r *wlanFrameworkResource) Create(
 	ctx context.Context,
 	req resource.CreateRequest,
@@ -642,6 +673,14 @@ func (r *wlanFrameworkResource) Create(
 		if len(wlan.ApGroupIDs) == 0 && len(apGroups) > 0 {
 			wlan.ApGroupIDs = []string{apGroups[0].ID}
 		}
+	}
+
+	if err := r.setDefaultWLANGroupID(ctx, site, wlan); err != nil {
+		resp.Diagnostics.AddError(
+			"Error Listing WLAN Groups",
+			"Could not list WLAN groups: "+err.Error(),
+		)
+		return
 	}
 
 	// Create the WLAN
@@ -769,6 +808,13 @@ func (r *wlanFrameworkResource) Update(
 
 	// Step 4: Send to API
 	wlan.ID = state.ID.ValueString()
+	if err := r.setDefaultWLANGroupID(ctx, site, wlan); err != nil {
+		resp.Diagnostics.AddError(
+			"Error Listing WLAN Groups",
+			"Could not list WLAN groups: "+err.Error(),
+		)
+		return
+	}
 	updatedWLAN, err := r.client.UpdateWLAN(ctx, site, wlan)
 	if err != nil {
 		resp.Diagnostics.AddError(
@@ -1294,8 +1340,19 @@ func (r *wlanFrameworkResource) wlanToModel(
 		model.MinrateSettingPreference = types.StringValue("auto")
 	}
 
-	model.MinimumDataRate2GKbps = types.Int64PointerValue(wlan.MinrateNgDataRateKbps)
-	model.MinimumDataRate5GKbps = types.Int64PointerValue(wlan.MinrateNaDataRateKbps)
+	// The API omits these fields from GET responses when unset; map the missing
+	// value to 0 (the schema default) instead of null to avoid perpetual
+	// null->0 plan drift after import.
+	if wlan.MinrateNgDataRateKbps != nil {
+		model.MinimumDataRate2GKbps = types.Int64Value(*wlan.MinrateNgDataRateKbps)
+	} else {
+		model.MinimumDataRate2GKbps = types.Int64Value(0)
+	}
+	if wlan.MinrateNaDataRateKbps != nil {
+		model.MinimumDataRate5GKbps = types.Int64Value(*wlan.MinrateNaDataRateKbps)
+	} else {
+		model.MinimumDataRate5GKbps = types.Int64Value(0)
+	}
 
 	if wlan.WPAMode != "" {
 		model.WPAMode = types.StringValue(wlan.WPAMode)

--- a/unifi/wlan_resource_test.go
+++ b/unifi/wlan_resource_test.go
@@ -65,6 +65,12 @@ func TestAccWLANFramework_additionalFields(t *testing.T) {
 					resource.TestCheckResourceAttrSet("unifi_wlan.test", "group_rekey"),
 					resource.TestCheckResourceAttrSet("unifi_wlan.test", "iapp_enabled"),
 					resource.TestCheckResourceAttrSet("unifi_wlan.test", "mlo_enabled"),
+					// Issue #176 (secondary): the API omits minimum_data_rate_*
+					// from GET responses, so the read path must surface them as 0
+					// (the schema default), not null, to avoid perpetual plan
+					// drift after import.
+					resource.TestCheckResourceAttr("unifi_wlan.test", "minimum_data_rate_2g_kbps", "0"),
+					resource.TestCheckResourceAttr("unifi_wlan.test", "minimum_data_rate_5g_kbps", "0"),
 				),
 				ResourceName:  "unifi_wlan.test",
 				ImportState:   true,

--- a/unifi/wlan_resource_test.go
+++ b/unifi/wlan_resource_test.go
@@ -69,8 +69,16 @@ func TestAccWLANFramework_additionalFields(t *testing.T) {
 					// from GET responses, so the read path must surface them as 0
 					// (the schema default), not null, to avoid perpetual plan
 					// drift after import.
-					resource.TestCheckResourceAttr("unifi_wlan.test", "minimum_data_rate_2g_kbps", "0"),
-					resource.TestCheckResourceAttr("unifi_wlan.test", "minimum_data_rate_5g_kbps", "0"),
+					resource.TestCheckResourceAttr(
+						"unifi_wlan.test",
+						"minimum_data_rate_2g_kbps",
+						"0",
+					),
+					resource.TestCheckResourceAttr(
+						"unifi_wlan.test",
+						"minimum_data_rate_5g_kbps",
+						"0",
+					),
 				),
 				ResourceName:  "unifi_wlan.test",
 				ImportState:   true,


### PR DESCRIPTION
Fixes #176.

## Bug 1 — `wlangroup_id` sent as empty string

go-unifi serializes `WLANGroupID` with `json:"wlangroup_id"` (no `omitempty`), so the provider sent `"wlangroup_id":""` in every WLAN POST/PUT. UniFi Network 10.x validates this strictly and rejects both creates and updates with `api.err.InvalidPayload`.

**Fix:** before `CreateWLAN`/`UpdateWLAN`, populate `WLANGroupID` from the site's default WLAN group via `ListWLANGroup` when it is empty — matching `attr_hidden_id` case-insensitively (the default WLAN group reports `"Default"`, unlike AP groups which use `"default"`), with a first-group fallback. This mirrors the existing default-AP-group handling in `Create`.

## Bug 2 — `minimum_data_rate_*_kbps` null→0 plan drift after import

The API omits `minimum_data_rate_2g/5g_kbps` from GET responses, so `Read` left them `null` while the schema marks them `Computed` with default `0` → perpetual `null→0` drift that `ignore_changes` cannot suppress.

**Fix:** map the missing values to `0` (the schema default) in the read path.

## Validation

Tested locally against a UniFi Network 10.0.162 controller (Podman + testcontainers):

- **Non-regression:** `TestAccWLANFramework_basic` and `TestAccWLANFramework_additionalFields` pass.
- **Bug 2:** `additionalFields` now asserts `minimum_data_rate_2g/5g_kbps == 0` after import (would be `null` without the fix).
- **Bug 1 (partial):** the POST payload now carries a populated `wlangroup_id` and no longer triggers `InvalidPayload`. A full create cannot be green-tested on the demo controller (it caps wireless networks and times out provisioning a fresh WLAN — unrelated to this change), so end-to-end create validation should be confirmed on real hardware (e.g. the UDM Beast 10.4.57 from the report).