### PR TITLE
fix(device): write op_mode so SFP+ link aggregation (LAG) actually forms

### DIFF
--- a/docs/resources/device.md
+++ b/docs/resources/device.md
@@ -144,7 +144,7 @@ Required:
 
 Optional:
 
-- `aggregate_members` (List of Number) Number of ports in the aggregate.
+- `aggregate_members` (List of Number) Port indices that make up this link-aggregation (LAG) group. Only takes effect when `op_mode` is `aggregate` on this port.
 - `autoneg` (Boolean) Enable auto-negotiation for port speed.
 - `dot1x_ctrl` (String) 802.1X control mode.
 - `dot1x_idle_timeout` (Number) 802.1X idle timeout in seconds.
@@ -162,7 +162,7 @@ Optional:
 - `multicast_router_networkconf_ids` (List of String) List of network IDs for multicast router.
 - `name` (String) Human-readable name of the port.
 - `native_networkconf_id` (String) Native network ID (VLAN).
-- `op_mode` (String) Operating mode of the port, valid values are `switch`, `mirror`, and `aggregate`.
+- `op_mode` (String) Operating mode of the port: `switch` (default), `mirror`, or `aggregate`. Set `aggregate` on the lead port of an SFP+/link-aggregation (LAG) group and list the member ports in `aggregate_members`. Only written when not `switch`, as gateway devices (UDM) reject op_mode on update.
 - `poe_mode` (String) PoE mode of the port; valid values are `auto`, `pasv24`, `passthrough`, and `off`.
 - `port_keepalive_enabled` (Boolean) Enable port keepalive.
 - `port_profile_id` (String) ID of the Port Profile used on this port.

--- a/unifi/device_port_override_test.go
+++ b/unifi/device_port_override_test.go
@@ -1,0 +1,111 @@
+package unifi
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+)
+
+// nullPortOverrideAttrValues returns every port-override attribute set to its
+// typed null, so a test only has to override the few fields it cares about.
+func nullPortOverrideAttrValues() map[string]attr.Value {
+	attrs := portOverrideAttrTypes()
+	vals := make(map[string]attr.Value, len(attrs))
+	for name, t := range attrs {
+		switch tt := t.(type) {
+		case basetypes.StringType:
+			vals[name] = types.StringNull()
+		case basetypes.Int64Type:
+			vals[name] = types.Int64Null()
+		case basetypes.BoolType:
+			vals[name] = types.BoolNull()
+		case basetypes.ListType:
+			vals[name] = types.ListNull(tt.ElemType)
+		}
+		// Any unhandled attr type is intentionally left out so ObjectValue fails
+		// loudly (signalling the helper needs updating) rather than silently.
+	}
+	return vals
+}
+
+func portOverrideSetWith(t *testing.T, overrides map[string]attr.Value) types.Set {
+	t.Helper()
+	attrs := nullPortOverrideAttrValues()
+	for k, v := range overrides {
+		attrs[k] = v
+	}
+	obj, d := types.ObjectValue(portOverrideAttrTypes(), attrs)
+	if d.HasError() {
+		t.Fatalf("building port override object: %v", d)
+	}
+	set, d := types.SetValue(types.ObjectType{AttrTypes: portOverrideAttrTypes()}, []attr.Value{obj})
+	if d.HasError() {
+		t.Fatalf("building port override set: %v", d)
+	}
+	return set
+}
+
+// TestFrameworkToPortOverrides_AggregateOpMode guards #177: to form an SFP+ link
+// aggregation the port's op_mode must be written as "aggregate" alongside the
+// aggregate_members. op_mode is otherwise skipped (default "switch") so gateway
+// devices that reject op_mode on PUT keep working (#213).
+func TestFrameworkToPortOverrides_AggregateOpMode(t *testing.T) {
+	ctx := context.Background()
+	r := &deviceResource{}
+
+	members, d := types.ListValue(types.Int64Type, []attr.Value{
+		types.Int64Value(9),
+		types.Int64Value(10),
+	})
+	if d.HasError() {
+		t.Fatalf("building members list: %v", d)
+	}
+
+	set := portOverrideSetWith(t, map[string]attr.Value{
+		"index":             types.Int64Value(9),
+		"op_mode":           types.StringValue("aggregate"),
+		"aggregate_members": members,
+	})
+
+	pos, diags := r.frameworkToPortOverrides(ctx, set)
+	if diags.HasError() {
+		t.Fatalf("frameworkToPortOverrides errored: %v", diags)
+	}
+	if len(pos) != 1 {
+		t.Fatalf("got %d port overrides, want 1", len(pos))
+	}
+	po := pos[0]
+	if po.OpMode != "aggregate" {
+		t.Errorf("OpMode = %q, want aggregate (LAG would not engage)", po.OpMode)
+	}
+	if len(po.AggregateMembers) != 2 || po.AggregateMembers[0] != 9 || po.AggregateMembers[1] != 10 {
+		t.Errorf("AggregateMembers = %v, want [9 10]", po.AggregateMembers)
+	}
+}
+
+// TestFrameworkToPortOverrides_SwitchOpModeOmitted ensures the default "switch"
+// op_mode is not sent on the wire (it has omitempty), preserving the gateway
+// write fix (#213).
+func TestFrameworkToPortOverrides_SwitchOpModeOmitted(t *testing.T) {
+	ctx := context.Background()
+	r := &deviceResource{}
+
+	set := portOverrideSetWith(t, map[string]attr.Value{
+		"index":   types.Int64Value(1),
+		"op_mode": types.StringValue("switch"),
+	})
+
+	pos, diags := r.frameworkToPortOverrides(ctx, set)
+	if diags.HasError() {
+		t.Fatalf("frameworkToPortOverrides errored: %v", diags)
+	}
+	if len(pos) != 1 {
+		t.Fatalf("got %d port overrides, want 1", len(pos))
+	}
+	if pos[0].OpMode != "" {
+		t.Errorf("OpMode = %q, want empty (omitted) for the switch default", pos[0].OpMode)
+	}
+}

--- a/unifi/device_port_override_test.go
+++ b/unifi/device_port_override_test.go
@@ -41,7 +41,10 @@ func portOverrideSetWith(t *testing.T, overrides map[string]attr.Value) types.Se
 	if d.HasError() {
 		t.Fatalf("building port override object: %v", d)
 	}
-	set, d := types.SetValue(types.ObjectType{AttrTypes: portOverrideAttrTypes()}, []attr.Value{obj})
+	set, d := types.SetValue(
+		types.ObjectType{AttrTypes: portOverrideAttrTypes()},
+		[]attr.Value{obj},
+	)
 	if d.HasError() {
 		t.Fatalf("building port override set: %v", d)
 	}
@@ -81,7 +84,8 @@ func TestFrameworkToPortOverrides_AggregateOpMode(t *testing.T) {
 	if po.OpMode != "aggregate" {
 		t.Errorf("OpMode = %q, want aggregate (LAG would not engage)", po.OpMode)
 	}
-	if len(po.AggregateMembers) != 2 || po.AggregateMembers[0] != 9 || po.AggregateMembers[1] != 10 {
+	if len(po.AggregateMembers) != 2 || po.AggregateMembers[0] != 9 ||
+		po.AggregateMembers[1] != 10 {
 		t.Errorf("AggregateMembers = %v, want [9 10]", po.AggregateMembers)
 	}
 }

--- a/unifi/device_resource.go
+++ b/unifi/device_resource.go
@@ -645,10 +645,12 @@ func (r *deviceResource) Schema(
 							Optional:    true,
 						},
 						"op_mode": schema.StringAttribute{
-							Description: "Operating mode of the port, valid values are `switch`, `mirror`, and `aggregate`.",
-							Optional:    true,
-							Computed:    true,
-							Default:     stringdefault.StaticString("switch"),
+							Description: "Operating mode of the port: `switch` (default), `mirror`, or `aggregate`. " +
+								"Set `aggregate` on the lead port of an SFP+/link-aggregation (LAG) group and list the member ports in `aggregate_members`. " +
+								"Only written when not `switch`, as gateway devices (UDM) reject op_mode on update.",
+							Optional: true,
+							Computed: true,
+							Default:  stringdefault.StaticString("switch"),
 							Validators: []validator.String{
 								stringvalidator.OneOf("switch", "mirror", "aggregate"),
 							},
@@ -661,7 +663,8 @@ func (r *deviceResource) Schema(
 							},
 						},
 						"aggregate_members": schema.ListAttribute{
-							Description: "Number of ports in the aggregate.",
+							Description: "Port indices that make up this link-aggregation (LAG) group. " +
+								"Only takes effect when `op_mode` is `aggregate` on this port.",
 							Optional:    true,
 							ElementType: types.Int64Type,
 						},
@@ -2082,9 +2085,17 @@ func (r *deviceResource) frameworkToPortOverrides(
 			if !model.PortProfileID.IsNull() {
 				po.PortProfileID = model.PortProfileID.ValueString()
 			}
-			// op_mode is intentionally not written: the API returns it on GET
-			// but rejects it on PUT for gateway devices. Switches work fine
-			// without it as the controller preserves the existing value.
+			// op_mode is only written when the port runs in a non-default mode
+			// (aggregate/mirror). Sending op_mode on a PUT for gateway devices
+			// (UDM) is rejected — see #213 — but those ports never use
+			// aggregate/mirror, so they stay at the "switch" default and we skip
+			// it. Writing it for the non-default cases is required to form an
+			// SFP+ link aggregation (#177), which otherwise never engages because
+			// aggregate_members is sent without ever switching op_mode.
+			if !model.OpMode.IsNull() && !model.OpMode.IsUnknown() &&
+				model.OpMode.ValueString() != "" && model.OpMode.ValueString() != "switch" {
+				po.OpMode = model.OpMode.ValueString()
+			}
 			if !model.PoeMode.IsNull() {
 				po.PoeMode = model.PoeMode.ValueString()
 			}


### PR DESCRIPTION
## Problem

`unifi_device` exposes `port_override.aggregate_members` and serializes it, but the port's `op_mode` was **never written** — it is intentionally skipped because gateway devices (UDM) reject `op_mode` on a PUT (#213).

The result: setting `op_mode = "aggregate"` + `aggregate_members` sent the members but never switched the port into aggregate mode, so the SFP+ LAG never engaged. This is the remaining half of #177 (the `state:0` write failure was already fixed in #213).

## Fix

Write `op_mode` only when it is **not** the default `switch` (i.e. `aggregate` or `mirror`):

- Gateway/UDM ports never use aggregate/mirror, so they stay at `switch` and `op_mode` is still skipped — the #213 write fix is preserved.
- Switches can now form an SFP+ aggregation by setting `op_mode = "aggregate"` with the member ports in `aggregate_members`.

`op_mode` has `omitempty` in go-unifi, so the skipped (`switch`) case sends nothing and the controller preserves the existing value.

## Tests

New unit tests on `frameworkToPortOverrides`:
- `TestFrameworkToPortOverrides_AggregateOpMode` — `op_mode` and `aggregate_members` reach the API struct.
- `TestFrameworkToPortOverrides_SwitchOpModeOmitted` — the `switch` default is omitted (guards the #213 gateway path).

Build, vet, gofmt, `go generate` (docs updated) and the unit suite are green. Device/port acceptance tests run against the dockerized controller on the daily/release acctest workflow; final LAG validation should be done on real hardware with SFP+ ports.

Addresses the remaining `aggregate_members` part of #177.