### PR TITLE
docs(changelog): add v0.45.0 entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project will be documented in this file.
 
+## [v0.45.0] - 2026-06-10
+
+### ✨ Features
+
+- **`unifi_network.ipv6_client_address_assignment`** — new optional+computed attribute to declaratively pin how clients on a network obtain an IPv6 address: `slaac` (SLAAC only), `dhcpv6` (DHCPv6 only), or `slaac-dhcpv6` (both). UI: Networks → IPv6 → Client Address Assignment. Backed by a go-unifi fix that emits the field in the corporate/guest marshalers (it was decode-only before). Validated on a live UniFi Network 10.4.57 controller (#232, #233)
+
+### 🐛 Bug Fixes
+
+- **Login rate-limit resilience** — username/password auth no longer fails with `Unable to Create HTTP Client` when several back-to-back operations (`init → import → plan → plan → apply`) exhaust the controller's `POST /api/auth/login` rate-limit. The SDK now surfaces HTTP 429 and retries login with a dedicated budget that honors `Retry-After`. API-key auth is unaffected (it skips login) (#231)
+
+---
+
 ## [v0.44.0] - 2026-06-10
 
 ### ✨ Features


### PR DESCRIPTION
Changelog for the upcoming **v0.45.0** release:
- `unifi_network.ipv6_client_address_assignment` (#233, closes #232)
- Login rate-limit (HTTP 429) resilience via go-unifi bump (#231)

Merge before tagging `v0.45.0`.