### PR TITLE
fix(firewall-policy): round-trip connection_states so CUSTOM policies update

### DIFF
--- a/docs/resources/firewall_policy.md
+++ b/docs/resources/firewall_policy.md
@@ -34,7 +34,8 @@ Manages a UniFi zone-based firewall policy (UniFi Network 8.x+). Zone-based fire
 
 ### Read-Only
 
-- `connection_state_type` (String) Connection-state matching mode (`ALL` or `RESPOND_ONLY`). Managed by the UniFi controller; the provider round-trips it so updates are accepted.
+- `connection_state_type` (String) Connection-state matching mode (`ALL`, `RESPOND_ONLY`, or `CUSTOM`). Managed by the UniFi controller; the provider round-trips it so updates are accepted.
+- `connection_states` (List of String) Connection states matched when `connection_state_type` is `CUSTOM` (e.g. `NEW`, `ESTABLISHED`, `RELATED`, `INVALID`). Managed by the UniFi controller; the provider round-trips it so a `CUSTOM` policy's states are not dropped on update (which the firmware rejects with HTTP 400).
 - `icmp_typename` (String) ICMP type matching mode. Managed by the UniFi controller; the provider round-trips it so updates are accepted.
 - `icmp_v6_typename` (String) ICMPv6 type matching mode. Managed by the UniFi controller; the provider round-trips it so updates are accepted.
 - `id` (String) The ID of the firewall policy.

--- a/unifi/firewall_policy_resource.go
+++ b/unifi/firewall_policy_resource.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
@@ -53,6 +54,7 @@ type firewallPolicyModel struct {
 	// not user-settable; the provider round-trips them so updates don't drop them
 	// (an omitted connection_state_type/icmp_typename makes the PUT fail HTTP 400).
 	ConnectionStateType types.String `tfsdk:"connection_state_type"`
+	ConnectionStates    types.List   `tfsdk:"connection_states"`
 	ICMPTypename        types.String `tfsdk:"icmp_typename"`
 	ICMPV6Typename      types.String `tfsdk:"icmp_v6_typename"`
 	Source              types.Object `tfsdk:"source"`
@@ -249,10 +251,18 @@ func (r *firewallPolicyResource) Schema(
 				},
 			},
 			"connection_state_type": schema.StringAttribute{
-				MarkdownDescription: "Connection-state matching mode (`ALL` or `RESPOND_ONLY`). Managed by the UniFi controller; the provider round-trips it so updates are accepted.",
+				MarkdownDescription: "Connection-state matching mode (`ALL`, `RESPOND_ONLY`, or `CUSTOM`). Managed by the UniFi controller; the provider round-trips it so updates are accepted.",
 				Computed:            true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"connection_states": schema.ListAttribute{
+				MarkdownDescription: "Connection states matched when `connection_state_type` is `CUSTOM` (e.g. `NEW`, `ESTABLISHED`, `RELATED`, `INVALID`). Managed by the UniFi controller; the provider round-trips it so a `CUSTOM` policy's states are not dropped on update (which the firmware rejects with HTTP 400).",
+				ElementType:         types.StringType,
+				Computed:            true,
+				PlanModifiers: []planmodifier.List{
+					listplanmodifier.UseStateForUnknown(),
 				},
 			},
 			"icmp_typename": schema.StringAttribute{
@@ -491,6 +501,12 @@ func modelToFirewallPolicy(
 		},
 	}
 
+	// Round-trip the connection states (e.g. ["NEW"]) the controller reported.
+	// Omitting them makes a CUSTOM-state policy's PUT fail with HTTP 400 (#227).
+	if !model.ConnectionStates.IsNull() && !model.ConnectionStates.IsUnknown() {
+		diags.Append(model.ConnectionStates.ElementsAs(ctx, &fp.ConnectionStates, false)...)
+	}
+
 	if !model.Index.IsNull() && !model.Index.IsUnknown() {
 		idx := model.Index.ValueInt64()
 		fp.Index = &idx
@@ -566,6 +582,9 @@ func firewallPolicyToModel(
 	model.CreateAllowRespond = types.BoolValue(fp.CreateAllowRespond)
 	model.IPVersion = types.StringValue(fp.Version)
 	model.ConnectionStateType = types.StringValue(fp.ConnectionStateType)
+	connStates, csDiags := types.ListValueFrom(ctx, types.StringType, fp.ConnectionStates)
+	diags.Append(csDiags...)
+	model.ConnectionStates = connStates
 	model.ICMPTypename = types.StringValue(fp.ICMPTypename)
 	model.ICMPV6Typename = types.StringValue(fp.ICMPV6Typename)
 

--- a/unifi/firewall_policy_resource_test.go
+++ b/unifi/firewall_policy_resource_test.go
@@ -130,3 +130,41 @@ func TestFirewallPolicyPreservesFirmwareFields(t *testing.T) {
 		t.Errorf("PUT destination Port not preserved: %+v", out.Destination)
 	}
 }
+
+// TestFirewallPolicyConnectionStatesRoundTrip guards #227: a policy whose
+// connection_state_type is CUSTOM must round-trip its connection_states. The
+// model->API conversion previously hard-coded an empty slice, so updates sent
+// "connection_states": [] and the firmware rejected CUSTOM policies (HTTP 400).
+func TestFirewallPolicyConnectionStatesRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	fp := &unifi.FirewallPolicy{
+		ID:                  "p1",
+		Name:                "deny-vpn-to-lan",
+		Action:              "BLOCK",
+		Protocol:            "all",
+		ConnectionStateType: "CUSTOM",
+		ConnectionStates:    []string{"NEW", "ESTABLISHED"},
+		Source:              &unifi.FirewallPolicySource{ZoneID: "z1", MatchingTarget: "ANY", PortMatchingType: "ANY"},
+		Destination:         &unifi.FirewallPolicyDestination{ZoneID: "z2", MatchingTarget: "ANY", PortMatchingType: "ANY"},
+	}
+
+	var model firewallPolicyModel
+	if d := firewallPolicyToModel(ctx, fp, &model); d.HasError() {
+		t.Fatalf("firewallPolicyToModel: %v", d)
+	}
+	var states []string
+	if d := model.ConnectionStates.ElementsAs(ctx, &states, false); d.HasError() {
+		t.Fatalf("reading connection_states: %v", d)
+	}
+	if len(states) != 2 || states[0] != "NEW" || states[1] != "ESTABLISHED" {
+		t.Errorf("read connection_states = %v, want [NEW ESTABLISHED]", states)
+	}
+
+	out, d := modelToFirewallPolicy(ctx, model)
+	if d.HasError() {
+		t.Fatalf("modelToFirewallPolicy: %v", d)
+	}
+	if len(out.ConnectionStates) != 2 || out.ConnectionStates[0] != "NEW" || out.ConnectionStates[1] != "ESTABLISHED" {
+		t.Errorf("PUT dropped connection_states: %v, want [NEW ESTABLISHED]", out.ConnectionStates)
+	}
+}

--- a/unifi/firewall_policy_resource_test.go
+++ b/unifi/firewall_policy_resource_test.go
@@ -144,8 +144,16 @@ func TestFirewallPolicyConnectionStatesRoundTrip(t *testing.T) {
 		Protocol:            "all",
 		ConnectionStateType: "CUSTOM",
 		ConnectionStates:    []string{"NEW", "ESTABLISHED"},
-		Source:              &unifi.FirewallPolicySource{ZoneID: "z1", MatchingTarget: "ANY", PortMatchingType: "ANY"},
-		Destination:         &unifi.FirewallPolicyDestination{ZoneID: "z2", MatchingTarget: "ANY", PortMatchingType: "ANY"},
+		Source: &unifi.FirewallPolicySource{
+			ZoneID:           "z1",
+			MatchingTarget:   "ANY",
+			PortMatchingType: "ANY",
+		},
+		Destination: &unifi.FirewallPolicyDestination{
+			ZoneID:           "z2",
+			MatchingTarget:   "ANY",
+			PortMatchingType: "ANY",
+		},
 	}
 
 	var model firewallPolicyModel
@@ -164,7 +172,8 @@ func TestFirewallPolicyConnectionStatesRoundTrip(t *testing.T) {
 	if d.HasError() {
 		t.Fatalf("modelToFirewallPolicy: %v", d)
 	}
-	if len(out.ConnectionStates) != 2 || out.ConnectionStates[0] != "NEW" || out.ConnectionStates[1] != "ESTABLISHED" {
+	if len(out.ConnectionStates) != 2 || out.ConnectionStates[0] != "NEW" ||
+		out.ConnectionStates[1] != "ESTABLISHED" {
 		t.Errorf("PUT dropped connection_states: %v, want [NEW ESTABLISHED]", out.ConnectionStates)
 	}
 }


### PR DESCRIPTION
## Context
Follow-up to #220/#223. After #223 (v0.43.1) `unifi_firewall_policy` updates work for `connection_state_type = ALL`, but still fail with **HTTP 400** for policies whose firmware-side `connection_state_type` is **CUSTOM**: the provider round-tripped `connection_state_type` but **hard-coded `connection_states` to `[]`**, so the PUT sent an empty state list and the firmware rejected the CUSTOM policy (#227).

## Changes
- Add `connection_states` to the model and schema as a **computed, round-tripped** list (mirrors the existing `connection_state_type` handling): read during Refresh, re-sent on update.
- `modelToFirewallPolicy` now emits the round-tripped states instead of an empty slice.
- go-unifi already exposes `FirewallPolicy.ConnectionStates` — no SDK change needed.

## Tests
- New unit round-trip test `TestFirewallPolicyConnectionStatesRoundTrip` (read -> model -> API preserves `["NEW", "ESTABLISHED"]`). `go build`/`go vet`/`golangci-lint`/`go generate` clean.
- Not run as an acceptance test: zone-based firewall isn't available in the dockerized acceptance controller (no zones), consistent with the other firewall-policy tests.

Fixes #227.