### PR TITLE
fix(device): stop port_override refresh crash on tagged_networkconf_ids

### DIFF
--- a/unifi/device_resource.go
+++ b/unifi/device_resource.go
@@ -2034,6 +2034,14 @@ func (r *deviceResource) portOverridesToFramework(
 			model.PortSecurityMACAddress = listVal
 		}
 
+		// tagged_networkconf_ids is declared in the schema but go-unifi's
+		// DevicePortOverrides does not yet expose the field, so it cannot be
+		// read back from the API. Initialize it to a typed null list — leaving
+		// it as the zero-value types.List has no element type and makes the
+		// ObjectValueFrom below fail with "MISSING TYPE" during refresh/plan
+		// (ubiquiti-community/terraform-provider-unifi#235).
+		model.TaggedNetworkIDs = types.ListNull(types.StringType)
+
 		// Convert model to object
 		objVal, objDiags := types.ObjectValueFrom(ctx, model.AttributeTypes(), model)
 		diags.Append(objDiags...)


### PR DESCRIPTION
## Problem
`unifi_device` refresh/plan crashes in v0.45.0 for any switch with `port_override` blocks:
```
Error: Value Conversion Error
Expected framework type from provider logic: types.ListType[basetypes.StringType]
Received framework type from provider logic: types.ListType[!!! MISSING TYPE !!!]
Path: tagged_networkconf_ids
```
`portOverridesToFramework` never initialized `model.TaggedNetworkIDs`, so the zero-value `types.List` (which has no element type) made the per-override `ObjectValueFrom` fail. Reported in #235 with a precise root-cause analysis (thanks @MysticRyuujin).

## Fix
Initialize `model.TaggedNetworkIDs = types.ListNull(types.StringType)` alongside the other list attributes. go-unifi's `DevicePortOverrides` does not yet expose `tagged_networkconf_ids`, so the attribute reads as null for now — a full round-trip is a follow-up that needs the SDK field added.

## Tests
- `go build` / `go vet` / `go test ./...` / `golangci-lint` clean.
- **Validated live on UniFi Network 10.4.57** with a switch carrying 5 `port_override` blocks: `tofu import`, `tofu plan`, and `tofu plan -refresh-only` all succeed (previously crashed).

## Risk
Low — single typed-null initialization on the read path; no write-path or API change.

Closes #235.