### PR TITLE
fix(firewall-policy): round-trip firmware fields so zone-based UPDATE doesn't 400

### DIFF
--- a/docs/resources/firewall_policy.md
+++ b/docs/resources/firewall_policy.md
@@ -34,6 +34,9 @@ Manages a UniFi zone-based firewall policy (UniFi Network 8.x+). Zone-based fire
 
 ### Read-Only
 
+- `connection_state_type` (String) Connection-state matching mode (`ALL` or `RESPOND_ONLY`). Managed by the UniFi controller; the provider round-trips it so updates are accepted.
+- `icmp_typename` (String) ICMP type matching mode. Managed by the UniFi controller; the provider round-trips it so updates are accepted.
+- `icmp_v6_typename` (String) ICMPv6 type matching mode. Managed by the UniFi controller; the provider round-trips it so updates are accepted.
 - `id` (String) The ID of the firewall policy.
 
 <a id="nestedatt--destination"></a>
@@ -53,6 +56,10 @@ Optional:
 - `port_group_id` (String) ID of a `unifi_firewall_group` (port-group type) to match. Used when `port_matching_type` is `OBJECT`.
 - `port_matching_type` (String) How to match ports: `ANY`, `SPECIFIC`, or `OBJECT` (port group).
 
+Read-Only:
+
+- `matching_target_type` (String) How the matching target is specified (`ANY`, `SPECIFIC`, `LIST`, `OBJECT`). Managed by the UniFi controller; the provider round-trips it so updates are accepted.
+
 
 <a id="nestedatt--source"></a>
 ### Nested Schema for `source`
@@ -70,3 +77,7 @@ Optional:
 - `port` (Number) Specific port to match. Used when `port_matching_type` is `SPECIFIC`.
 - `port_group_id` (String) ID of a `unifi_firewall_group` (port-group type) to match. Used when `port_matching_type` is `OBJECT`.
 - `port_matching_type` (String) How to match ports: `ANY`, `SPECIFIC`, or `OBJECT` (port group).
+
+Read-Only:
+
+- `matching_target_type` (String) How the matching target is specified (`ANY`, `SPECIFIC`, `LIST`, `OBJECT`). Managed by the UniFi controller; the provider round-trips it so updates are accepted.

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/hashicorp/terraform-plugin-testing v1.16.0
 	github.com/testcontainers/testcontainers-go v0.42.0
 	github.com/testcontainers/testcontainers-go/modules/compose v0.42.0
-	github.com/ubiquiti-community/go-unifi v1.33.43-0.20260609205204-c32397ea7408
+	github.com/ubiquiti-community/go-unifi v1.33.43-0.20260610122329-3b8fa0f63b66
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -528,8 +528,8 @@ github.com/transparency-dev/formats v0.0.0-20251017110053-404c0d5b696c h1:5a2XDQ
 github.com/transparency-dev/formats v0.0.0-20251017110053-404c0d5b696c/go.mod h1:g85IafeFJZLxlzZCDRu4JLpfS7HKzR+Hw9qRh3bVzDI=
 github.com/transparency-dev/merkle v0.0.2 h1:Q9nBoQcZcgPamMkGn7ghV8XiTZ/kRxn1yCG81+twTK4=
 github.com/transparency-dev/merkle v0.0.2/go.mod h1:pqSy+OXefQ1EDUVmAJ8MUhHB9TXGuzVAT58PqBoHz1A=
-github.com/ubiquiti-community/go-unifi v1.33.43-0.20260609205204-c32397ea7408 h1:Eoma5bGJ8VW13YUobnYycQlQrbCgfj5rQxA+dyK02B8=
-github.com/ubiquiti-community/go-unifi v1.33.43-0.20260609205204-c32397ea7408/go.mod h1:lOld3iJD/7eXE5+phOVWz3Y45qTlb73g24tPipLIkac=
+github.com/ubiquiti-community/go-unifi v1.33.43-0.20260610122329-3b8fa0f63b66 h1:bqjWIXNt++BmWs2GC83DOQRgvNZmNQsBTc0jwcJ/QX4=
+github.com/ubiquiti-community/go-unifi v1.33.43-0.20260610122329-3b8fa0f63b66/go.mod h1:lOld3iJD/7eXE5+phOVWz3Y45qTlb73g24tPipLIkac=
 github.com/vbatts/tar-split v0.12.2 h1:w/Y6tjxpeiFMR47yzZPlPj/FcPLpXbTUi/9H7d3CPa4=
 github.com/vbatts/tar-split v0.12.2/go.mod h1:eF6B6i6ftWQcDqEn3/iGFRFRo8cBIMSJVOpnNdfTMFA=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=

--- a/unifi/firewall_policy_resource.go
+++ b/unifi/firewall_policy_resource.go
@@ -49,8 +49,14 @@ type firewallPolicyModel struct {
 	Index              types.Int64  `tfsdk:"index"`
 	CreateAllowRespond types.Bool   `tfsdk:"create_allow_respond"`
 	IPVersion          types.String `tfsdk:"ip_version"`
-	Source             types.Object `tfsdk:"source"`
-	Destination        types.Object `tfsdk:"destination"`
+	// Firmware-managed fields the controller requires back on every PUT. They are
+	// not user-settable; the provider round-trips them so updates don't drop them
+	// (an omitted connection_state_type/icmp_typename makes the PUT fail HTTP 400).
+	ConnectionStateType types.String `tfsdk:"connection_state_type"`
+	ICMPTypename        types.String `tfsdk:"icmp_typename"`
+	ICMPV6Typename      types.String `tfsdk:"icmp_v6_typename"`
+	Source              types.Object `tfsdk:"source"`
+	Destination         types.Object `tfsdk:"destination"`
 }
 
 // firewallPolicyEndpointModel is the nested source/destination block model.
@@ -63,18 +69,22 @@ type firewallPolicyEndpointModel struct {
 	Port             types.Int64  `tfsdk:"port"`
 	PortGroupID      types.String `tfsdk:"port_group_id"`
 	PortMatchingType types.String `tfsdk:"port_matching_type"`
+	// Firmware-managed; round-tripped so updates keep it (a PUT that omits
+	// source/destination matching_target_type is rejected with HTTP 400).
+	MatchingTargetType types.String `tfsdk:"matching_target_type"`
 }
 
 func (m firewallPolicyEndpointModel) AttributeTypes() map[string]attr.Type {
 	return map[string]attr.Type{
-		"zone_id":            types.StringType,
-		"matching_target":    types.StringType,
-		"network_ids":        types.ListType{ElemType: types.StringType},
-		"client_macs":        types.ListType{ElemType: types.StringType},
-		"ips":                types.ListType{ElemType: types.StringType},
-		"port":               types.Int64Type,
-		"port_group_id":      types.StringType,
-		"port_matching_type": types.StringType,
+		"zone_id":              types.StringType,
+		"matching_target":      types.StringType,
+		"network_ids":          types.ListType{ElemType: types.StringType},
+		"client_macs":          types.ListType{ElemType: types.StringType},
+		"ips":                  types.ListType{ElemType: types.StringType},
+		"port":                 types.Int64Type,
+		"port_group_id":        types.StringType,
+		"port_matching_type":   types.StringType,
+		"matching_target_type": types.StringType,
 	}
 }
 
@@ -145,6 +155,13 @@ func (r *firewallPolicyResource) Schema(
 			Default:             stringdefault.StaticString("ANY"),
 			Validators: []validator.String{
 				stringvalidator.OneOf("ANY", "SPECIFIC", "OBJECT"),
+			},
+		},
+		"matching_target_type": schema.StringAttribute{
+			MarkdownDescription: "How the matching target is specified (`ANY`, `SPECIFIC`, `LIST`, `OBJECT`). Managed by the UniFi controller; the provider round-trips it so updates are accepted.",
+			Computed:            true,
+			PlanModifiers: []planmodifier.String{
+				stringplanmodifier.UseStateForUnknown(),
 			},
 		},
 	}
@@ -229,6 +246,27 @@ func (r *firewallPolicyResource) Schema(
 				Default:             stringdefault.StaticString("IPV4"),
 				Validators: []validator.String{
 					stringvalidator.OneOf("BOTH", "IPV4", "IPV6"),
+				},
+			},
+			"connection_state_type": schema.StringAttribute{
+				MarkdownDescription: "Connection-state matching mode (`ALL` or `RESPOND_ONLY`). Managed by the UniFi controller; the provider round-trips it so updates are accepted.",
+				Computed:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"icmp_typename": schema.StringAttribute{
+				MarkdownDescription: "ICMP type matching mode. Managed by the UniFi controller; the provider round-trips it so updates are accepted.",
+				Computed:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"icmp_v6_typename": schema.StringAttribute{
+				MarkdownDescription: "ICMPv6 type matching mode. Managed by the UniFi controller; the provider round-trips it so updates are accepted.",
+				Computed:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
 				},
 			},
 			"source": schema.SingleNestedAttribute{
@@ -435,16 +473,19 @@ func modelToFirewallPolicy(
 	var diags diag.Diagnostics
 
 	fp := &unifi.FirewallPolicy{
-		ID:                 model.ID.ValueString(),
-		Name:               model.Name.ValueString(),
-		Action:             model.Action.ValueString(),
-		Enabled:            model.Enabled.ValueBool(),
-		Protocol:           model.Protocol.ValueString(),
-		Description:        model.Description.ValueString(),
-		Logging:            model.Logging.ValueBool(),
-		CreateAllowRespond: model.CreateAllowRespond.ValueBool(),
-		Version:            model.IPVersion.ValueString(),
-		ConnectionStates:   []string{},
+		ID:                  model.ID.ValueString(),
+		Name:                model.Name.ValueString(),
+		Action:              model.Action.ValueString(),
+		Enabled:             model.Enabled.ValueBool(),
+		Protocol:            model.Protocol.ValueString(),
+		Description:         model.Description.ValueString(),
+		Logging:             model.Logging.ValueBool(),
+		CreateAllowRespond:  model.CreateAllowRespond.ValueBool(),
+		Version:             model.IPVersion.ValueString(),
+		ConnectionStateType: model.ConnectionStateType.ValueString(),
+		ICMPTypename:        model.ICMPTypename.ValueString(),
+		ICMPV6Typename:      model.ICMPV6Typename.ValueString(),
+		ConnectionStates:    []string{},
 		Schedule: &unifi.FirewallPolicySchedule{
 			Mode: "ALWAYS",
 		},
@@ -476,11 +517,12 @@ func endpointModelToSource(
 	diags *diag.Diagnostics,
 ) *unifi.FirewallPolicySource {
 	ep := &unifi.FirewallPolicySource{
-		ZoneID:           m.ZoneID.ValueString(),
-		MatchingTarget:   m.MatchingTarget.ValueString(),
-		Port:             m.Port.ValueInt64Pointer(),
-		PortGroupID:      m.PortGroupID.ValueString(),
-		PortMatchingType: m.PortMatchingType.ValueString(),
+		ZoneID:             m.ZoneID.ValueString(),
+		MatchingTarget:     m.MatchingTarget.ValueString(),
+		MatchingTargetType: m.MatchingTargetType.ValueString(),
+		Port:               m.Port.ValueInt64Pointer(),
+		PortGroupID:        m.PortGroupID.ValueString(),
+		PortMatchingType:   m.PortMatchingType.ValueString(),
 	}
 	if !m.IPs.IsNull() && !m.IPs.IsUnknown() {
 		diags.Append(m.IPs.ElementsAs(ctx, &ep.IPs, false)...)
@@ -494,11 +536,12 @@ func endpointModelToDestination(
 	diags *diag.Diagnostics,
 ) *unifi.FirewallPolicyDestination {
 	ep := &unifi.FirewallPolicyDestination{
-		ZoneID:           m.ZoneID.ValueString(),
-		MatchingTarget:   m.MatchingTarget.ValueString(),
-		Port:             m.Port.ValueInt64Pointer(),
-		PortGroupID:      m.PortGroupID.ValueString(),
-		PortMatchingType: m.PortMatchingType.ValueString(),
+		ZoneID:             m.ZoneID.ValueString(),
+		MatchingTarget:     m.MatchingTarget.ValueString(),
+		MatchingTargetType: m.MatchingTargetType.ValueString(),
+		Port:               m.Port.ValueInt64Pointer(),
+		PortGroupID:        m.PortGroupID.ValueString(),
+		PortMatchingType:   m.PortMatchingType.ValueString(),
 	}
 	if !m.IPs.IsNull() && !m.IPs.IsUnknown() {
 		diags.Append(m.IPs.ElementsAs(ctx, &ep.IPs, false)...)
@@ -522,6 +565,9 @@ func firewallPolicyToModel(
 	model.Logging = types.BoolValue(fp.Logging)
 	model.CreateAllowRespond = types.BoolValue(fp.CreateAllowRespond)
 	model.IPVersion = types.StringValue(fp.Version)
+	model.ConnectionStateType = types.StringValue(fp.ConnectionStateType)
+	model.ICMPTypename = types.StringValue(fp.ICMPTypename)
+	model.ICMPV6Typename = types.StringValue(fp.ICMPV6Typename)
 
 	if fp.Index != nil {
 		model.Index = types.Int64Value(*fp.Index)
@@ -558,11 +604,12 @@ func apiSourceToEndpointModel(
 	diags *diag.Diagnostics,
 ) firewallPolicyEndpointModel {
 	m := firewallPolicyEndpointModel{
-		ZoneID:           types.StringValue(src.ZoneID),
-		MatchingTarget:   types.StringValue(src.MatchingTarget),
-		Port:             types.Int64PointerValue(src.Port),
-		PortGroupID:      types.StringValue(src.PortGroupID),
-		PortMatchingType: types.StringValue(src.PortMatchingType),
+		ZoneID:             types.StringValue(src.ZoneID),
+		MatchingTarget:     types.StringValue(src.MatchingTarget),
+		MatchingTargetType: types.StringValue(src.MatchingTargetType),
+		Port:               types.Int64PointerValue(src.Port),
+		PortGroupID:        types.StringValue(src.PortGroupID),
+		PortMatchingType:   types.StringValue(src.PortMatchingType),
 	}
 	m.NetworkIDs = types.ListNull(types.StringType)
 	m.ClientMACs = types.ListNull(types.StringType)
@@ -580,11 +627,12 @@ func apiDestinationToEndpointModel(
 	diags *diag.Diagnostics,
 ) firewallPolicyEndpointModel {
 	m := firewallPolicyEndpointModel{
-		ZoneID:           types.StringValue(dst.ZoneID),
-		MatchingTarget:   types.StringValue(dst.MatchingTarget),
-		Port:             types.Int64PointerValue(dst.Port),
-		PortGroupID:      types.StringValue(dst.PortGroupID),
-		PortMatchingType: types.StringValue(dst.PortMatchingType),
+		ZoneID:             types.StringValue(dst.ZoneID),
+		MatchingTarget:     types.StringValue(dst.MatchingTarget),
+		MatchingTargetType: types.StringValue(dst.MatchingTargetType),
+		Port:               types.Int64PointerValue(dst.Port),
+		PortGroupID:        types.StringValue(dst.PortGroupID),
+		PortMatchingType:   types.StringValue(dst.PortMatchingType),
 	}
 	m.NetworkIDs = types.ListNull(types.StringType)
 	m.ClientMACs = types.ListNull(types.StringType)

--- a/unifi/firewall_policy_resource_test.go
+++ b/unifi/firewall_policy_resource_test.go
@@ -6,7 +6,10 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/ubiquiti-community/go-unifi/unifi"
 )
+
+func ptrInt64(v int64) *int64 { return &v }
 
 // TestFirewallPolicyEndpointSpecificPort is a unit round-trip for the SPECIFIC
 // port match (#207): a `port` set on a firewall policy endpoint must reach the
@@ -52,5 +55,78 @@ func TestFirewallPolicyEndpointSpecificPort(t *testing.T) {
 	}
 	if dst.PortMatchingType != "SPECIFIC" {
 		t.Errorf("destination PortMatchingType = %q, want SPECIFIC", dst.PortMatchingType)
+	}
+}
+
+// TestFirewallPolicyPreservesFirmwareFields guards #220: the UCG Max firmware
+// rejects a PUT that omits connection_state_type, icmp_typename, icmp_v6_typename
+// or the source/destination matching_target_type. These fields are not
+// user-settable, so the provider round-trips them through state. This test reads
+// an API object into the model and converts it back, asserting nothing is dropped.
+func TestFirewallPolicyPreservesFirmwareFields(t *testing.T) {
+	ctx := context.Background()
+
+	// A policy as the controller returns it, with all firmware-managed fields set.
+	api := &unifi.FirewallPolicy{
+		ID:                  "pol-1",
+		Name:                "allow-vpn-to-nas-snmp",
+		Action:              "ALLOW",
+		Enabled:             true,
+		Protocol:            "all",
+		Version:             "BOTH",
+		ConnectionStateType: "ALL",
+		ICMPTypename:        "ANY",
+		ICMPV6Typename:      "ANY",
+		Source: &unifi.FirewallPolicySource{
+			ZoneID:             "zone-vpn",
+			MatchingTarget:     "IP",
+			MatchingTargetType: "OBJECT",
+		},
+		Destination: &unifi.FirewallPolicyDestination{
+			ZoneID:             "zone-internal",
+			MatchingTarget:     "IP",
+			MatchingTargetType: "OBJECT",
+			PortMatchingType:   "SPECIFIC",
+			Port:               ptrInt64(161),
+		},
+	}
+
+	// Read API -> model (Read/Create response path).
+	var model firewallPolicyModel
+	if diags := firewallPolicyToModel(ctx, api, &model); diags.HasError() {
+		t.Fatalf("firewallPolicyToModel errored: %v", diags)
+	}
+	if model.ConnectionStateType.ValueString() != "ALL" {
+		t.Errorf("ConnectionStateType = %q, want ALL", model.ConnectionStateType.ValueString())
+	}
+	if model.ICMPTypename.ValueString() != "ANY" {
+		t.Errorf("ICMPTypename = %q, want ANY", model.ICMPTypename.ValueString())
+	}
+	if model.ICMPV6Typename.ValueString() != "ANY" {
+		t.Errorf("ICMPV6Typename = %q, want ANY", model.ICMPV6Typename.ValueString())
+	}
+
+	// Convert model -> API (Update PUT path) and assert the fields survive.
+	out, diags := modelToFirewallPolicy(ctx, model)
+	if diags.HasError() {
+		t.Fatalf("modelToFirewallPolicy errored: %v", diags)
+	}
+	if out.ConnectionStateType != "ALL" {
+		t.Errorf("PUT ConnectionStateType = %q, want ALL", out.ConnectionStateType)
+	}
+	if out.ICMPTypename != "ANY" {
+		t.Errorf("PUT ICMPTypename = %q, want ANY", out.ICMPTypename)
+	}
+	if out.ICMPV6Typename != "ANY" {
+		t.Errorf("PUT ICMPV6Typename = %q, want ANY", out.ICMPV6Typename)
+	}
+	if out.Source == nil || out.Source.MatchingTargetType != "OBJECT" {
+		t.Errorf("PUT source MatchingTargetType not preserved: %+v", out.Source)
+	}
+	if out.Destination == nil || out.Destination.MatchingTargetType != "OBJECT" {
+		t.Errorf("PUT destination MatchingTargetType not preserved: %+v", out.Destination)
+	}
+	if out.Destination == nil || out.Destination.Port == nil || *out.Destination.Port != 161 {
+		t.Errorf("PUT destination Port not preserved: %+v", out.Destination)
 	}
 }


### PR DESCRIPTION
## Problem

`unifi_firewall_policy` (zone-based, UniFi Network 8.x+) can be **created** and **imported**, but any **update** fails with HTTP 400 on the `PUT` to the v2 firewall API (reported on **UCG Max**, UniFi OS 5.1.x / Network 10.4.x — #220, #221).

Two root causes (diagnosed in #220):

1. **Required fields omitted** by the update payload — the firmware rejects the `PUT` unless `connection_state_type`, `icmp_typename`, `icmp_v6_typename` and the source/destination `matching_target_type` are present. The provider didn't manage these, so updates dropped them.
2. **`port` sent as an int** — the firmware expects a string. *(Fixed upstream in go-unifi — see dependency below.)*

## Fix (this PR)

Adds the four firmware-managed fields as **computed, controller-managed** attributes that round-trip through state (read on Create/Read, sent back on Update). They are not user-settable. This makes updates preserve exactly what the controller assigned, fixing the HTTP 400.

- `connection_state_type`, `icmp_typename`, `icmp_v6_typename` (top level)
- `source.matching_target_type`, `destination.matching_target_type`

New unit test `TestFirewallPolicyPreservesFirmwareFields` guards the round-trip (model → API → model). Build, vet, gofmt and the `./unifi/` suite are green.

## ⚠️ Dependency

The port-as-string half of #220/#221 lives in **ubiquiti-community/go-unifi#26**. This PR's code compiles against the current go-unifi, but the port fix only takes effect once that PR merges and the `go-unifi` dependency is bumped here. **The go.mod bump is intentionally left out until go-unifi#26 merges**, then it will be added.

## Validation

Zone-based firewall is not exercisable on the dockerized acceptance controller (no gateway), so this is covered by unit tests + manual validation against a real UCG Max as described in #220. Final end-to-end validation should be done on a real controller.

Fixes #221. Addresses the update path of #220.