### PR TITLE
feat(wlan): support private pre-shared keys (PPSK)

### DIFF
--- a/docs/resources/wlan.md
+++ b/docs/resources/wlan.md
@@ -47,6 +47,18 @@ resource "unifi_wlan" "wifi" {
   network_id    = unifi_network.vlan.id
   ap_group_ids  = [data.unifi_ap_group.default.id]
   user_group_id = data.unifi_client_qos_rate.default.id
+
+  # Per-key (PPSK) passphrases, each optionally bound to its own network/VLAN
+  private_preshared_keys_enabled = true
+  private_preshared_keys = [
+    {
+      password   = "guest-key-1234"
+      network_id = unifi_network.vlan.id
+    },
+    {
+      password = "iot-key-5678"
+    },
+  ]
 }
 ```
 
@@ -92,6 +104,8 @@ resource "unifi_wlan" "wifi" {
 - `passphrase` (String, Sensitive) The passphrase for the network, only required if `security` is not `open`. Stored in state — use `passphrase_wo` to avoid persisting the secret.
 - `passphrase_wo` (String, Sensitive, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) Write-only equivalent of `passphrase` (Terraform 1.11+). Used at apply time but never written to state, so it can be sourced from an ephemeral resource (e.g. a Vault secret). Mutually exclusive with `passphrase`.
 - `pmf_mode` (String) Enable Protected Management Frames. This cannot be disabled if using WPA 3.
+- `private_preshared_keys` (Attributes List) Private pre-shared keys (PPSK): a list of per-key passphrases, each optionally bound to its own network/VLAN. Only valid when `private_preshared_keys_enabled` is `true`. (see [below for nested schema](#nestedatt--private_preshared_keys))
+- `private_preshared_keys_enabled` (Boolean) Whether per-key (PPSK) passphrases are enabled for this WLAN. Requires `security = wpapsk`.
 - `proxy_arp` (Boolean) Reduces airtime usage by allowing APs to "proxy" common broadcast frames as unicast.
 - `radius_mac_auth_enabled` (Boolean) Enable RADIUS MAC authentication.
 - `radius_profile_id` (String) ID of the RADIUS profile to use when security `wpaeap`.
@@ -121,6 +135,18 @@ Optional:
 - `enabled` (Boolean) Indicates whether or not the MAC filter is turned on for the network.
 - `list` (Set of String) List of MAC addresses to filter (only valid if `enabled` is `true`).
 - `policy` (String) MAC address filter policy (only valid if `enabled` is `true`).
+
+
+<a id="nestedatt--private_preshared_keys"></a>
+### Nested Schema for `private_preshared_keys`
+
+Required:
+
+- `password` (String, Sensitive) The passphrase for this key (8-255 characters).
+
+Optional:
+
+- `network_id` (String) ID of the network/VLAN this key is bound to. Leave unset to use the WLAN's default network.
 
 
 <a id="nestedblock--schedule"></a>

--- a/examples/resources/unifi_wlan/resource.tf
+++ b/examples/resources/unifi_wlan/resource.tf
@@ -33,4 +33,16 @@ resource "unifi_wlan" "wifi" {
   network_id    = unifi_network.vlan.id
   ap_group_ids  = [data.unifi_ap_group.default.id]
   user_group_id = data.unifi_client_qos_rate.default.id
+
+  # Per-key (PPSK) passphrases, each optionally bound to its own network/VLAN
+  private_preshared_keys_enabled = true
+  private_preshared_keys = [
+    {
+      password   = "guest-key-1234"
+      network_id = unifi_network.vlan.id
+    },
+    {
+      password = "iot-key-5678"
+    },
+  ]
 }

--- a/unifi/wlan_ppsk_test.go
+++ b/unifi/wlan_ppsk_test.go
@@ -1,0 +1,97 @@
+package unifi
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/ubiquiti-community/go-unifi/unifi"
+)
+
+// TestWLANPrivatePresharedKeys_roundTrip exercises the private pre-shared key
+// (PPSK) mapping added for issue #47: a plan carrying PPSK entries must be
+// translated to the go-unifi WLAN struct (planToWLAN) and back into the
+// resource model (wlanToModel) without losing the per-key network binding or
+// password.
+func TestWLANPrivatePresharedKeys_roundTrip(t *testing.T) {
+	ctx := context.Background()
+	r := &wlanFrameworkResource{}
+
+	ppskType := types.ObjectType{AttrTypes: wlanPrivatePresharedKeyModel{}.AttributeTypes()}
+	ppskList, d := types.ListValueFrom(ctx, ppskType, []wlanPrivatePresharedKeyModel{
+		{NetworkID: types.StringValue("net-a"), Password: types.StringValue("secretpass1")},
+		{NetworkID: types.StringValue(""), Password: types.StringValue("secretpass2")},
+	})
+	if d.HasError() {
+		t.Fatalf("building PPSK list: %v", d)
+	}
+
+	plan := wlanFrameworkResourceModel{
+		Name:                        types.StringValue("ppsk-wlan"),
+		Security:                    types.StringValue("wpapsk"),
+		PrivatePresharedKeysEnabled: types.BoolValue(true),
+		PrivatePresharedKeys:        ppskList,
+	}
+
+	// plan -> API
+	wlan, diags := r.planToWLAN(ctx, plan)
+	if diags.HasError() {
+		t.Fatalf("planToWLAN: %v", diags)
+	}
+	if !wlan.PrivatePresharedKeysEnabled {
+		t.Errorf("PrivatePresharedKeysEnabled = false, want true")
+	}
+	if got := len(wlan.PrivatePresharedKeys); got != 2 {
+		t.Fatalf("PrivatePresharedKeys len = %d, want 2", got)
+	}
+	if wlan.PrivatePresharedKeys[0].NetworkID != "net-a" ||
+		wlan.PrivatePresharedKeys[0].Password != "secretpass1" {
+		t.Errorf("PPSK[0] = %+v, want {net-a secretpass1}", wlan.PrivatePresharedKeys[0])
+	}
+	if wlan.PrivatePresharedKeys[1].NetworkID != "" ||
+		wlan.PrivatePresharedKeys[1].Password != "secretpass2" {
+		t.Errorf("PPSK[1] = %+v, want { secretpass2}", wlan.PrivatePresharedKeys[1])
+	}
+
+	// API -> model
+	var model wlanFrameworkResourceModel
+	if diags := r.wlanToModel(ctx, wlan, &model, "default"); diags.HasError() {
+		t.Fatalf("wlanToModel: %v", diags)
+	}
+	if !model.PrivatePresharedKeysEnabled.ValueBool() {
+		t.Errorf("model.PrivatePresharedKeysEnabled = false, want true")
+	}
+	if model.PrivatePresharedKeys.IsNull() {
+		t.Fatalf("model.PrivatePresharedKeys is null, want 2 entries")
+	}
+	var got []wlanPrivatePresharedKeyModel
+	if diags := model.PrivatePresharedKeys.ElementsAs(ctx, &got, false); diags.HasError() {
+		t.Fatalf("decoding model PPSK: %v", diags)
+	}
+	if len(got) != 2 {
+		t.Fatalf("model PPSK len = %d, want 2", len(got))
+	}
+	if got[0].NetworkID.ValueString() != "net-a" ||
+		got[0].Password.ValueString() != "secretpass1" {
+		t.Errorf("model PPSK[0] = %+v, want {net-a secretpass1}", got[0])
+	}
+}
+
+// TestWLANPrivatePresharedKeys_emptyIsNull verifies that a WLAN without PPSK
+// entries reads back as a null list (not an empty list), avoiding spurious
+// plan drift for WLANs that don't use private pre-shared keys.
+func TestWLANPrivatePresharedKeys_emptyIsNull(t *testing.T) {
+	ctx := context.Background()
+	r := &wlanFrameworkResource{}
+
+	var model wlanFrameworkResourceModel
+	if diags := r.wlanToModel(ctx, &unifi.WLAN{}, &model, "default"); diags.HasError() {
+		t.Fatalf("wlanToModel: %v", diags)
+	}
+	if model.PrivatePresharedKeysEnabled.ValueBool() {
+		t.Errorf("PrivatePresharedKeysEnabled = true, want false")
+	}
+	if !model.PrivatePresharedKeys.IsNull() {
+		t.Errorf("PrivatePresharedKeys = %v, want null", model.PrivatePresharedKeys)
+	}
+}

--- a/unifi/wlan_resource.go
+++ b/unifi/wlan_resource.go
@@ -60,42 +60,58 @@ type wlanMacFilterModel struct {
 	Policy  types.String `tfsdk:"policy"`
 }
 
+// wlanPrivatePresharedKeyModel represents a single private pre-shared key (PPSK)
+// entry: a per-key password optionally bound to its own VLAN/network.
+type wlanPrivatePresharedKeyModel struct {
+	NetworkID types.String `tfsdk:"network_id"`
+	Password  types.String `tfsdk:"password"`
+}
+
+func (m wlanPrivatePresharedKeyModel) AttributeTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"network_id": types.StringType,
+		"password":   types.StringType,
+	}
+}
+
 // wlanFrameworkResourceModel describes the resource data model.
 type wlanFrameworkResourceModel struct {
-	ID                       types.String `tfsdk:"id"`
-	Site                     types.String `tfsdk:"site"`
-	Name                     types.String `tfsdk:"name"`
-	NetworkID                types.String `tfsdk:"network_id"`
-	UserGroupID              types.String `tfsdk:"user_group_id"`
-	Security                 types.String `tfsdk:"security"`
-	WPA3Support              types.Bool   `tfsdk:"wpa3_support"`
-	WPA3Transition           types.Bool   `tfsdk:"wpa3_transition"`
-	PMFMode                  types.String `tfsdk:"pmf_mode"`
-	Passphrase               types.String `tfsdk:"passphrase"`
-	PassphraseWO             types.String `tfsdk:"passphrase_wo"`
-	HideSSID                 types.Bool   `tfsdk:"hide_ssid"`
-	IsGuest                  types.Bool   `tfsdk:"is_guest"`
-	Enabled                  types.Bool   `tfsdk:"enabled"`
-	ApGroupIDs               types.Set    `tfsdk:"ap_group_ids"`
-	ApGroupMode              types.String `tfsdk:"ap_group_mode"`
-	VLANEnabled              types.Bool   `tfsdk:"vlan_enabled"`
-	VLAN                     types.Int64  `tfsdk:"vlan"`
-	WLANBand                 types.String `tfsdk:"wlan_band"`
-	WLANBands                types.Set    `tfsdk:"wlan_bands"`
-	MulticastEnhance         types.Bool   `tfsdk:"multicast_enhance"`
-	MacFilter                types.Object `tfsdk:"mac_filter"`
-	RadiusProfileID          types.String `tfsdk:"radius_profile_id"`
-	NasIDentifierType        types.String `tfsdk:"nas_identifier_type"`
-	Schedule                 types.List   `tfsdk:"schedule"`
-	No2GhzOui                types.Bool   `tfsdk:"no2ghz_oui"`
-	L2Isolation              types.Bool   `tfsdk:"l2_isolation"`
-	ProxyArp                 types.Bool   `tfsdk:"proxy_arp"`
-	BssTransition            types.Bool   `tfsdk:"bss_transition"`
-	Uapsd                    types.Bool   `tfsdk:"uapsd"`
-	FastRoamingEnabled       types.Bool   `tfsdk:"fast_roaming_enabled"`
-	MinimumDataRate2GKbps    types.Int64  `tfsdk:"minimum_data_rate_2g_kbps"`
-	MinimumDataRate5GKbps    types.Int64  `tfsdk:"minimum_data_rate_5g_kbps"`
-	MinrateSettingPreference types.String `tfsdk:"minrate_setting_preference"`
+	ID                          types.String `tfsdk:"id"`
+	Site                        types.String `tfsdk:"site"`
+	Name                        types.String `tfsdk:"name"`
+	NetworkID                   types.String `tfsdk:"network_id"`
+	UserGroupID                 types.String `tfsdk:"user_group_id"`
+	Security                    types.String `tfsdk:"security"`
+	WPA3Support                 types.Bool   `tfsdk:"wpa3_support"`
+	WPA3Transition              types.Bool   `tfsdk:"wpa3_transition"`
+	PMFMode                     types.String `tfsdk:"pmf_mode"`
+	Passphrase                  types.String `tfsdk:"passphrase"`
+	PassphraseWO                types.String `tfsdk:"passphrase_wo"`
+	HideSSID                    types.Bool   `tfsdk:"hide_ssid"`
+	IsGuest                     types.Bool   `tfsdk:"is_guest"`
+	Enabled                     types.Bool   `tfsdk:"enabled"`
+	ApGroupIDs                  types.Set    `tfsdk:"ap_group_ids"`
+	ApGroupMode                 types.String `tfsdk:"ap_group_mode"`
+	VLANEnabled                 types.Bool   `tfsdk:"vlan_enabled"`
+	VLAN                        types.Int64  `tfsdk:"vlan"`
+	WLANBand                    types.String `tfsdk:"wlan_band"`
+	WLANBands                   types.Set    `tfsdk:"wlan_bands"`
+	MulticastEnhance            types.Bool   `tfsdk:"multicast_enhance"`
+	MacFilter                   types.Object `tfsdk:"mac_filter"`
+	PrivatePresharedKeysEnabled types.Bool   `tfsdk:"private_preshared_keys_enabled"`
+	PrivatePresharedKeys        types.List   `tfsdk:"private_preshared_keys"`
+	RadiusProfileID             types.String `tfsdk:"radius_profile_id"`
+	NasIDentifierType           types.String `tfsdk:"nas_identifier_type"`
+	Schedule                    types.List   `tfsdk:"schedule"`
+	No2GhzOui                   types.Bool   `tfsdk:"no2ghz_oui"`
+	L2Isolation                 types.Bool   `tfsdk:"l2_isolation"`
+	ProxyArp                    types.Bool   `tfsdk:"proxy_arp"`
+	BssTransition               types.Bool   `tfsdk:"bss_transition"`
+	Uapsd                       types.Bool   `tfsdk:"uapsd"`
+	FastRoamingEnabled          types.Bool   `tfsdk:"fast_roaming_enabled"`
+	MinimumDataRate2GKbps       types.Int64  `tfsdk:"minimum_data_rate_2g_kbps"`
+	MinimumDataRate5GKbps       types.Int64  `tfsdk:"minimum_data_rate_5g_kbps"`
+	MinrateSettingPreference    types.String `tfsdk:"minrate_setting_preference"`
 
 	// Security / encryption
 	WPAMode types.String `tfsdk:"wpa_mode"`
@@ -308,6 +324,38 @@ func (r *wlanFrameworkResource) Schema(
 						Default:             stringdefault.StaticString("deny"),
 						Validators: []validator.String{
 							stringvalidator.OneOf("allow", "deny"),
+						},
+					},
+				},
+			},
+			"private_preshared_keys_enabled": schema.BoolAttribute{
+				MarkdownDescription: "Whether per-key (PPSK) passphrases are enabled for this WLAN. " +
+					"Requires `security = wpapsk`.",
+				Optional: true,
+				Computed: true,
+				Default:  booldefault.StaticBool(false),
+			},
+			"private_preshared_keys": schema.ListNestedAttribute{
+				MarkdownDescription: "Private pre-shared keys (PPSK): a list of per-key passphrases, " +
+					"each optionally bound to its own network/VLAN. Only valid when " +
+					"`private_preshared_keys_enabled` is `true`.",
+				Optional: true,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"network_id": schema.StringAttribute{
+							MarkdownDescription: "ID of the network/VLAN this key is bound to. " +
+								"Leave unset to use the WLAN's default network.",
+							Optional: true,
+							Computed: true,
+							Default:  stringdefault.StaticString(""),
+						},
+						"password": schema.StringAttribute{
+							MarkdownDescription: "The passphrase for this key (8-255 characters).",
+							Required:            true,
+							Sensitive:           true,
+							Validators: []validator.String{
+								stringvalidator.LengthBetween(8, 255),
+							},
 						},
 					},
 				},
@@ -915,6 +963,13 @@ func (r *wlanFrameworkResource) applyPlanToState(
 	if !plan.MacFilter.IsNull() && !plan.MacFilter.IsUnknown() {
 		state.MacFilter = plan.MacFilter
 	}
+	if !plan.PrivatePresharedKeysEnabled.IsNull() &&
+		!plan.PrivatePresharedKeysEnabled.IsUnknown() {
+		state.PrivatePresharedKeysEnabled = plan.PrivatePresharedKeysEnabled
+	}
+	if !plan.PrivatePresharedKeys.IsNull() && !plan.PrivatePresharedKeys.IsUnknown() {
+		state.PrivatePresharedKeys = plan.PrivatePresharedKeys
+	}
 	if !plan.RadiusProfileID.IsNull() && !plan.RadiusProfileID.IsUnknown() {
 		state.RadiusProfileID = plan.RadiusProfileID
 	}
@@ -1150,6 +1205,26 @@ func (r *wlanFrameworkResource) planToWLAN(
 		}
 	}
 
+	// Handle private pre-shared keys (PPSK)
+	wlan.PrivatePresharedKeysEnabled = plan.PrivatePresharedKeysEnabled.ValueBool()
+	if !plan.PrivatePresharedKeys.IsNull() && !plan.PrivatePresharedKeys.IsUnknown() {
+		var ppskList []wlanPrivatePresharedKeyModel
+		diags.Append(plan.PrivatePresharedKeys.ElementsAs(ctx, &ppskList, false)...)
+		if diags.HasError() {
+			return nil, diags
+		}
+
+		for _, ppsk := range ppskList {
+			wlan.PrivatePresharedKeys = append(
+				wlan.PrivatePresharedKeys,
+				unifi.WLANPrivatePresharedKeys{
+					NetworkID: ppsk.NetworkID.ValueString(),
+					Password:  ppsk.Password.ValueString(),
+				},
+			)
+		}
+	}
+
 	// Handle AP group IDs
 	if !plan.ApGroupIDs.IsNull() && !plan.ApGroupIDs.IsUnknown() {
 		var apGroupList []types.String
@@ -1314,6 +1389,33 @@ func (r *wlanFrameworkResource) wlanToModel(
 	)
 	diags.Append(d...)
 	model.MacFilter = macFilterObj
+
+	// Handle private pre-shared keys (PPSK). The per-key password is sensitive
+	// and not always echoed back by the controller; the plan value is preserved
+	// in applyPlanToState for create/update, so this read path mainly serves
+	// refresh and import.
+	model.PrivatePresharedKeysEnabled = types.BoolValue(wlan.PrivatePresharedKeysEnabled)
+
+	ppskType := types.ObjectType{AttrTypes: wlanPrivatePresharedKeyModel{}.AttributeTypes()}
+	if len(wlan.PrivatePresharedKeys) > 0 {
+		ppskValues := make([]attr.Value, len(wlan.PrivatePresharedKeys))
+		for i, ppsk := range wlan.PrivatePresharedKeys {
+			obj, d := types.ObjectValue(
+				wlanPrivatePresharedKeyModel{}.AttributeTypes(),
+				map[string]attr.Value{
+					"network_id": types.StringValue(ppsk.NetworkID),
+					"password":   types.StringValue(ppsk.Password),
+				},
+			)
+			diags.Append(d...)
+			ppskValues[i] = obj
+		}
+		ppskList, d := types.ListValue(ppskType, ppskValues)
+		diags.Append(d...)
+		model.PrivatePresharedKeys = ppskList
+	} else {
+		model.PrivatePresharedKeys = types.ListNull(ppskType)
+	}
 
 	if wlan.RADIUSProfileID != "" {
 		model.RadiusProfileID = types.StringValue(wlan.RADIUSProfileID)


### PR DESCRIPTION
Closes #47.

## Fonctionnalité

Expose les **private pre-shared keys (PPSK)** sur `unifi_wlan` : une liste de passphrases par clé, chacune optionnellement liée à son propre network/VLAN. Permet de gérer le multi-PSK depuis Terraform.

```hcl
resource "unifi_wlan" "wifi" {
  name       = "myssid"
  security   = "wpapsk"
  passphrase = "12345678"

  private_preshared_keys_enabled = true
  private_preshared_keys = [
    {
      password   = "guest-key-1234"
      network_id = unifi_network.vlan.id
    },
    {
      password = "iot-key-5678"
    },
  ]
}
```

## Détails

`go-unifi` porte déjà `WLANPrivatePresharedKeys` et `PrivatePresharedKeysEnabled` ; il suffisait de les câbler :

- Nouveaux attributs `private_preshared_keys_enabled` (Bool) et `private_preshared_keys` (liste de `{network_id, password}`). Le `password` est **Sensitive** et validé (8–255 caractères).
- Mappé dans les deux sens (`planToWLAN` / `wlanToModel`) ; une liste vide est relue comme `null` pour éviter le drift sur les WLAN sans PPSK.
- Valeur du plan préservée dans `applyPlanToState` pour ne pas écraser le secret avec l'écho de l'API — même approche que le `passphrase` existant.

## Validation

- ✅ **Tests unitaires** de round-trip (`planToWLAN` → `wlanToModel`) + cas vide→null : passent localement
- ✅ `go build`, `go vet`, `gofmt`, suite unitaire : verts
- Doc régénérée + exemple ajouté

> Un test acceptance de bout en bout n'est pas inclus : la création de WLAN échoue sur le contrôleur démo (`api.err.InvalidPayload` pré-existant, déjà documenté dans les tests WLAN existants), et la WLAN seedée n'a pas de PPSK à importer. Le mapping est couvert par les tests unitaires à la place.