### PR TITLE
fix(network): bump go-unifi to tolerate string-encoded dhcpd_enabled

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/hashicorp/terraform-plugin-testing v1.16.0
 	github.com/testcontainers/testcontainers-go v0.42.0
 	github.com/testcontainers/testcontainers-go/modules/compose v0.42.0
-	github.com/ubiquiti-community/go-unifi v1.33.43-0.20260609201330-9d5096dc2ca6
+	github.com/ubiquiti-community/go-unifi v1.33.43-0.20260609205204-c32397ea7408
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -528,8 +528,8 @@ github.com/transparency-dev/formats v0.0.0-20251017110053-404c0d5b696c h1:5a2XDQ
 github.com/transparency-dev/formats v0.0.0-20251017110053-404c0d5b696c/go.mod h1:g85IafeFJZLxlzZCDRu4JLpfS7HKzR+Hw9qRh3bVzDI=
 github.com/transparency-dev/merkle v0.0.2 h1:Q9nBoQcZcgPamMkGn7ghV8XiTZ/kRxn1yCG81+twTK4=
 github.com/transparency-dev/merkle v0.0.2/go.mod h1:pqSy+OXefQ1EDUVmAJ8MUhHB9TXGuzVAT58PqBoHz1A=
-github.com/ubiquiti-community/go-unifi v1.33.43-0.20260609201330-9d5096dc2ca6 h1:64AwQ6vXujWR4gpGePWG8A1BltLJuaXJwBsFZrPKHa0=
-github.com/ubiquiti-community/go-unifi v1.33.43-0.20260609201330-9d5096dc2ca6/go.mod h1:lOld3iJD/7eXE5+phOVWz3Y45qTlb73g24tPipLIkac=
+github.com/ubiquiti-community/go-unifi v1.33.43-0.20260609205204-c32397ea7408 h1:Eoma5bGJ8VW13YUobnYycQlQrbCgfj5rQxA+dyK02B8=
+github.com/ubiquiti-community/go-unifi v1.33.43-0.20260609205204-c32397ea7408/go.mod h1:lOld3iJD/7eXE5+phOVWz3Y45qTlb73g24tPipLIkac=
 github.com/vbatts/tar-split v0.12.2 h1:w/Y6tjxpeiFMR47yzZPlPj/FcPLpXbTUi/9H7d3CPa4=
 github.com/vbatts/tar-split v0.12.2/go.mod h1:eF6B6i6ftWQcDqEn3/iGFRFRo8cBIMSJVOpnNdfTMFA=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=


### PR DESCRIPTION
## Context
Some UniFi controllers return boolean flags such as `dhcpd_enabled` as JSON **strings** (`"true"`/`"false"`). The pinned go-unifi unmarshalled them into a plain Go `bool`, so network import / data-source reads failed with:

```
cannot unmarshal string into Go struct field .dhcpd_enabled of type bool
```

## Changes
Bump go-unifi to include ubiquiti-community/go-unifi#23, which decodes these flags through a tolerant `types.Bool` (accepts both real booleans and string-encoded ones). The same change also covers the client `blocked` flag (may help #132).

## Tests
go-unifi side has a unit test (`stringable_bool_test.go`); `go build`/`go vet` clean here.

Fixes #65.