### PR TITLE
fix(device): bump go-unifi to read numeric radio_table channel/tx_power

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/hashicorp/terraform-plugin-testing v1.16.0
 	github.com/testcontainers/testcontainers-go v0.42.0
 	github.com/testcontainers/testcontainers-go/modules/compose v0.42.0
-	github.com/ubiquiti-community/go-unifi v1.33.43-0.20260609191717-27e2c9aec921
+	github.com/ubiquiti-community/go-unifi v1.33.43-0.20260609201330-9d5096dc2ca6
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -528,8 +528,8 @@ github.com/transparency-dev/formats v0.0.0-20251017110053-404c0d5b696c h1:5a2XDQ
 github.com/transparency-dev/formats v0.0.0-20251017110053-404c0d5b696c/go.mod h1:g85IafeFJZLxlzZCDRu4JLpfS7HKzR+Hw9qRh3bVzDI=
 github.com/transparency-dev/merkle v0.0.2 h1:Q9nBoQcZcgPamMkGn7ghV8XiTZ/kRxn1yCG81+twTK4=
 github.com/transparency-dev/merkle v0.0.2/go.mod h1:pqSy+OXefQ1EDUVmAJ8MUhHB9TXGuzVAT58PqBoHz1A=
-github.com/ubiquiti-community/go-unifi v1.33.43-0.20260609191717-27e2c9aec921 h1:qA9zyCgCW4xIhaDgLXD7IaoaS8Y+aZRGqlT2IIUnc/M=
-github.com/ubiquiti-community/go-unifi v1.33.43-0.20260609191717-27e2c9aec921/go.mod h1:lOld3iJD/7eXE5+phOVWz3Y45qTlb73g24tPipLIkac=
+github.com/ubiquiti-community/go-unifi v1.33.43-0.20260609201330-9d5096dc2ca6 h1:64AwQ6vXujWR4gpGePWG8A1BltLJuaXJwBsFZrPKHa0=
+github.com/ubiquiti-community/go-unifi v1.33.43-0.20260609201330-9d5096dc2ca6/go.mod h1:lOld3iJD/7eXE5+phOVWz3Y45qTlb73g24tPipLIkac=
 github.com/vbatts/tar-split v0.12.2 h1:w/Y6tjxpeiFMR47yzZPlPj/FcPLpXbTUi/9H7d3CPa4=
 github.com/vbatts/tar-split v0.12.2/go.mod h1:eF6B6i6ftWQcDqEn3/iGFRFRo8cBIMSJVOpnNdfTMFA=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=


### PR DESCRIPTION
## Context
On UniFi Network 10.x, `GET stat/device` returns `radio_table` `channel` and `tx_power` as JSON **numbers**. The pinned go-unifi typed them as `string`, so device reads/imports failed with:

```
unable to decode body: GET api/s/default/stat/device unable to unmarshal alias:
json: cannot unmarshal number into Go struct field .Alias.channel of type string
```

This broke `unifi_device` reads/imports on recent controllers for multiple users (#112).

## Changes
Bump go-unifi to include ubiquiti-community/go-unifi#25, which makes
`DeviceRadioTable.channel`/`tx_power` accept either a number or a string
(`"auto"`, fractional channels) via the existing `types.Number` mechanism.

## Tests
- go-unifi side has a unit test covering numeric / `"auto"` / numeric-string / fractional inputs.
- Validated end-to-end on a real UDM (UniFi OS 10.x): `terraform import` of a U7 Lite AP whose controller returns `channel` as the integer `13` now succeeds (previously failed to unmarshal).

Fixes #112.