### PR TITLE
ci(gosec): trigger on go.mod/go.sum changes

### DIFF
--- a/.github/workflows/gosec.yaml
+++ b/.github/workflows/gosec.yaml
@@ -6,6 +6,8 @@ on:
       - main
     paths:
       - "**.go"
+      - "go.mod"
+      - "go.sum"
       - "vendor/**"
       - ".github/workflows/**"
 
@@ -13,6 +15,8 @@ on:
     types: ["opened", "synchronize"]
     paths:
       - "**.go"
+      - "go.mod"
+      - "go.sum"
       - "vendor/**"
       - ".github/workflows/**"
 


### PR DESCRIPTION
## Context
Dependency-only PRs (dependabot) change just `go.mod`/`go.sum`. The gosec
workflow's `paths` filter only matched `**.go`, `vendor/**` and
`.github/workflows/**`, so gosec never ran on dependency bumps. With the
required *code scanning results* merge gate enabled, those PRs stay **BLOCKED**
(no gosec result for the commit) even when every other check is green — e.g. #148.

#204 removed the `branches-ignore: dependabot/**` exclusion (necessary), but the
`paths` filter still kept gosec from running on bump PRs. This completes that fix.

## Changes
- Add `go.mod` and `go.sum` to the gosec `push` and `pull_request` path filters.

## Tests
- YAML validated; no logic change beyond trigger paths.
- Will be confirmed by gosec running on the next dependency bump PR (e.g. #148 after re-trigger).

## Risks
- Minimal: gosec now also runs on dependency bumps (slightly more CI minutes). No change to scan rules or thresholds.