### PR TITLE
docs(changelog): add v0.45.1 entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## [v0.45.1] - 2026-06-11
+
+### 🐛 Bug Fixes
+
+- `unifi_device`: fix a refresh/plan crash (`Value Conversion Error … types.ListType[!!! MISSING TYPE !!!]` on `tagged_networkconf_ids`) that hit any device with `port_override` blocks. The override read path now initializes the list to a typed null. Note: `tagged_networkconf_ids` is not yet round-tripped (it reads as null) pending the field being added to the go-unifi SDK (#235, #237)
+
+---
+
 ## [v0.45.0] - 2026-06-10
 
 ### ✨ Features


### PR DESCRIPTION
Changelog for **v0.45.1** patch: fixes the `unifi_device` `port_override` refresh crash on `tagged_networkconf_ids` (#235, #237). Merge before tagging `v0.45.1`.