### PR TITLE
feat(radius-user): support moving deprecated unifi_account in place

### DIFF
--- a/unifi/radius_user_move_state.go
+++ b/unifi/radius_user_move_state.go
@@ -1,0 +1,69 @@
+package unifi
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+)
+
+// Ensure unifi_radius_user advertises move support so practitioners can migrate
+// a deprecated unifi_account resource with a `moved` block.
+var _ resource.ResourceWithMoveState = &radiusUserResource{}
+
+// MoveState lets practitioners migrate the deprecated `unifi_account` resource to
+// `unifi_radius_user` in place (via a `moved` block) instead of destroy/recreate.
+//
+//	moved {
+//	  from = unifi_account.example
+//	  to   = unifi_radius_user.example
+//	}
+//
+// `unifi_account` is a deprecated alias backed by the same model and schema as
+// this resource (see account_deprecated.go), so the source state can be copied
+// across verbatim. We declare the source schema so the framework decodes it into
+// MoveStateRequest.SourceState for us.
+func (r *radiusUserResource) MoveState(ctx context.Context) []resource.StateMover {
+	schemaResp := &resource.SchemaResponse{}
+	r.Schema(ctx, resource.SchemaRequest{}, schemaResp)
+
+	return []resource.StateMover{
+		{
+			SourceSchema: &schemaResp.Schema,
+			StateMover:   r.moveFromAccount,
+		},
+	}
+}
+
+// moveFromAccount handles a move originating from this provider's unifi_account.
+// It is deliberately conservative: if the source provider, type or schema version
+// is anything else, it returns without state so the framework treats this mover
+// as skipped (and reports "implementation not found" rather than a bad move).
+func (r *radiusUserResource) moveFromAccount(
+	ctx context.Context,
+	req resource.MoveStateRequest,
+	resp *resource.MoveStateResponse,
+) {
+	if req.SourceTypeName != "unifi_account" {
+		return
+	}
+	// Ignore the hostname (registry.terraform.io vs registry.opentofu.org) and
+	// match on namespace/type only.
+	if !strings.HasSuffix(req.SourceProviderAddress, "ubiquiti-community/unifi") {
+		return
+	}
+	if req.SourceSchemaVersion != 0 {
+		return
+	}
+	if req.SourceState == nil {
+		return
+	}
+
+	var data radiusUserResourceModel
+	resp.Diagnostics.Append(req.SourceState.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resp.Diagnostics.Append(resp.TargetState.Set(ctx, &data)...)
+}

--- a/unifi/radius_user_resource_test.go
+++ b/unifi/radius_user_resource_test.go
@@ -147,7 +147,11 @@ func TestAccRadiusUser_moveFromAccount(t *testing.T) {
 			{
 				Config: testAccRadiusUserConfig_radiusUserAfterMove(),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("unifi_radius_user.move", "name", "move-account"),
+					resource.TestCheckResourceAttr(
+						"unifi_radius_user.move",
+						"name",
+						"move-account",
+					),
 					resource.TestCheckResourceAttrPtr("unifi_radius_user.move", "id", &accountID),
 				),
 			},

--- a/unifi/radius_user_resource_test.go
+++ b/unifi/radius_user_resource_test.go
@@ -1,9 +1,11 @@
 package unifi
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 func TestAccRadiusUser_basic(t *testing.T) {
@@ -120,4 +122,74 @@ resource "unifi_radius_user" "tt13" {
 	tunnel_type = 13
 }
 `
+}
+
+// TestAccRadiusUser_moveFromAccount exercises the ResourceWithMoveState support
+// (#222): a deprecated unifi_account can be migrated to unifi_radius_user with a
+// `moved` block, in place. The move is proven by the target keeping the source's
+// ID — a destroy/recreate would assign a new one.
+func TestAccRadiusUser_moveFromAccount(t *testing.T) {
+	var accountID string
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { preCheck(t) },
+		ProtoV6ProviderFactories: providerFactories,
+		Steps: []resource.TestStep{
+			// Create the deprecated resource and capture its ID.
+			{
+				Config: testAccRadiusUserConfig_accountForMove(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("unifi_account.move", "name", "move-account"),
+					testAccCaptureResourceID("unifi_account.move", &accountID),
+				),
+			},
+			// Move it to unifi_radius_user; the underlying object (ID) must survive.
+			{
+				Config: testAccRadiusUserConfig_radiusUserAfterMove(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("unifi_radius_user.move", "name", "move-account"),
+					resource.TestCheckResourceAttrPtr("unifi_radius_user.move", "id", &accountID),
+				),
+			},
+		},
+	})
+}
+
+func testAccRadiusUserConfig_accountForMove() string {
+	return `
+resource "unifi_account" "move" {
+	name     = "move-account"
+	password = "move-password"
+}
+`
+}
+
+func testAccRadiusUserConfig_radiusUserAfterMove() string {
+	return `
+resource "unifi_radius_user" "move" {
+	name     = "move-account"
+	password = "move-password"
+}
+
+moved {
+	from = unifi_account.move
+	to   = unifi_radius_user.move
+}
+`
+}
+
+// testAccCaptureResourceID stores the primary ID of a resource into dst so a
+// later step can assert it is unchanged.
+func testAccCaptureResourceID(name string, dst *string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("resource not found: %s", name)
+		}
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("resource %s has no ID set", name)
+		}
+		*dst = rs.Primary.ID
+		return nil
+	}
 }


### PR DESCRIPTION
## Problem

Migrating a deprecated `unifi_account` to `unifi_radius_user` with a `moved` block fails (#222):

```
Error: Unable to Move Resource State
The target resource implementation does not include move resource state support.
Source Resource Type: unifi_account
Target Resource Type: unifi_radius_user
```

Users are forced to destroy/recreate (losing the RADIUS account) or hand-edit state, even though `unifi_account` is just a deprecated alias of `unifi_radius_user`.

## Fix

Implement `resource.ResourceWithMoveState` on `unifi_radius_user`. Since `unifi_account` is backed by the **same model and schema** (see `account_deprecated.go`), the mover declares that schema so the framework decodes `SourceState`, then copies it across verbatim.

```hcl
moved {
  from = unifi_account.example
  to   = unifi_radius_user.example
}
```

The mover is deliberately conservative — it only matches this provider's `unifi_account` at schema version 0 (ignoring the registry hostname so it works on both Terraform and OpenTofu) and skips otherwise, so unsupported moves get a clear framework error rather than a bad copy.

## Tests

`TestAccRadiusUser_moveFromAccount`: creates `unifi_account`, captures its ID, moves to `unifi_radius_user` via a `moved` block, and asserts the target keeps the **same ID** — a destroy/recreate would assign a new one.

Build, vet, gofmt, `go generate` (no schema diff) and the unit suite are green. The acceptance test runs against the dockerized controller on the daily/release acctest workflow (RADIUS accounts need no gateway); it can't run on PR CI, which skips `TF_ACC`.

Fixes #222.