### PR TITLE
fix(network): stop forcing multicast_dns=true at create

### DIFF
--- a/docs/resources/network.md
+++ b/docs/resources/network.md
@@ -60,7 +60,7 @@ resource "unifi_network" "third_party" {
 - `ipv6_aliases` (List of String) List of IPv6 aliases for the network.
 - `ipv6_interface_type` (String) Specifies which type of IPv6 connection to use. Must be one of `none`, `pd`, or `static`.
 - `lte_lan` (Boolean) Whether this network/VLAN stays active when the gateway fails over to a UniFi LTE (cellular) backup WAN. Maps to the controller's `lte_lan_enabled` flag and only matters when a UniFi LTE failover device is in use; otherwise it is cosmetic. Defaults to `true` (network stays available during LTE failover); set to `false` to disable it while on the LTE backup link. The controller may set this automatically, which is why existing networks can show differing values.
-- `multicast_dns` (Boolean) Specifies whether mDNS is enabled.
+- `multicast_dns` (Boolean) Specifies whether mDNS is enabled. This is read back from the controller rather than defaulted: some controllers (notably UniFi OS gateways) ignore `mdns_enabled` at create/update time and always store `false`, so forcing a `true` default produced a "provider produced inconsistent result after apply" error.
 - `nat_outbound_ip_addresses` (Attributes List) List of NAT outbound IP addresses. (see [below for nested schema](#nestedatt--nat_outbound_ip_addresses))
 - `network_isolation` (Boolean) Specifies whether network isolation is enabled.
 - `setting_preference` (String) Setting preference. Must be one of `auto` or `manual`.

--- a/unifi/network_resource.go
+++ b/unifi/network_resource.go
@@ -19,6 +19,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/identityschema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
@@ -358,10 +359,17 @@ func (r *networkResource) Schema(
 				Default:             booldefault.StaticBool(false),
 			},
 			"multicast_dns": schema.BoolAttribute{
-				MarkdownDescription: "Specifies whether mDNS is enabled.",
-				Optional:            true,
-				Computed:            true,
-				Default:             booldefault.StaticBool(true),
+				MarkdownDescription: "Specifies whether mDNS is enabled. This is " +
+					"read back from the controller rather than defaulted: some " +
+					"controllers (notably UniFi OS gateways) ignore `mdns_enabled` " +
+					"at create/update time and always store `false`, so forcing a " +
+					"`true` default produced a \"provider produced inconsistent " +
+					"result after apply\" error.",
+				Optional: true,
+				Computed: true,
+				PlanModifiers: []planmodifier.Bool{
+					boolplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"gateway_type": schema.StringAttribute{
 				MarkdownDescription: "The gateway type. Must be one of `default` or `switch`.",
@@ -1252,7 +1260,14 @@ func (r *networkResource) networkToModel(
 		model.AutoScale = previousModel.AutoScale
 		model.SettingPreference = previousModel.SettingPreference
 		model.InternetAccess = previousModel.InternetAccess
-		model.MulticastDNS = previousModel.MulticastDNS
+		// multicast_dns uses UseStateForUnknown, so it may be unknown during
+		// Create. Resolve it from the API value (the controller does not honor
+		// mDNS for vlan-only networks, so this is effectively false).
+		if previousModel.MulticastDNS.IsUnknown() {
+			model.MulticastDNS = types.BoolValue(network.MdnsEnabled)
+		} else {
+			model.MulticastDNS = previousModel.MulticastDNS
+		}
 		model.GatewayType = previousModel.GatewayType
 		model.IPv6InterfaceType = previousModel.IPv6InterfaceType
 		model.LteLan = previousModel.LteLan


### PR DESCRIPTION
## Context
On UniFi OS gateways (UDM, UniFi 10.x), `mdns_enabled` is **ignored at create/update time** and always stored as `false` by the controller (confirmed by raw API: create or PUT with `mdns_enabled:true` → reads back `false`; existing networks can show `true` because mDNS is enabled by a different mechanism). The `unifi_network` schema defaulted `multicast_dns` to `true`, so **every network create** against such a controller failed with *"provider produced inconsistent result after apply: .multicast_dns was true, but now false"*.

The simulator stores the sent value, so the acceptance suite never caught this — it only shows up against real hardware.

## Changes
- `multicast_dns`: drop the static `true` default; make it Optional+Computed with `UseStateForUnknown` (read back from the controller).
- `networkToModel` vlan-only branch: resolve the now-possibly-unknown `multicast_dns` from the API response (mirrors the existing `domain_name` handling), so vlan-only/third_party_gateway creates don't leave it unknown.

## Tests
- **Real UDM (UniFi 10.x):** plain and `dhcp_relay` networks apply with no inconsistency and a clean re-plan; destroy clean.
- Full `TestAccNetworkFramework` suite passes on the simulator (incl. vlan-only / third_party_gateway).
- `go build`, `go vet`, `golangci-lint`, `go generate` clean.

## Risks
- Behavior change: `multicast_dns` is no longer defaulted to `true` — it reflects the controller value. On controllers that *do* honor it, an explicit `true` still works; only the implicit `true` default is removed (it was unsatisfiable on UniFi OS gateways).