### PR TITLE
docs(changelog): add v0.46.0 entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project will be documented in this file.
 
+## [v0.46.0] - 2026-06-11
+
+### ✨ Features
+
+- **New `unifi_site_to_site_vpn` resource** — manage a UniFi manual site-to-site IPsec VPN (`purpose = site-vpn`, `vpn_type = ipsec-vpn`). Exposes the tunnel essentials (`peer_ip`, `interface`, `key_exchange`, `remote_subnets`, `pre_shared_key`) plus the full `profile = customized` IKE/ESP tuning surface (encryption, hash, DH groups, lifetimes, PFS, dynamic routing, route distance). The pre-shared key supports a write-only variant (`pre_shared_key_wo`, Terraform 1.11+). Backed by a go-unifi fix that completes the previously-stubbed site-VPN marshaler. Validated live on UniFi Network 10.4.57 (#78, #239)
+
+### 🧹 Maintenance
+
+- Added a regression unit test for the `unifi_device` `port_override` refresh crash fixed in v0.45.1, and removed a duplicate initialization left by merging the parallel fix (#236, #240)
+
+---
+
 ## [v0.45.1] - 2026-06-11
 
 ### 🐛 Bug Fixes


### PR DESCRIPTION
Changelog for **v0.46.0**: new `unifi_site_to_site_vpn` resource (#78, #239), plus the `port_override` regression test + cleanup (#236, #240). Merge before tagging `v0.46.0`.