### PR TITLE
build(deps): bump go-unifi to survive login rate-limit (HTTP 429)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/hashicorp/terraform-plugin-testing v1.16.0
 	github.com/testcontainers/testcontainers-go v0.42.0
 	github.com/testcontainers/testcontainers-go/modules/compose v0.42.0
-	github.com/ubiquiti-community/go-unifi v1.33.43-0.20260610190850-8bb99aee8046
+	github.com/ubiquiti-community/go-unifi v1.33.43-0.20260610195744-5ae6b7eb5276
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -528,8 +528,8 @@ github.com/transparency-dev/formats v0.0.0-20251017110053-404c0d5b696c h1:5a2XDQ
 github.com/transparency-dev/formats v0.0.0-20251017110053-404c0d5b696c/go.mod h1:g85IafeFJZLxlzZCDRu4JLpfS7HKzR+Hw9qRh3bVzDI=
 github.com/transparency-dev/merkle v0.0.2 h1:Q9nBoQcZcgPamMkGn7ghV8XiTZ/kRxn1yCG81+twTK4=
 github.com/transparency-dev/merkle v0.0.2/go.mod h1:pqSy+OXefQ1EDUVmAJ8MUhHB9TXGuzVAT58PqBoHz1A=
-github.com/ubiquiti-community/go-unifi v1.33.43-0.20260610190850-8bb99aee8046 h1:LDBRaAsSQtQNXi0zvcci09EpDMUrzuitJ6IKs283+bY=
-github.com/ubiquiti-community/go-unifi v1.33.43-0.20260610190850-8bb99aee8046/go.mod h1:lOld3iJD/7eXE5+phOVWz3Y45qTlb73g24tPipLIkac=
+github.com/ubiquiti-community/go-unifi v1.33.43-0.20260610195744-5ae6b7eb5276 h1:CsKT0dIBsPAFYokboap69B3tDq/aKgEv4Or28bmbmmo=
+github.com/ubiquiti-community/go-unifi v1.33.43-0.20260610195744-5ae6b7eb5276/go.mod h1:lOld3iJD/7eXE5+phOVWz3Y45qTlb73g24tPipLIkac=
 github.com/vbatts/tar-split v0.12.2 h1:w/Y6tjxpeiFMR47yzZPlPj/FcPLpXbTUi/9H7d3CPa4=
 github.com/vbatts/tar-split v0.12.2/go.mod h1:eF6B6i6ftWQcDqEn3/iGFRFRo8cBIMSJVOpnNdfTMFA=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=


### PR DESCRIPTION
## Context
Username/password auth logs in on every `go-unifi` client construction, and UniFi controllers rate-limit `POST /api/auth/login`. Back-to-back Terraform operations (`init → import → plan → plan → apply`) could exhaust the limit and fail with a confusing `Error: Unable to Create HTTP Client` — while the same operation run in isolation succeeded.

## Changes
Bump `github.com/ubiquiti-community/go-unifi` to pull in [go-unifi#18](https://github.com/ubiquiti-community/go-unifi/pull/18):
- HTTP 429 on login is surfaced as a typed `RateLimitError` and login is retried with a dedicated budget that honors `Retry-After` (capped), instead of failing on the transport's short retry budget.
- A `2xx` login that establishes no session (seen under throttling) is treated as retryable.

The fix is transparent to the provider — it flows through `go-unifi`'s `New()`. **API-key auth is unaffected** (login is skipped entirely).

## Tests
- `go build` / `go vet` / `go test ./...` clean (provider unit tests).
- Upstream go-unifi#18 ships `httptest`-based unit tests for the 429 retry, `Retry-After` honoring, exhaustion error, and API-key-skips-login paths; CI green before merge.

## Risk
Low — dependency bump only (`go.mod`/`go.sum`), no provider code change. Behavior change is confined to login resilience; happy path and API-key auth unchanged.