### PR TITLE
docs(network): require ipv6_pd_start/stop in prefix-delegation example

### DIFF
--- a/docs/resources/network.md
+++ b/docs/resources/network.md
@@ -62,7 +62,11 @@ resource "unifi_network" "ipv6_pd" {
   ipv6_pd_interface             = "wan"
   ipv6_pd_prefixid              = "1"
   ipv6_pd_auto_prefixid_enabled = false
-  ipv6_ra                       = true
+  # ipv6_pd_start/stop are required for a prefix-delegation network — the
+  # controller rejects it with api.err.InvalidIpv6Addr otherwise.
+  ipv6_pd_start = "::2"
+  ipv6_pd_stop  = "::7d1"
+  ipv6_ra       = true
 }
 
 # Third-party gateway (VLAN-only) network
@@ -104,8 +108,8 @@ resource "unifi_network" "third_party" {
 - `ipv6_pd_auto_prefixid_enabled` (Boolean) Specifies whether automatic prefix ID assignment is enabled for IPv6 Prefix Delegation.
 - `ipv6_pd_interface` (String) The IPv6 Prefix Delegation WAN interface (e.g., `wan`, `wan2`).
 - `ipv6_pd_prefixid` (String) The IPv6 Prefix Delegation prefix ID (hex string, e.g., `0`, `1a`).
-- `ipv6_pd_start` (String) The start of the IPv6 Prefix Delegation range.
-- `ipv6_pd_stop` (String) The end of the IPv6 Prefix Delegation range.
+- `ipv6_pd_start` (String) The start of the IPv6 Prefix Delegation range (e.g. `::2`). Required together with `ipv6_pd_stop` when `ipv6_interface_type` is `pd`, otherwise the controller rejects the network with `api.err.InvalidIpv6Addr`.
+- `ipv6_pd_stop` (String) The end of the IPv6 Prefix Delegation range (e.g. `::7d1`). Required together with `ipv6_pd_start` when `ipv6_interface_type` is `pd`.
 - `ipv6_ra` (Boolean) Specifies whether IPv6 Router Advertisement (RA) is enabled.
 - `ipv6_ra_preferred_lifetime` (Number) The IPv6 Router Advertisement preferred lifetime in seconds (0-31536000).
 - `ipv6_ra_priority` (String) The IPv6 Router Advertisement priority. Must be one of `high`, `medium`, or `low`.

--- a/examples/resources/unifi_network/resource.tf
+++ b/examples/resources/unifi_network/resource.tf
@@ -48,7 +48,11 @@ resource "unifi_network" "ipv6_pd" {
   ipv6_pd_interface             = "wan"
   ipv6_pd_prefixid              = "1"
   ipv6_pd_auto_prefixid_enabled = false
-  ipv6_ra                       = true
+  # ipv6_pd_start/stop are required for a prefix-delegation network — the
+  # controller rejects it with api.err.InvalidIpv6Addr otherwise.
+  ipv6_pd_start = "::2"
+  ipv6_pd_stop  = "::7d1"
+  ipv6_ra       = true
 }
 
 # Third-party gateway (VLAN-only) network

--- a/unifi/network_resource.go
+++ b/unifi/network_resource.go
@@ -461,12 +461,16 @@ func (r *networkResource) Schema(
 				Optional:            true,
 			},
 			"ipv6_pd_start": schema.StringAttribute{
-				MarkdownDescription: "The start of the IPv6 Prefix Delegation range.",
-				Optional:            true,
+				MarkdownDescription: "The start of the IPv6 Prefix Delegation range (e.g. `::2`). " +
+					"Required together with `ipv6_pd_stop` when `ipv6_interface_type` is " +
+					"`pd`, otherwise the controller rejects the network with " +
+					"`api.err.InvalidIpv6Addr`.",
+				Optional: true,
 			},
 			"ipv6_pd_stop": schema.StringAttribute{
-				MarkdownDescription: "The end of the IPv6 Prefix Delegation range.",
-				Optional:            true,
+				MarkdownDescription: "The end of the IPv6 Prefix Delegation range (e.g. `::7d1`). " +
+					"Required together with `ipv6_pd_start` when `ipv6_interface_type` is `pd`.",
+				Optional: true,
 			},
 			"ipv6_pd_auto_prefixid_enabled": schema.BoolAttribute{
 				MarkdownDescription: "Specifies whether automatic prefix ID assignment is enabled for IPv6 Prefix Delegation.",


### PR DESCRIPTION
## Context
Follow-up to #158. A prefix-delegation network (`ipv6_interface_type = "pd"`) is rejected by the controller with `api.err.InvalidIpv6Addr` unless `ipv6_pd_start` and `ipv6_pd_stop` are set. The example added in #158 omitted them, so a user copying it hits that error.

Confirmed by bisection against a real UDM (UniFi OS 10.x): `pd` + RA without the range → `InvalidIpv6Addr`; with `ipv6_pd_start`/`ipv6_pd_stop` → applies and round-trips cleanly (no drift, import OK).

## Changes
- `examples/resources/unifi_network/resource.tf`: add `ipv6_pd_start`/`ipv6_pd_stop` to the PD example with an explanatory comment.
- Document the requirement on both attribute descriptions (regenerated docs).

## Tests
Docs-only behaviour change; `go build`/`go vet`/`golangci-lint`/`go generate` clean. PD network validated end-to-end on a real UDM.