### PR TITLE
fix(device,port_profile,wlan): resolve inconsistent-result-after-apply on computed/write-only fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### 🐛 Bug Fixes
+
+- **`unifi_device`: fix `Provider produced inconsistent result after apply` that broke every device update.** Write-only attributes never returned by the controller (`forget_on_destroy`, `allow_adoption`) are no longer clobbered to `null` by prior state (notably after an import), and the LED attributes (`led_override`, `led_override_color`, `led_override_color_brightness`) now preserve their configured value when the controller does not echo them back. All five gained `UseStateForUnknown` plan modifiers (#243)
+- **`unifi_port_profile`: fix `inconsistent result after apply` on `stp_port_mode` and `excluded_networkconf_ids`.** `stp_port_mode` is now actually round-tripped to/from the controller (it was forced to `null` and never sent), and both attributes became `Optional + Computed` with `UseStateForUnknown` so controller-computed values no longer conflict with the plan (#245)
+- **`unifi_wlan`: fix `inconsistent result after apply` on `dtim_ng`/`dtim_na`/`dtim_6e` and `iapp_enabled`.** The DTIM fields became `Optional + Computed` so controller defaults (e.g. `1`/`3`/`3`) are accepted when unset, and `iapp_enabled` dropped its static `false` default (the controller may return `true`) in favor of `Optional + Computed` + `UseStateForUnknown` (#245)
+
+---
+
 ## [v0.46.0] - 2026-06-11
 
 ### ✨ Features

--- a/docs/resources/port_profile.md
+++ b/docs/resources/port_profile.md
@@ -46,7 +46,7 @@ resource "unifi_port_profile" "poe_disabled" {
 - `dot1x_idle_timeout` (Number) The timeout, in seconds, to use when using the MAC Based 802.1X control. Can be between 0 and 65535
 - `egress_rate_limit_kbps` (Number) The egress rate limit, in kpbs, for the port profile. Can be between `64` and `9999999`.
 - `egress_rate_limit_kbps_enabled` (Boolean) Enable egress rate limiting for the port profile.
-- `excluded_networkconf_ids` (Set of String) The IDs of networks excluded from the port profile (used when `tagged_vlan_mgmt` is `custom`).
+- `excluded_networkconf_ids` (Set of String) The IDs of networks excluded from the port profile (used when `tagged_vlan_mgmt` is `custom`). Computed from the controller when not set.
 - `fec_mode` (String) Forward Error Correction mode. Can be `rs-fec`, `fc-fec`, `default`, or `disabled`.
 - `forward` (String) The type forwarding to use for the port profile. Can be `all`, `native`, `customize` or `disabled`.
 - `full_duplex` (Boolean) Enable full duplex for the port profile.
@@ -78,7 +78,7 @@ resource "unifi_port_profile" "poe_disabled" {
 - `stormctrl_ucast_enabled` (Boolean) Enable unknown unicast Storm Control for the port profile.
 - `stormctrl_ucast_level` (Number) The unknown unicast Storm Control level for the port profile. Can be between 0 and 100.
 - `stormctrl_ucast_rate` (Number) The unknown unicast Storm Control rate for the port profile. Can be between 0 and 14880000.
-- `stp_port_mode` (Boolean) Enable Spanning Tree Protocol (STP) for the port profile.
+- `stp_port_mode` (Boolean) Enable Spanning Tree Protocol (STP) for the port profile. Computed from the controller when not set.
 - `tagged_networkconf_ids` (Set of String) The IDs of networks to tag traffic with for the port profile.
 - `tagged_vlan_mgmt` (String) How tagged VLANs are managed on the port. Can be `auto`, `block_all`, or `custom`.
 - `voice_networkconf_id` (String) The ID of network to use for voice traffic for the port profile.

--- a/docs/resources/wlan.md
+++ b/docs/resources/wlan.md
@@ -79,17 +79,17 @@ resource "unifi_wlan" "wifi" {
 - `ap_group_mode` (String) Access point group mode.
 - `bc_filter_list` (Set of String) List of MAC addresses for the broadcast filter.
 - `bss_transition` (Boolean) Improves client roaming by providing connection details of nearby APs.
-- `dtim_6e` (Number) DTIM period for the 6 GHz band (1-255). Only used when `dtim_mode` is `custom`.
+- `dtim_6e` (Number) DTIM period for the 6 GHz band (1-255). Only used when `dtim_mode` is `custom`. Computed from the controller when not set.
 - `dtim_mode` (String) DTIM mode. Can be one of `default` or `custom`. Use `custom` together with `dtim_ng`/`dtim_na`/`dtim_6e`.
-- `dtim_na` (Number) DTIM period for the 5 GHz band (1-255). Only used when `dtim_mode` is `custom`.
-- `dtim_ng` (Number) DTIM period for the 2.4 GHz band (1-255). Only used when `dtim_mode` is `custom`.
+- `dtim_na` (Number) DTIM period for the 5 GHz band (1-255). Only used when `dtim_mode` is `custom`. Computed from the controller when not set.
+- `dtim_ng` (Number) DTIM period for the 2.4 GHz band (1-255). Only used when `dtim_mode` is `custom`. Computed from the controller when not set.
 - `enabled` (Boolean) Enable or disable the WLAN.
 - `enhanced_iot` (Boolean) Enable enhanced IoT connectivity.
 - `fast_roaming_enabled` (Boolean) Enable fast roaming, aka 802.11r.
 - `group_rekey` (Number) Group rekey interval in seconds (0 to disable).
 - `hide_ssid` (Boolean) Indicates whether or not to hide the SSID from broadcast.
 - `hotspot2conf_enabled` (Boolean) Enable Hotspot 2.0 configuration.
-- `iapp_enabled` (Boolean) Enable Inter-Access Point Protocol (802.11f) for faster roaming.
+- `iapp_enabled` (Boolean) Enable Inter-Access Point Protocol (802.11f) for faster roaming. Computed from the controller when not set.
 - `is_guest` (Boolean) Indicates that this is a guest WLAN and should use guest behaviors.
 - `l2_isolation` (Boolean) Isolates stations on layer 2 (ethernet) level.
 - `mac_filter` (Attributes) MAC address filtering configuration. (see [below for nested schema](#nestedatt--mac_filter))

--- a/unifi/device_resource.go
+++ b/unifi/device_resource.go
@@ -17,6 +17,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
@@ -263,12 +265,18 @@ func (r *deviceResource) Schema(
 				Optional:    true,
 				Computed:    true,
 				Default:     booldefault.StaticBool(true),
+				PlanModifiers: []planmodifier.Bool{
+					boolplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"forget_on_destroy": schema.BoolAttribute{
 				Description: "Specifies whether this resource should tell the controller to forget the device on destroy.",
 				Optional:    true,
 				Computed:    true,
 				Default:     booldefault.StaticBool(true),
+				PlanModifiers: []planmodifier.Bool{
+					boolplanmodifier.UseStateForUnknown(),
+				},
 			},
 
 			// Network configuration
@@ -331,16 +339,25 @@ func (r *deviceResource) Schema(
 				Validators: []validator.String{
 					stringvalidator.OneOf("default", "on", "off"),
 				},
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"led_override_color": schema.StringAttribute{
 				Description: "LED color override (hex color code).",
 				Optional:    true,
 				Computed:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"led_override_color_brightness": schema.Int64Attribute{
 				Description: "LED brightness (0-100).",
 				Optional:    true,
 				Computed:    true,
+				PlanModifiers: []planmodifier.Int64{
+					int64planmodifier.UseStateForUnknown(),
+				},
 			},
 
 			// Device features
@@ -1077,9 +1094,20 @@ func (r *deviceResource) Read(
 		return
 	}
 
-	// Restore plan-only flags
-	state.AllowAdoption = allowAdoption
-	state.ForgetOnDestroy = forgetOnDestroy
+	// Restore plan-only flags. These are write-only and never returned by the
+	// API, so keep the prior value. After an import the prior value is null/unknown;
+	// normalize it to the schema default (true) so a later apply does not see a
+	// null and report an inconsistent result.
+	if allowAdoption.IsNull() || allowAdoption.IsUnknown() {
+		state.AllowAdoption = types.BoolValue(true)
+	} else {
+		state.AllowAdoption = allowAdoption
+	}
+	if forgetOnDestroy.IsNull() || forgetOnDestroy.IsUnknown() {
+		state.ForgetOnDestroy = types.BoolValue(true)
+	} else {
+		state.ForgetOnDestroy = forgetOnDestroy
+	}
 
 	// Reconcile port_override: the API returns all ports with all fields, but
 	// the user only configures a subset. Rebuild state from the API response
@@ -1160,9 +1188,16 @@ func (r *deviceResource) Update(
 	}
 	plan.ID = state.ID
 
-	// Preserve plan-only flags
-	plan.AllowAdoption = state.AllowAdoption
-	plan.ForgetOnDestroy = state.ForgetOnDestroy
+	// Preserve plan-only flags. They are write-only (config or default); keep the
+	// planned value and only fall back to prior state if the plan left them unset.
+	// Do NOT unconditionally overwrite with state — a null state (e.g. after an
+	// import) would clobber the planned `true` and produce an inconsistent result.
+	if plan.AllowAdoption.IsNull() || plan.AllowAdoption.IsUnknown() {
+		plan.AllowAdoption = state.AllowAdoption
+	}
+	if plan.ForgetOnDestroy.IsNull() || plan.ForgetOnDestroy.IsUnknown() {
+		plan.ForgetOnDestroy = state.ForgetOnDestroy
+	}
 
 	if plan.ConfigNetwork.IsNull() || plan.ConfigNetwork.IsUnknown() {
 		plan.ConfigNetwork = types.ObjectNull(configNetworkAttrTypes())
@@ -1192,8 +1227,15 @@ func (r *deviceResource) Update(
 
 	// Restore port_override from plan (API returns all ports, plan has subset)
 	plan.PortOverride = plannedPortOverride
-	plan.AllowAdoption = state.AllowAdoption
-	plan.ForgetOnDestroy = state.ForgetOnDestroy
+	// allow_adoption / forget_on_destroy were resolved before the update and are
+	// not touched by setResourceData; ensure a concrete value (default true)
+	// rather than overwriting the planned value with prior state.
+	if plan.AllowAdoption.IsNull() || plan.AllowAdoption.IsUnknown() {
+		plan.AllowAdoption = types.BoolValue(true)
+	}
+	if plan.ForgetOnDestroy.IsNull() || plan.ForgetOnDestroy.IsUnknown() {
+		plan.ForgetOnDestroy = types.BoolValue(true)
+	}
 
 	diags = resp.State.Set(ctx, plan)
 	resp.Diagnostics.Append(diags...)
@@ -1464,22 +1506,29 @@ func (r *deviceResource) setResourceData(
 	// State is always present as int64
 	model.State = types.Int64Value(int64(device.State))
 
-	// LED settings
-	if device.LedOverride == "" {
-		model.LedOverride = types.StringNull()
-	} else {
+	// LED settings — write-only in practice: the controller frequently does not
+	// echo these back. When the API returns an empty value, preserve the
+	// configured/known value from the model instead of nulling it (which would
+	// trigger "inconsistent result after apply"). Only resolve unknowns to null.
+	if device.LedOverride != "" {
 		model.LedOverride = types.StringValue(device.LedOverride)
+	} else if model.LedOverride.IsUnknown() {
+		model.LedOverride = types.StringNull()
 	}
 
-	if device.LedOverrideColor == "" {
-		model.LedOverrideColor = types.StringNull()
-	} else {
+	if device.LedOverrideColor != "" {
 		model.LedOverrideColor = types.StringValue(device.LedOverrideColor)
+	} else if model.LedOverrideColor.IsUnknown() {
+		model.LedOverrideColor = types.StringNull()
 	}
 
-	model.LedOverrideColorBrightness = types.Int64PointerValue(
-		device.LedOverrideColorBrightness,
-	)
+	if device.LedOverrideColorBrightness != nil {
+		model.LedOverrideColorBrightness = types.Int64PointerValue(
+			device.LedOverrideColorBrightness,
+		)
+	} else if model.LedOverrideColorBrightness.IsUnknown() {
+		model.LedOverrideColorBrightness = types.Int64Null()
+	}
 
 	// Device features
 	if device.BandsteeringMode == "" {

--- a/unifi/port_profile_resource.go
+++ b/unifi/port_profile_resource.go
@@ -11,8 +11,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/setplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -349,8 +351,12 @@ func (r *portProfileResource) Schema(
 				},
 			},
 			"stp_port_mode": schema.BoolAttribute{
-				Description: "Enable Spanning Tree Protocol (STP) for the port profile.",
+				Description: "Enable Spanning Tree Protocol (STP) for the port profile. Computed from the controller when not set.",
 				Optional:    true,
+				Computed:    true,
+				PlanModifiers: []planmodifier.Bool{
+					boolplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"tagged_networkconf_ids": schema.SetAttribute{
 				Description: "The IDs of networks to tag traffic with for the port profile.",
@@ -362,9 +368,13 @@ func (r *portProfileResource) Schema(
 				Optional:    true,
 			},
 			"excluded_networkconf_ids": schema.SetAttribute{
-				Description: "The IDs of networks excluded from the port profile (used when `tagged_vlan_mgmt` is `custom`).",
+				Description: "The IDs of networks excluded from the port profile (used when `tagged_vlan_mgmt` is `custom`). Computed from the controller when not set.",
 				Optional:    true,
+				Computed:    true,
 				ElementType: types.StringType,
+				PlanModifiers: []planmodifier.Set{
+					setplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"multicast_router_networkconf_ids": schema.SetAttribute{
 				Description: "The IDs of networks designated as multicast routers for the port profile.",
@@ -707,6 +717,7 @@ func (r *portProfileResource) modelToAPIPortProfile(
 		portProfile.SettingPreference = model.SettingPreference.ValueString()
 	}
 	portProfile.PortKeepaliveEnabled = model.PortKeepaliveEnabled.ValueBool()
+	portProfile.StpPortMode = model.STPPortMode.ValueBool()
 
 	if !model.ExcludedNetworkConfIDs.IsNull() && !model.ExcludedNetworkConfIDs.IsUnknown() {
 		var ids []string
@@ -867,7 +878,7 @@ func (r *portProfileResource) setResourceData(
 	model.StormctrlUcastEnabled = types.BoolValue(false)
 	model.StormctrlUcastLevel = types.Int64Null()
 	model.StormctrlUcastRate = types.Int64Null()
-	model.STPPortMode = types.BoolNull()
+	model.STPPortMode = types.BoolValue(portProfile.StpPortMode)
 }
 
 func (r *portProfileResource) applyPlanToState(
@@ -950,6 +961,9 @@ func (r *portProfileResource) applyPlanToState(
 	}
 	if !plan.PortKeepaliveEnabled.IsNull() && !plan.PortKeepaliveEnabled.IsUnknown() {
 		state.PortKeepaliveEnabled = plan.PortKeepaliveEnabled
+	}
+	if !plan.STPPortMode.IsNull() && !plan.STPPortMode.IsUnknown() {
+		state.STPPortMode = plan.STPPortMode
 	}
 	// Apply other fields as needed...
 }

--- a/unifi/wlan_resource.go
+++ b/unifi/wlan_resource.go
@@ -15,7 +15,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/setdefault"
@@ -478,24 +480,36 @@ func (r *wlanFrameworkResource) Schema(
 				},
 			},
 			"dtim_ng": schema.Int64Attribute{
-				MarkdownDescription: "DTIM period for the 2.4 GHz band (1-255). Only used when `dtim_mode` is `custom`.",
+				MarkdownDescription: "DTIM period for the 2.4 GHz band (1-255). Only used when `dtim_mode` is `custom`. Computed from the controller when not set.",
 				Optional:            true,
+				Computed:            true,
 				Validators: []validator.Int64{
 					int64validator.Between(1, 255),
+				},
+				PlanModifiers: []planmodifier.Int64{
+					int64planmodifier.UseStateForUnknown(),
 				},
 			},
 			"dtim_na": schema.Int64Attribute{
-				MarkdownDescription: "DTIM period for the 5 GHz band (1-255). Only used when `dtim_mode` is `custom`.",
+				MarkdownDescription: "DTIM period for the 5 GHz band (1-255). Only used when `dtim_mode` is `custom`. Computed from the controller when not set.",
 				Optional:            true,
+				Computed:            true,
 				Validators: []validator.Int64{
 					int64validator.Between(1, 255),
 				},
+				PlanModifiers: []planmodifier.Int64{
+					int64planmodifier.UseStateForUnknown(),
+				},
 			},
 			"dtim_6e": schema.Int64Attribute{
-				MarkdownDescription: "DTIM period for the 6 GHz band (1-255). Only used when `dtim_mode` is `custom`.",
+				MarkdownDescription: "DTIM period for the 6 GHz band (1-255). Only used when `dtim_mode` is `custom`. Computed from the controller when not set.",
 				Optional:            true,
+				Computed:            true,
 				Validators: []validator.Int64{
 					int64validator.Between(1, 255),
+				},
+				PlanModifiers: []planmodifier.Int64{
+					int64planmodifier.UseStateForUnknown(),
 				},
 			},
 			"group_rekey": schema.Int64Attribute{
@@ -505,10 +519,12 @@ func (r *wlanFrameworkResource) Schema(
 				Default:             int64default.StaticInt64(3600),
 			},
 			"iapp_enabled": schema.BoolAttribute{
-				MarkdownDescription: "Enable Inter-Access Point Protocol (802.11f) for faster roaming.",
+				MarkdownDescription: "Enable Inter-Access Point Protocol (802.11f) for faster roaming. Computed from the controller when not set.",
 				Optional:            true,
 				Computed:            true,
-				Default:             booldefault.StaticBool(false),
+				PlanModifiers: []planmodifier.Bool{
+					boolplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"wpa3_fast_roaming": schema.BoolAttribute{
 				MarkdownDescription: "Enable WPA3 fast roaming (802.11r).",


### PR DESCRIPTION
## Summary
Fixes the Terraform Framework error `Provider produced inconsistent result after apply` that made `unifi_device`, `unifi_port_profile` and `unifi_wlan` updates fail to converge.

Closes #243. Closes #245.

The root cause is a common pattern: attributes declared `Optional` only (or `Optional+Computed` with a static default the controller overrides) get repopulated from the API read, so the post-apply state differs from the plan. There are two sub-classes, fixed differently.

## `unifi_device` (#243) — write-only fields
- `forget_on_destroy` / `allow_adoption` are never returned by the API. `Update` no longer unconditionally overwrites the **planned** value with prior **state** (which is `null` after an import) — it only falls back to state when the plan is unset, and `Read` normalizes a null prior value to the schema default. Added `UseStateForUnknown`.
- `led_override` / `led_override_color` / `led_override_color_brightness` now preserve their configured value when the controller does not echo them back, instead of being nulled out in `setResourceData`. Added `UseStateForUnknown`.

## `unifi_port_profile` (#245)
- `stp_port_mode` is now actually round-tripped: it was **never mapped into the API request** and **forced to `null`** on read. Now mapped both ways.
- `stp_port_mode` and `excluded_networkconf_ids` became `Optional + Computed` with `UseStateForUnknown`, so controller-computed values no longer conflict with a `null` plan.

## `unifi_wlan` (#245)
- `dtim_ng` / `dtim_na` / `dtim_6e` became `Optional + Computed` so controller defaults (e.g. `1`/`3`/`3`) are accepted when unset.
- `iapp_enabled` drops its static `false` default (the controller may return `true`) in favor of `Optional + Computed` + `UseStateForUnknown`.

## Validation
- `go build ./...`, `go vet ./unifi/`, `gofmt` and unit tests pass.
- Docs regenerated with `tfplugindocs`.
- Acceptance tests require a live controller and were not run locally; the issues were reported against UniFi Network 10.4.57 (UDM-SE / cloud-connector) and would benefit from a real-controller validation.

## Notes
- Independent of #246 (the go-unifi bump) — branched off `main`; all touched fields already existed in the current go-unifi version.