### PR TITLE
ci(gosec): run on dependabot PRs so they can pass required code scanning

### DIFF
--- a/.github/workflows/gosec.yaml
+++ b/.github/workflows/gosec.yaml
@@ -11,8 +11,6 @@ on:
 
   pull_request:
     types: ["opened", "synchronize"]
-    branches-ignore:
-      - "dependabot/**"
     paths:
       - "**.go"
       - "vendor/**"


### PR DESCRIPTION
Dependabot PRs (#148, #149, #195) are permanently stuck in a `BLOCKED` state with the message:

> Code scanning is waiting for results from Golang security checks by gosec for the commits …

## Root cause

`gosec.yaml` skips `dependabot/**` branches on `pull_request`:

```yaml
pull_request:
  types: ["opened", "synchronize"]
  branches-ignore:
    - "dependabot/**"
```

…but the branch protection on `main` **requires** the `gosec` code-scanning result. So dependabot PRs can never produce that result and can never be merged through the normal flow.

## Fix

Remove the `branches-ignore: dependabot/**` filter so `gosec` runs on dependabot PRs and uploads its SARIF, satisfying the required check.

Dependabot branches are created inside this repo (not forks), so the job-level `permissions: security-events: write` already declared in the workflow allows the `upload-sarif` step to succeed.

## Note

This only fixes the gosec deadlock going forward. Existing open dependabot PRs (e.g. #148) will pick up the new trigger on their next `synchronize` (rebase/push).