### PR TITLE
fix(device): set tagged_networkconf_ids to a typed null (#235)

### DIFF
--- a/unifi/device_port_override_test.go
+++ b/unifi/device_port_override_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	"github.com/ubiquiti-community/go-unifi/unifi"
 )
 
 // nullPortOverrideAttrValues returns every port-override attribute set to its
@@ -111,5 +112,52 @@ func TestFrameworkToPortOverrides_SwitchOpModeOmitted(t *testing.T) {
 	}
 	if pos[0].OpMode != "" {
 		t.Errorf("OpMode = %q, want empty (omitted) for the switch default", pos[0].OpMode)
+	}
+}
+
+// TestPortOverridesToFramework_TaggedNetworkIDsTypedNull is a regression test
+// for #235. portOverridesToFramework must initialize the tagged_networkconf_ids
+// model field to a typed null list. Previously it was left as an untyped
+// zero-value types.List, which made types.ObjectValueFrom fail with a
+// "types.ListType[!!! MISSING TYPE !!!]" Value Conversion Error during the
+// Read/refresh (and import) of any unifi_device that has port overrides.
+func TestPortOverridesToFramework_TaggedNetworkIDsTypedNull(t *testing.T) {
+	r := &deviceResource{}
+
+	set, diags := r.portOverridesToFramework(context.Background(), []unifi.DevicePortOverrides{
+		{Name: "Port 1"},
+	})
+
+	if diags.HasError() {
+		t.Fatalf("portOverridesToFramework returned diagnostics (regression #235): %v", diags.Errors())
+	}
+	if set.IsNull() {
+		t.Fatal("expected a non-null port_override set for a single override")
+	}
+
+	elems := set.Elements()
+	if len(elems) != 1 {
+		t.Fatalf("expected 1 port_override element, got %d", len(elems))
+	}
+
+	obj, ok := elems[0].(types.Object)
+	if !ok {
+		t.Fatalf("expected port_override element to be types.Object, got %T", elems[0])
+	}
+
+	taggedAttr, ok := obj.Attributes()["tagged_networkconf_ids"]
+	if !ok {
+		t.Fatal("port_override is missing the tagged_networkconf_ids attribute")
+	}
+
+	list, ok := taggedAttr.(types.List)
+	if !ok {
+		t.Fatalf("expected tagged_networkconf_ids to be types.List, got %T", taggedAttr)
+	}
+	if !list.IsNull() {
+		t.Errorf("expected tagged_networkconf_ids to be a null list, got %v", list)
+	}
+	if et := list.ElementType(context.Background()); !et.Equal(types.StringType) {
+		t.Errorf("expected tagged_networkconf_ids element type to be string, got %v", et)
 	}
 }

--- a/unifi/device_port_override_test.go
+++ b/unifi/device_port_override_test.go
@@ -129,7 +129,10 @@ func TestPortOverridesToFramework_TaggedNetworkIDsTypedNull(t *testing.T) {
 	})
 
 	if diags.HasError() {
-		t.Fatalf("portOverridesToFramework returned diagnostics (regression #235): %v", diags.Errors())
+		t.Fatalf(
+			"portOverridesToFramework returned diagnostics (regression #235): %v",
+			diags.Errors(),
+		)
 	}
 	if set.IsNull() {
 		t.Fatal("expected a non-null port_override set for a single override")

--- a/unifi/device_resource.go
+++ b/unifi/device_resource.go
@@ -2004,6 +2004,13 @@ func (r *deviceResource) portOverridesToFramework(
 			model.ExcludedNetworkIDs = listVal
 		}
 
+		// FIX (#235): the pinned go-unifi SDK has no TaggedNetworkIDs field, so
+		// nothing populates it below. Without this assignment the model field
+		// stays an untyped zero-value types.List, which makes ObjectValueFrom
+		// emit a "types.ListType[!!! MISSING TYPE !!!]" Value Conversion Error
+		// against the schema's ListAttribute{ElementType: types.StringType}.
+		model.TaggedNetworkIDs = types.ListNull(types.StringType)
+
 		if len(po.MulticastRouterNetworkIDs) == 0 {
 			model.MulticastRouterNetworkIDs = types.ListNull(types.StringType)
 		} else {


### PR DESCRIPTION
## Summary

Fixes #235. Importing or refreshing a `unifi_device` that has any `port_override`
block crashes the provider during the Read/refresh phase:

```
Error: Value Conversion Error
Expected framework type from provider logic: types.ListType[basetypes.StringType]
Received framework type from provider logic: types.ListType[!!! MISSING TYPE !!!]
Path: tagged_networkconf_ids
```

## Root cause

`portOverridesToFramework` initializes the other list-typed port-override fields
(`ExcludedNetworkIDs`, `MulticastRouterNetworkIDs`, ...) but never assigns
`TaggedNetworkIDs`. The pinned `go-unifi` `DevicePortOverrides` struct has no
corresponding field, so `model.TaggedNetworkIDs` stays a zero-value `types.List`
with a `nil` element type. `types.ObjectValueFrom` then cannot reconcile it
against the schema's `ListAttribute{ElementType: types.StringType}`, producing
the `!!! MISSING TYPE !!!` conversion error on every Read/refresh/import.

The `tagged_networkconf_ids` attribute was added in #153 (anticipating SDK
support that hasn't landed), and the model field was left uninitialized.

## Fix

Initialize `model.TaggedNetworkIDs = types.ListNull(types.StringType)` alongside
the sibling list fields. The change is minimal and non-destructive — the schema
and state shape are unchanged, so existing configurations and state are
unaffected. When the SDK exposes the field, this can become a real
`ListValueFrom` mapping.

## Tests

- Added `TestPortOverridesToFramework_TaggedNetworkIDsTypedNull`, a unit test
  that runs `portOverridesToFramework` over a port override and asserts there is
  no conversion error and that `tagged_networkconf_ids` is a typed-null list.
  Verified it **fails without** this fix (reproducing the exact
  `!!! MISSING TYPE !!!` error) and **passes with** it.
- `go build ./...` and the existing `device_port_override_test.go` tests pass.

## References

- Fixes #235
- `tagged_networkconf_ids` attribute introduced in #153
