### PR TITLE
fix(device): stop resetting state/adopted on PUT, fixing UDM writes

### DIFF
--- a/unifi/device_resource.go
+++ b/unifi/device_resource.go
@@ -1347,22 +1347,26 @@ func (r *deviceResource) updateDevice(
 
 	deviceReq.ID = model.ID.ValueString()
 
-	// Fill in required fields from the current device state if not set in the model.
-	// The API requires 'type' in the PUT body, but it's a computed field not set by users.
-	// Fill type from API. Prefer MAC lookup (works through cloud connector).
-	// Fall back to ID lookup (works locally).
-	if deviceReq.Type == "" {
-		var currentDevice *unifi.Device
-		if deviceReq.MAC != "" {
-			currentDevice, _ = r.client.GetDeviceByMAC(ctx, site, deviceReq.MAC)
-		}
-		if currentDevice == nil && deviceReq.ID != "" {
-			currentDevice, _ = r.client.GetDevice(ctx, site, deviceReq.ID)
-		}
-		if currentDevice != nil {
-			deviceReq.Type = currentDevice.Type
-		}
+	// Fetch the current device once. We need it for two reasons:
+	//   1. 'type' is a computed field the API requires in the PUT body.
+	//   2. UpdateDevice sends a diff against the existing device. The Device
+	//      struct marshals `state` and `adopted` without omitempty, so leaving
+	//      them at their Go zero-values makes the diff try to reset state to 0
+	//      and adopted to false — which UDM/Dream Machine gateways reject with
+	//      api.err.Invalid (issue #177). Echo the current values so they don't
+	//      appear in the diff.
+	// Prefer MAC lookup (works through cloud connector); fall back to ID (local).
+	var currentDevice *unifi.Device
+	if deviceReq.MAC != "" {
+		currentDevice, _ = r.client.GetDeviceByMAC(ctx, site, deviceReq.MAC)
 	}
+	if currentDevice == nil && deviceReq.ID != "" {
+		currentDevice, _ = r.client.GetDevice(ctx, site, deviceReq.ID)
+	}
+	if currentDevice != nil && deviceReq.Type == "" {
+		deviceReq.Type = currentDevice.Type
+	}
+
 	// Build a minimal Device for the PUT request. The full Device struct includes
 	// computed fields (adopted, state, etc.) with Go zero-values that the API rejects.
 	// Only send fields that the user configured or that the API requires.
@@ -1372,6 +1376,10 @@ func (r *deviceResource) updateDevice(
 		MAC:           deviceReq.MAC,
 		Name:          deviceReq.Name,
 		PortOverrides: deviceReq.PortOverrides,
+	}
+	if currentDevice != nil {
+		minimalDevice.State = currentDevice.State
+		minimalDevice.Adopted = currentDevice.Adopted
 	}
 
 	if reqJSON, jsonErr := json.Marshal(minimalDevice); jsonErr == nil {


### PR DESCRIPTION
Addresses the `state:0` failure in #177.

## Problème

`UpdateDevice` (go-unifi) envoie un **diff JSON** contre le device existant. Or le struct `Device` sérialise `state` et `adopted` **sans `omitempty`**. Le `minimalDevice` construit pour le PUT laissait ces deux champs à leur zéro Go (`state=0`, `adopted=false`), ce qui faisait apparaître `state: 0` et `adopted: false` dans le diff. Les gateways UDM / Dream Machine rejettent ça avec `api.err.Invalid (400)` → **toute écriture de device échoue**.

## Correctif

On récupère le device courant une seule fois (déjà nécessaire pour le champ calculé `type`) et on **réinjecte ses valeurs `state` et `adopted`** sur le `minimalDevice`, pour qu'ils n'apparaissent plus dans le diff.

## Portée

- ✅ `go build`, `go vet`, `gofmt` : verts
- Couvre le `state:0` de #177. La partie **`aggregate_members` / `op_mode` (SFP+ LAG)** de cette issue est spécifique au matériel/gateway et reste suivie séparément — l'issue n'est donc pas auto-fermée.
- Non reproductible sur le contrôleur démo (pas de matériel adoptable) ; validé par lecture de `getDeviceDiff` dans go-unifi. L'auteur de #177 pourra confirmer sur son UDM.