### PR TITLE
feat(setting): manage site-level igmp_snooping

### DIFF
--- a/docs/resources/setting.md
+++ b/docs/resources/setting.md
@@ -69,6 +69,7 @@ resource "unifi_setting" "radius_only" {
 ### Optional
 
 - `doh` (Attributes) Encrypted DNS (DNS-over-HTTPS) settings. (see [below for nested schema](#nestedatt--doh))
+- `igmp_snooping` (Attributes) Site-level IGMP snooping setting. On UniFi Network 10.3.x+ the effective IGMP snooping toggle lives here rather than on each network. Advanced querier/flood options configured in the UI are preserved across updates. (see [below for nested schema](#nestedatt--igmp_snooping))
 - `ips` (Attributes) Intrusion Prevention System (IPS/IDS) and threat management settings. Basic IDS/IPS uses the built-in Emerging Threats ruleset and is free. A UniFi CyberSecure subscription adds enhanced threat intelligence from Proofpoint and Cloudflare on top of the base ruleset. (see [below for nested schema](#nestedatt--ips))
 - `mgmt` (Attributes) Management settings. (see [below for nested schema](#nestedatt--mgmt))
 - `radius` (Attributes) RADIUS settings. (see [below for nested schema](#nestedatt--radius))
@@ -100,6 +101,15 @@ Optional:
 
 - `enabled` (Boolean) Enable this custom server. Defaults to true.
 
+
+
+<a id="nestedatt--igmp_snooping"></a>
+### Nested Schema for `igmp_snooping`
+
+Optional:
+
+- `enabled` (Boolean) Whether IGMP snooping is enabled for the site.
+- `network_ids` (List of String) IDs of the networks IGMP snooping applies to.
 
 
 <a id="nestedatt--ips"></a>

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/hashicorp/terraform-plugin-testing v1.16.0
 	github.com/testcontainers/testcontainers-go v0.42.0
 	github.com/testcontainers/testcontainers-go/modules/compose v0.42.0
-	github.com/ubiquiti-community/go-unifi v1.33.43-0.20260610122329-3b8fa0f63b66
+	github.com/ubiquiti-community/go-unifi v1.33.43-0.20260610190850-8bb99aee8046
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -528,8 +528,8 @@ github.com/transparency-dev/formats v0.0.0-20251017110053-404c0d5b696c h1:5a2XDQ
 github.com/transparency-dev/formats v0.0.0-20251017110053-404c0d5b696c/go.mod h1:g85IafeFJZLxlzZCDRu4JLpfS7HKzR+Hw9qRh3bVzDI=
 github.com/transparency-dev/merkle v0.0.2 h1:Q9nBoQcZcgPamMkGn7ghV8XiTZ/kRxn1yCG81+twTK4=
 github.com/transparency-dev/merkle v0.0.2/go.mod h1:pqSy+OXefQ1EDUVmAJ8MUhHB9TXGuzVAT58PqBoHz1A=
-github.com/ubiquiti-community/go-unifi v1.33.43-0.20260610122329-3b8fa0f63b66 h1:bqjWIXNt++BmWs2GC83DOQRgvNZmNQsBTc0jwcJ/QX4=
-github.com/ubiquiti-community/go-unifi v1.33.43-0.20260610122329-3b8fa0f63b66/go.mod h1:lOld3iJD/7eXE5+phOVWz3Y45qTlb73g24tPipLIkac=
+github.com/ubiquiti-community/go-unifi v1.33.43-0.20260610190850-8bb99aee8046 h1:LDBRaAsSQtQNXi0zvcci09EpDMUrzuitJ6IKs283+bY=
+github.com/ubiquiti-community/go-unifi v1.33.43-0.20260610190850-8bb99aee8046/go.mod h1:lOld3iJD/7eXE5+phOVWz3Y45qTlb73g24tPipLIkac=
 github.com/vbatts/tar-split v0.12.2 h1:w/Y6tjxpeiFMR47yzZPlPj/FcPLpXbTUi/9H7d3CPa4=
 github.com/vbatts/tar-split v0.12.2/go.mod h1:eF6B6i6ftWQcDqEn3/iGFRFRo8cBIMSJVOpnNdfTMFA=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=

--- a/unifi/setting_igmp_snooping_test.go
+++ b/unifi/setting_igmp_snooping_test.go
@@ -1,0 +1,68 @@
+package unifi
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/ubiquiti-community/go-unifi/unifi/settings"
+)
+
+// TestIgmpSnoopingModelMerge guards #164: the site-level igmp_snooping setting
+// exposes only enabled + network_ids, and the model->setting conversion must
+// overlay those onto the current remote setting so advanced querier/flood
+// fields configured in the UI are preserved across an update.
+func TestIgmpSnoopingModelMerge(t *testing.T) {
+	ctx := context.Background()
+	r := &settingResource{}
+	var diags diag.Diagnostics
+
+	// Current remote setting with advanced fields that must survive.
+	base := &settings.IgmpSnooping{
+		Enabled:             false,
+		QuerierMode:         "CUSTOM",
+		QuerierSwitches:     []string{"aa:bb:cc:dd:ee:ff"},
+		FloodKnownProtocols: true,
+	}
+	nids, d := types.ListValueFrom(ctx, types.StringType, []string{"net-1", "net-2"})
+	if d.HasError() {
+		t.Fatalf("building network_ids: %v", d)
+	}
+	model := &settingIgmpSnoopingModel{
+		Enabled:    types.BoolValue(true),
+		NetworkIDs: nids,
+	}
+
+	out := r.igmpSnoopingModelToSetting(ctx, model, base, &diags)
+	if diags.HasError() {
+		t.Fatalf("igmpSnoopingModelToSetting: %v", diags)
+	}
+	if !out.Enabled {
+		t.Error("Enabled not applied from model")
+	}
+	if len(out.NetworkIDs) != 2 || out.NetworkIDs[0] != "net-1" {
+		t.Errorf("NetworkIDs = %v, want [net-1 net-2]", out.NetworkIDs)
+	}
+	// Advanced fields must be preserved from base (not dropped).
+	if out.QuerierMode != "CUSTOM" || len(out.QuerierSwitches) != 1 || !out.FloodKnownProtocols {
+		t.Errorf("advanced fields not preserved: querier_mode=%q querier_switches=%v flood=%v",
+			out.QuerierMode, out.QuerierSwitches, out.FloodKnownProtocols)
+	}
+
+	// Read-back conversion.
+	m := r.igmpSnoopingSettingToModel(ctx, out, &diags)
+	if diags.HasError() {
+		t.Fatalf("igmpSnoopingSettingToModel: %v", diags)
+	}
+	if !m.Enabled.ValueBool() {
+		t.Error("model Enabled = false, want true")
+	}
+	var ids []string
+	if d := m.NetworkIDs.ElementsAs(ctx, &ids, false); d.HasError() {
+		t.Fatalf("reading model network_ids: %v", d)
+	}
+	if len(ids) != 2 {
+		t.Errorf("model network_ids = %v, want 2", ids)
+	}
+}

--- a/unifi/setting_resource.go
+++ b/unifi/setting_resource.go
@@ -143,13 +143,23 @@ type settingIpsModel struct {
 }
 
 type settingResourceModel struct {
-	ID     types.String `tfsdk:"id"`
-	Site   types.String `tfsdk:"site"`
-	Doh    types.Object `tfsdk:"doh"`
-	Ips    types.Object `tfsdk:"ips"`
-	Mgmt   types.Object `tfsdk:"mgmt"`
-	Radius types.Object `tfsdk:"radius"`
-	USG    types.Object `tfsdk:"usg"`
+	ID           types.String `tfsdk:"id"`
+	Site         types.String `tfsdk:"site"`
+	Doh          types.Object `tfsdk:"doh"`
+	Ips          types.Object `tfsdk:"ips"`
+	Mgmt         types.Object `tfsdk:"mgmt"`
+	Radius       types.Object `tfsdk:"radius"`
+	USG          types.Object `tfsdk:"usg"`
+	IgmpSnooping types.Object `tfsdk:"igmp_snooping"`
+}
+
+// settingIgmpSnoopingModel is the nested igmp_snooping block. On UniFi 10.3.x the
+// effective IGMP snooping toggle moved from the per-network object to this site
+// setting (#164). Only the common fields are exposed; advanced querier/flood
+// fields are preserved across updates via a read-modify-write merge.
+type settingIgmpSnoopingModel struct {
+	Enabled    types.Bool `tfsdk:"enabled"`
+	NetworkIDs types.List `tfsdk:"network_ids"`
 }
 
 // Shared attribute-type maps for the doh/ips nested objects and lists. These
@@ -193,6 +203,10 @@ var (
 		"suppression_whitelist": types.ListType{
 			ElemType: types.ObjectType{AttrTypes: ipsWhitelistAttrTypes},
 		},
+	}
+	igmpSnoopingAttrTypes = map[string]attr.Type{
+		"enabled":     types.BoolType,
+		"network_ids": types.ListType{ElemType: types.StringType},
 	}
 )
 
@@ -695,6 +709,23 @@ func (r *settingResource) Schema(
 					},
 				},
 			},
+			"igmp_snooping": schema.SingleNestedAttribute{
+				MarkdownDescription: "Site-level IGMP snooping setting. On UniFi Network 10.3.x+ the effective IGMP snooping toggle lives here rather than on each network. Advanced querier/flood options configured in the UI are preserved across updates.",
+				Optional:            true,
+				Attributes: map[string]schema.Attribute{
+					"enabled": schema.BoolAttribute{
+						MarkdownDescription: "Whether IGMP snooping is enabled for the site.",
+						Optional:            true,
+						Computed:            true,
+					},
+					"network_ids": schema.ListAttribute{
+						MarkdownDescription: "IDs of the networks IGMP snooping applies to.",
+						ElementType:         types.StringType,
+						Optional:            true,
+						Computed:            true,
+					},
+				},
+			},
 		},
 	}
 }
@@ -824,6 +855,35 @@ func (r *settingResource) Create(
 		setting := r.usgModelToSetting(ctx, &usg)
 		if err := r.client.UpdateSetting(ctx, site, setting); err != nil {
 			resp.Diagnostics.AddError("Error Creating USG Setting", err.Error())
+			return
+		}
+	}
+
+	if !data.IgmpSnooping.IsNull() && !data.IgmpSnooping.IsUnknown() {
+		var igmp settingIgmpSnoopingModel
+		resp.Diagnostics.Append(data.IgmpSnooping.As(ctx, &igmp, basetypes.ObjectAsOptions{})...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+
+		// Read current remote setting as the base so advanced querier/flood
+		// fields keep their remote values across the update.
+		_, currentIgmp, err := ui.GetSetting[*settings.IgmpSnooping](r.client.ApiClient, ctx, site)
+		if err != nil {
+			var notFound *ui.NotFoundError
+			if !errors.As(err, &notFound) {
+				resp.Diagnostics.AddError("Error Reading IGMP Snooping Setting", err.Error())
+				return
+			}
+			currentIgmp = &settings.IgmpSnooping{}
+		}
+
+		setting := r.igmpSnoopingModelToSetting(ctx, &igmp, currentIgmp, &resp.Diagnostics)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		if err := r.client.UpdateSetting(ctx, site, setting); err != nil {
+			resp.Diagnostics.AddError("Error Creating IGMP Snooping Setting", err.Error())
 			return
 		}
 	}
@@ -965,6 +1025,33 @@ func (r *settingResource) Update(
 		setting := r.usgModelToSetting(ctx, &usg)
 		if err := r.client.UpdateSetting(ctx, site, setting); err != nil {
 			resp.Diagnostics.AddError("Error Updating USG Setting", err.Error())
+			return
+		}
+	}
+
+	if !plan.IgmpSnooping.IsNull() && !plan.IgmpSnooping.IsUnknown() {
+		var igmp settingIgmpSnoopingModel
+		resp.Diagnostics.Append(plan.IgmpSnooping.As(ctx, &igmp, basetypes.ObjectAsOptions{})...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+
+		_, currentIgmp, err := ui.GetSetting[*settings.IgmpSnooping](r.client.ApiClient, ctx, site)
+		if err != nil {
+			var notFound *ui.NotFoundError
+			if !errors.As(err, &notFound) {
+				resp.Diagnostics.AddError("Error Reading IGMP Snooping Setting", err.Error())
+				return
+			}
+			currentIgmp = &settings.IgmpSnooping{}
+		}
+
+		setting := r.igmpSnoopingModelToSetting(ctx, &igmp, currentIgmp, &resp.Diagnostics)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		if err := r.client.UpdateSetting(ctx, site, setting); err != nil {
+			resp.Diagnostics.AddError("Error Updating IGMP Snooping Setting", err.Error())
 			return
 		}
 	}
@@ -1266,6 +1353,24 @@ func (r *settingResource) readSettings(
 			"upnp_secure_mode":                   types.BoolType,
 			"upnp_wan_interface":                 types.StringType,
 		})
+	}
+
+	// IGMP snooping (site-level)
+	if !data.IgmpSnooping.IsNull() && !data.IgmpSnooping.IsUnknown() {
+		_, igmpSetting, err := ui.GetSetting[*settings.IgmpSnooping](r.client.ApiClient, ctx, site)
+		if err != nil {
+			diags.AddError("Error Reading IGMP Snooping Setting", err.Error())
+			return
+		}
+		igmpModel := r.igmpSnoopingSettingToModel(ctx, igmpSetting, diags)
+		objValue, d := types.ObjectValueFrom(ctx, igmpSnoopingAttrTypes, igmpModel)
+		diags.Append(d...)
+		if diags.HasError() {
+			return
+		}
+		data.IgmpSnooping = objValue
+	} else {
+		data.IgmpSnooping = types.ObjectNull(igmpSnoopingAttrTypes)
 	}
 }
 
@@ -1822,6 +1927,43 @@ func (r *settingResource) usgSettingToModel(
 		model.UPnPWANInterface = types.StringNull()
 	}
 
+	return model
+}
+
+// IGMP snooping conversion functions.
+
+// igmpSnoopingModelToSetting overlays the user-set fields (enabled, network_ids)
+// onto the current remote setting (base) so advanced querier/flood options are
+// preserved across updates.
+func (r *settingResource) igmpSnoopingModelToSetting(
+	ctx context.Context,
+	model *settingIgmpSnoopingModel,
+	base *settings.IgmpSnooping,
+	diags *diag.Diagnostics,
+) *settings.IgmpSnooping {
+	setting := base
+	if !model.Enabled.IsNull() && !model.Enabled.IsUnknown() {
+		setting.Enabled = model.Enabled.ValueBool()
+	}
+	if !model.NetworkIDs.IsNull() && !model.NetworkIDs.IsUnknown() {
+		var ids []string
+		diags.Append(model.NetworkIDs.ElementsAs(ctx, &ids, false)...)
+		setting.NetworkIDs = ids
+	}
+	return setting
+}
+
+func (r *settingResource) igmpSnoopingSettingToModel(
+	ctx context.Context,
+	setting *settings.IgmpSnooping,
+	diags *diag.Diagnostics,
+) *settingIgmpSnoopingModel {
+	model := &settingIgmpSnoopingModel{
+		Enabled: types.BoolValue(setting.Enabled),
+	}
+	ids, d := types.ListValueFrom(ctx, types.StringType, setting.NetworkIDs)
+	diags.Append(d...)
+	model.NetworkIDs = ids
 	return model
 }
 


### PR DESCRIPTION
## Context
On UniFi Network 10.3.x the effective IGMP snooping toggle moved from the per-network object to a **site setting** (`/api/s/<site>/{get,set}/setting/igmp_snooping`). As a result `unifi_network.igmp_snooping` no longer drives behavior on those controllers (#164).

## Changes
- Add an `igmp_snooping` nested block to the `unifi_setting` resource exposing `enabled` and `network_ids` (the fields users actually manage).
- Backed by go-unifi's new `IgmpSnooping` setting (ubiquiti-community/go-unifi#27, pulled in via the go.mod bump).
- Advanced querier/flood fields (querier_mode, querier_switches, flood_*, etc.) are **preserved across updates** via a read-modify-write merge (mirrors the existing `radius` block), so managing `enabled`/`network_ids` from Terraform doesn't clobber UI-configured querier settings.

## Tests
- Unit test `TestIgmpSnoopingModelMerge` (merge preserves advanced base fields; read-back round-trips). `go build`/`go vet`/`golangci-lint`/`go generate` clean.
- **Validated on a real UDM (UniFi OS 10.x):** applying `igmp_snooping` equal to the current setting is a clean no-op, re-plan shows no drift, and the controller's querier/flood fields are left untouched.

Closes #164.