### PR TITLE
chore(deps): bump go-unifi for firewall policy and WLAN fields

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/hashicorp/terraform-plugin-testing v1.16.0
 	github.com/testcontainers/testcontainers-go v0.42.0
 	github.com/testcontainers/testcontainers-go/modules/compose v0.42.0
-	github.com/ubiquiti-community/go-unifi v1.33.43-0.20260611052908-40c5548a25d1
+	github.com/ubiquiti-community/go-unifi v1.33.43-0.20260611133046-fcf7180d408c
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -528,8 +528,8 @@ github.com/transparency-dev/formats v0.0.0-20251017110053-404c0d5b696c h1:5a2XDQ
 github.com/transparency-dev/formats v0.0.0-20251017110053-404c0d5b696c/go.mod h1:g85IafeFJZLxlzZCDRu4JLpfS7HKzR+Hw9qRh3bVzDI=
 github.com/transparency-dev/merkle v0.0.2 h1:Q9nBoQcZcgPamMkGn7ghV8XiTZ/kRxn1yCG81+twTK4=
 github.com/transparency-dev/merkle v0.0.2/go.mod h1:pqSy+OXefQ1EDUVmAJ8MUhHB9TXGuzVAT58PqBoHz1A=
-github.com/ubiquiti-community/go-unifi v1.33.43-0.20260611052908-40c5548a25d1 h1:w0ZHBv8YdRYH69HC2Ur2FO+oW/4R4iGG9gV5urriUDM=
-github.com/ubiquiti-community/go-unifi v1.33.43-0.20260611052908-40c5548a25d1/go.mod h1:lOld3iJD/7eXE5+phOVWz3Y45qTlb73g24tPipLIkac=
+github.com/ubiquiti-community/go-unifi v1.33.43-0.20260611133046-fcf7180d408c h1:L8LD/H4aTx25Io3j2Nyda92q9dqgABwKfgpyuba3F4M=
+github.com/ubiquiti-community/go-unifi v1.33.43-0.20260611133046-fcf7180d408c/go.mod h1:QfZDUwKQmGJNNW4af3KHzb7f+VmiSvkyTqC4/D5aPWU=
 github.com/vbatts/tar-split v0.12.2 h1:w/Y6tjxpeiFMR47yzZPlPj/FcPLpXbTUi/9H7d3CPa4=
 github.com/vbatts/tar-split v0.12.2/go.mod h1:eF6B6i6ftWQcDqEn3/iGFRFRo8cBIMSJVOpnNdfTMFA=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=


### PR DESCRIPTION
## Summary
Bumps `github.com/ubiquiti-community/go-unifi` to the latest `main`, pulling in two upstream PRs:

- **go-unifi#21** — `WLANGroupID` is now `omitempty`, so an empty `wlangroup_id` is no longer serialized (ref #176).
- **go-unifi#17** — new API fields:
  - `FirewallPolicySource`/`FirewallPolicyDestination`: `client_macs`, `network_ids`, `match_opposite_networks`, and `CLIENT` as a valid `matching_target`.
  - `tagged_networkconf_ids` on `DevicePortOverrides`.

## Notes
- This PR only bumps the dependency; exposing the new firewall-policy fields in the resource schema will follow in a dedicated PR.
- The native `tagged_networkconf_ids` field may let us simplify the current provider-side handling (#235/#236/#240) in a follow-up.

## Validation
- `go build ./...`, `go vet ./...` and unit tests pass.
- Acceptance tests not run locally (no controller available).