### PR TITLE
feat(radius-user): derive vlan from network_id for MAB VLAN assignment

### DIFF
--- a/docs/resources/account.md
+++ b/docs/resources/account.md
@@ -32,12 +32,12 @@ NOTE: MAC-based authentication accounts can only be used for wireless and wired 
 
 ### Optional
 
-- `network_id` (String) ID of the network for this account
+- `network_id` (String) ID of the network for this account. When set and `vlan` is omitted, the account inherits that network's VLAN (so RADIUS/MAB VLAN assignment is applied).
 - `site` (String) The name of the site to associate the account with.
 - `tunnel_config_type` (String) The tunnel configuration type. Can be `vpn`, `802.1x`, or `custom`.
 - `tunnel_medium_type` (Number) See [RFC 2868](https://www.rfc-editor.org/rfc/rfc2868) section 3.2
 - `tunnel_type` (Number) See [RFC 2868](https://www.rfc-editor.org/rfc/rfc2868) section 3.1. Valid values are 1-13; `13` (VLAN) is the most common.
-- `vlan` (Number) VLAN assigned to the account. If unset, the client falls back to the untagged VLAN.
+- `vlan` (Number) VLAN assigned to the account. If omitted but `network_id` is set, it is derived from that network's VLAN. If neither is set, the client falls back to the untagged VLAN.
 
 ### Read-Only
 

--- a/docs/resources/radius_user.md
+++ b/docs/resources/radius_user.md
@@ -32,12 +32,12 @@ NOTE: MAC-based authentication accounts can only be used for wireless and wired 
 
 ### Optional
 
-- `network_id` (String) ID of the network for this account
+- `network_id` (String) ID of the network for this account. When set and `vlan` is omitted, the account inherits that network's VLAN (so RADIUS/MAB VLAN assignment is applied).
 - `site` (String) The name of the site to associate the account with.
 - `tunnel_config_type` (String) The tunnel configuration type. Can be `vpn`, `802.1x`, or `custom`.
 - `tunnel_medium_type` (Number) See [RFC 2868](https://www.rfc-editor.org/rfc/rfc2868) section 3.2
 - `tunnel_type` (Number) See [RFC 2868](https://www.rfc-editor.org/rfc/rfc2868) section 3.1. Valid values are 1-13; `13` (VLAN) is the most common.
-- `vlan` (Number) VLAN assigned to the account. If unset, the client falls back to the untagged VLAN.
+- `vlan` (Number) VLAN assigned to the account. If omitted but `network_id` is set, it is derived from that network's VLAN. If neither is set, the client falls back to the untagged VLAN.
 
 ### Read-Only
 

--- a/unifi/radius_user_resource.go
+++ b/unifi/radius_user_resource.go
@@ -7,10 +7,12 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -115,14 +117,18 @@ NOTE: MAC-based authentication accounts can only be used for wireless and wired 
 				},
 			},
 			"network_id": schema.StringAttribute{
-				MarkdownDescription: "ID of the network for this account",
+				MarkdownDescription: "ID of the network for this account. When set and `vlan` is omitted, the account inherits that network's VLAN (so RADIUS/MAB VLAN assignment is applied).",
 				Optional:            true,
 			},
 			"vlan": schema.Int64Attribute{
-				MarkdownDescription: "VLAN assigned to the account. If unset, the client falls back to the untagged VLAN.",
+				MarkdownDescription: "VLAN assigned to the account. If omitted but `network_id` is set, it is derived from that network's VLAN. If neither is set, the client falls back to the untagged VLAN.",
 				Optional:            true,
+				Computed:            true,
 				Validators: []validator.Int64{
 					int64validator.Between(2, 4009),
+				},
+				PlanModifiers: []planmodifier.Int64{
+					int64planmodifier.UseStateForUnknown(),
 				},
 			},
 			"tunnel_config_type": schema.StringAttribute{
@@ -180,6 +186,14 @@ func (r *radiusUserResource) Create(
 	if site == "" {
 		site = r.client.Site
 	}
+
+	// Derive the VLAN from network_id when not set explicitly (#67).
+	vlan, vlanDiags := r.resolveVLAN(ctx, &data, site)
+	resp.Diagnostics.Append(vlanDiags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	account.VLAN = vlan
 
 	// Create the account
 	createdAccount, err := r.client.CreateAccount(ctx, site, account)
@@ -268,6 +282,14 @@ func (r *radiusUserResource) Update(
 	// Step 3: Convert the updated state to API format
 	account := r.modelToRadiusUser(ctx, &state)
 	account.ID = state.ID.ValueString()
+
+	// Derive the VLAN from network_id when not set explicitly (#67).
+	vlan, vlanDiags := r.resolveVLAN(ctx, &state, site)
+	resp.Diagnostics.Append(vlanDiags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	account.VLAN = vlan
 
 	// Step 4: Send to API
 	updatedAccount, err := r.client.UpdateAccount(ctx, site, account)
@@ -400,6 +422,44 @@ func (r *radiusUserResource) modelToRadiusUser(
 	}
 
 	return account
+}
+
+// resolveVLAN determines the VLAN to assign to the account. An explicit `vlan`
+// always wins. Otherwise, when `network_id` is set, the account inherits that
+// network's VLAN — the controller leaves the account `vlan` blank when only
+// networkconf_id is sent, so RADIUS/MAB VLAN assignment never applies (#67).
+// Returns nil when neither yields a VLAN (client falls back to the untagged VLAN).
+//
+// Note: because `vlan` is computed and stable, changing `network_id` later does
+// not re-derive the VLAN on its own; set `vlan` explicitly (or clear it) to
+// force a refresh.
+func (r *radiusUserResource) resolveVLAN(
+	ctx context.Context,
+	model *radiusUserResourceModel,
+	site string,
+) (*int64, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	if !model.VLAN.IsNull() && !model.VLAN.IsUnknown() {
+		return model.VLAN.ValueInt64Pointer(), diags
+	}
+
+	networkID := model.NetworkID.ValueString()
+	if model.NetworkID.IsNull() || networkID == "" {
+		return nil, diags
+	}
+
+	network, err := r.client.GetNetwork(ctx, site, networkID)
+	if err != nil {
+		diags.AddError(
+			"Error Deriving VLAN from network_id",
+			"Could not look up network "+networkID+
+				" to derive the account VLAN: "+err.Error(),
+		)
+		return nil, diags
+	}
+
+	return network.VLAN, diags
 }
 
 // radiusUserToModel converts the API struct to the Terraform model.

--- a/unifi/radius_user_vlan_test.go
+++ b/unifi/radius_user_vlan_test.go
@@ -1,0 +1,60 @@
+package unifi
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// TestResolveVLAN_DeterministicBranches covers the paths of resolveVLAN that do
+// not touch the controller (#67): an explicit vlan is returned as-is, and with
+// neither vlan nor network_id the result is nil (untagged fallback). The
+// network_id-derivation branch calls GetNetwork and is exercised by acceptance
+// tests against a real controller.
+func TestResolveVLAN_DeterministicBranches(t *testing.T) {
+	ctx := context.Background()
+	r := &radiusUserResource{} // client is nil; these branches never use it
+
+	t.Run("explicit vlan wins", func(t *testing.T) {
+		model := &radiusUserResourceModel{
+			VLAN:      types.Int64Value(100),
+			NetworkID: types.StringValue("net-abc"), // ignored when vlan is set
+		}
+		vlan, diags := r.resolveVLAN(ctx, model, "default")
+		if diags.HasError() {
+			t.Fatalf("unexpected diags: %v", diags)
+		}
+		if vlan == nil || *vlan != 100 {
+			t.Fatalf("vlan = %v, want 100", vlan)
+		}
+	})
+
+	t.Run("no vlan and no network_id yields nil", func(t *testing.T) {
+		model := &radiusUserResourceModel{
+			VLAN:      types.Int64Null(),
+			NetworkID: types.StringNull(),
+		}
+		vlan, diags := r.resolveVLAN(ctx, model, "default")
+		if diags.HasError() {
+			t.Fatalf("unexpected diags: %v", diags)
+		}
+		if vlan != nil {
+			t.Fatalf("vlan = %v, want nil", *vlan)
+		}
+	})
+
+	t.Run("empty network_id string yields nil", func(t *testing.T) {
+		model := &radiusUserResourceModel{
+			VLAN:      types.Int64Null(),
+			NetworkID: types.StringValue(""),
+		}
+		vlan, diags := r.resolveVLAN(ctx, model, "default")
+		if diags.HasError() {
+			t.Fatalf("unexpected diags: %v", diags)
+		}
+		if vlan != nil {
+			t.Fatalf("vlan = %v, want nil", *vlan)
+		}
+	})
+}


### PR DESCRIPTION
## Problem

Setting only `network_id` on a `unifi_account`/`unifi_radius_user` stores the account with `networkconf_id` but leaves `vlan` blank, so RADIUS/MAB VLAN assignment is never applied and the UI shows no VLAN (#67).

## Fix

When `vlan` is omitted but `network_id` is set, resolve the VLAN from the referenced network (`GetNetwork`) and send it on create/update — so `network_id` alone is enough to assign a VLAN. An explicit `vlan` always wins.

`vlan` becomes `Optional + Computed` so the derived value can be stored in state.

### Limitation

Because `vlan` is computed and stable, changing `network_id` later does not re-derive the VLAN on its own; set `vlan` explicitly (or clear it) to force a refresh. Documented on the attribute.

## Tests

Unit tests cover the deterministic branches (explicit vlan wins; no vlan + no network_id → untagged fallback). The `GetNetwork` derivation path needs a live controller (the dockerized harness has no gateway), so it should be confirmed on real hardware — this is a **best-effort** fix per the issue triage.

Build, vet, gofmt/golines, `go generate` (docs updated) and the unit suite are green.

Addresses #67.