### PR TITLE
feat(firewall-policy): add web_domains (FQDN) matching; wire network_ids/client_macs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,13 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### ✨ Features
+
+- **`unifi_firewall_policy`: match traffic by domain/FQDN.** A new `web_domains` attribute on `source` and `destination` (used with `matching_target = "WEB"`) lets a policy filter on hostnames. Backed by a go-unifi change that adds the `web_domains` field and the `WEB` matching target to the firewall-policy schema (#242)
+
 ### 🐛 Bug Fixes
 
+- **`unifi_firewall_policy`: actually send/read `network_ids` and `client_macs`.** These match fields were exposed in the schema but never wired to the API — the provider dropped them on write and forced them to `null` on read. They now round-trip like `ips` (#242)
 - **`unifi_device`: fix `Provider produced inconsistent result after apply` that broke every device update.** Write-only attributes never returned by the controller (`forget_on_destroy`, `allow_adoption`) are no longer clobbered to `null` by prior state (notably after an import), and the LED attributes (`led_override`, `led_override_color`, `led_override_color_brightness`) now preserve their configured value when the controller does not echo them back. All five gained `UseStateForUnknown` plan modifiers (#243)
 - **`unifi_port_profile`: fix `inconsistent result after apply` on `stp_port_mode` and `excluded_networkconf_ids`.** `stp_port_mode` is now actually round-tripped to/from the controller (it was forced to `null` and never sent), and both attributes became `Optional + Computed` with `UseStateForUnknown` so controller-computed values no longer conflict with the plan (#245)
 - **`unifi_wlan`: fix `inconsistent result after apply` on `dtim_ng`/`dtim_na`/`dtim_6e` and `iapp_enabled`.** The DTIM fields became `Optional + Computed` so controller defaults (e.g. `1`/`3`/`3`) are accepted when unset, and `iapp_enabled` dropped its static `false` default (the controller may return `true`) in favor of `Optional + Computed` + `UseStateForUnknown` (#245)

--- a/docs/resources/firewall_policy.md
+++ b/docs/resources/firewall_policy.md
@@ -45,7 +45,7 @@ Manages a UniFi zone-based firewall policy (UniFi Network 8.x+). Zone-based fire
 
 Required:
 
-- `matching_target` (String) What to match: `ANY`, `NETWORK`, `CLIENT`, `IP`, `DEVICE`, or `MAC`.
+- `matching_target` (String) What to match: `ANY`, `NETWORK`, `CLIENT`, `IP`, `DEVICE`, `MAC`, or `WEB` (domains/FQDN).
 - `zone_id` (String) The ID of the firewall zone this endpoint belongs to. Use the `unifi_firewall_zone` data source to look up zone IDs by name.
 
 Optional:
@@ -56,6 +56,7 @@ Optional:
 - `port` (Number) Specific port to match. Used when `port_matching_type` is `SPECIFIC`.
 - `port_group_id` (String) ID of a `unifi_firewall_group` (port-group type) to match. Used when `port_matching_type` is `OBJECT`.
 - `port_matching_type` (String) How to match ports: `ANY`, `SPECIFIC`, or `OBJECT` (port group).
+- `web_domains` (List of String) List of domains/FQDNs to match. Used when `matching_target` is `WEB`.
 
 Read-Only:
 
@@ -67,7 +68,7 @@ Read-Only:
 
 Required:
 
-- `matching_target` (String) What to match: `ANY`, `NETWORK`, `CLIENT`, `IP`, `DEVICE`, or `MAC`.
+- `matching_target` (String) What to match: `ANY`, `NETWORK`, `CLIENT`, `IP`, `DEVICE`, `MAC`, or `WEB` (domains/FQDN).
 - `zone_id` (String) The ID of the firewall zone this endpoint belongs to. Use the `unifi_firewall_zone` data source to look up zone IDs by name.
 
 Optional:
@@ -78,6 +79,7 @@ Optional:
 - `port` (Number) Specific port to match. Used when `port_matching_type` is `SPECIFIC`.
 - `port_group_id` (String) ID of a `unifi_firewall_group` (port-group type) to match. Used when `port_matching_type` is `OBJECT`.
 - `port_matching_type` (String) How to match ports: `ANY`, `SPECIFIC`, or `OBJECT` (port group).
+- `web_domains` (List of String) List of domains/FQDNs to match. Used when `matching_target` is `WEB`.
 
 Read-Only:
 

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/hashicorp/terraform-plugin-testing v1.16.0
 	github.com/testcontainers/testcontainers-go v0.42.0
 	github.com/testcontainers/testcontainers-go/modules/compose v0.42.0
-	github.com/ubiquiti-community/go-unifi v1.33.43-0.20260611133046-fcf7180d408c
+	github.com/ubiquiti-community/go-unifi v1.33.43-0.20260611144350-e11dbecb50df
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -528,8 +528,8 @@ github.com/transparency-dev/formats v0.0.0-20251017110053-404c0d5b696c h1:5a2XDQ
 github.com/transparency-dev/formats v0.0.0-20251017110053-404c0d5b696c/go.mod h1:g85IafeFJZLxlzZCDRu4JLpfS7HKzR+Hw9qRh3bVzDI=
 github.com/transparency-dev/merkle v0.0.2 h1:Q9nBoQcZcgPamMkGn7ghV8XiTZ/kRxn1yCG81+twTK4=
 github.com/transparency-dev/merkle v0.0.2/go.mod h1:pqSy+OXefQ1EDUVmAJ8MUhHB9TXGuzVAT58PqBoHz1A=
-github.com/ubiquiti-community/go-unifi v1.33.43-0.20260611133046-fcf7180d408c h1:L8LD/H4aTx25Io3j2Nyda92q9dqgABwKfgpyuba3F4M=
-github.com/ubiquiti-community/go-unifi v1.33.43-0.20260611133046-fcf7180d408c/go.mod h1:QfZDUwKQmGJNNW4af3KHzb7f+VmiSvkyTqC4/D5aPWU=
+github.com/ubiquiti-community/go-unifi v1.33.43-0.20260611144350-e11dbecb50df h1:DqzZqXKN9ec4xDcya0XaYt71dv1huMqNKVJaUO3tLSA=
+github.com/ubiquiti-community/go-unifi v1.33.43-0.20260611144350-e11dbecb50df/go.mod h1:QfZDUwKQmGJNNW4af3KHzb7f+VmiSvkyTqC4/D5aPWU=
 github.com/vbatts/tar-split v0.12.2 h1:w/Y6tjxpeiFMR47yzZPlPj/FcPLpXbTUi/9H7d3CPa4=
 github.com/vbatts/tar-split v0.12.2/go.mod h1:eF6B6i6ftWQcDqEn3/iGFRFRo8cBIMSJVOpnNdfTMFA=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=

--- a/unifi/firewall_policy_resource.go
+++ b/unifi/firewall_policy_resource.go
@@ -68,6 +68,7 @@ type firewallPolicyEndpointModel struct {
 	NetworkIDs       types.List   `tfsdk:"network_ids"`
 	ClientMACs       types.List   `tfsdk:"client_macs"`
 	IPs              types.List   `tfsdk:"ips"`
+	WebDomains       types.List   `tfsdk:"web_domains"`
 	Port             types.Int64  `tfsdk:"port"`
 	PortGroupID      types.String `tfsdk:"port_group_id"`
 	PortMatchingType types.String `tfsdk:"port_matching_type"`
@@ -83,6 +84,7 @@ func (m firewallPolicyEndpointModel) AttributeTypes() map[string]attr.Type {
 		"network_ids":          types.ListType{ElemType: types.StringType},
 		"client_macs":          types.ListType{ElemType: types.StringType},
 		"ips":                  types.ListType{ElemType: types.StringType},
+		"web_domains":          types.ListType{ElemType: types.StringType},
 		"port":                 types.Int64Type,
 		"port_group_id":        types.StringType,
 		"port_matching_type":   types.StringType,
@@ -109,10 +111,10 @@ func (r *firewallPolicyResource) Schema(
 			Required:            true,
 		},
 		"matching_target": schema.StringAttribute{
-			MarkdownDescription: "What to match: `ANY`, `NETWORK`, `CLIENT`, `IP`, `DEVICE`, or `MAC`.",
+			MarkdownDescription: "What to match: `ANY`, `NETWORK`, `CLIENT`, `IP`, `DEVICE`, `MAC`, or `WEB` (domains/FQDN).",
 			Required:            true,
 			Validators: []validator.String{
-				stringvalidator.OneOf("ANY", "NETWORK", "CLIENT", "IP", "DEVICE", "MAC"),
+				stringvalidator.OneOf("ANY", "NETWORK", "CLIENT", "IP", "DEVICE", "MAC", "WEB"),
 			},
 		},
 		"network_ids": schema.ListAttribute{
@@ -129,6 +131,12 @@ func (r *firewallPolicyResource) Schema(
 		},
 		"ips": schema.ListAttribute{
 			MarkdownDescription: "List of IP addresses or CIDR ranges to match. Used when `matching_target` is `IP`.",
+			Optional:            true,
+			Computed:            true,
+			ElementType:         types.StringType,
+		},
+		"web_domains": schema.ListAttribute{
+			MarkdownDescription: "List of domains/FQDNs to match. Used when `matching_target` is `WEB`.",
 			Optional:            true,
 			Computed:            true,
 			ElementType:         types.StringType,
@@ -543,6 +551,15 @@ func endpointModelToSource(
 	if !m.IPs.IsNull() && !m.IPs.IsUnknown() {
 		diags.Append(m.IPs.ElementsAs(ctx, &ep.IPs, false)...)
 	}
+	if !m.NetworkIDs.IsNull() && !m.NetworkIDs.IsUnknown() {
+		diags.Append(m.NetworkIDs.ElementsAs(ctx, &ep.NetworkIDs, false)...)
+	}
+	if !m.ClientMACs.IsNull() && !m.ClientMACs.IsUnknown() {
+		diags.Append(m.ClientMACs.ElementsAs(ctx, &ep.ClientMACs, false)...)
+	}
+	if !m.WebDomains.IsNull() && !m.WebDomains.IsUnknown() {
+		diags.Append(m.WebDomains.ElementsAs(ctx, &ep.WebDomains, false)...)
+	}
 	return ep
 }
 
@@ -561,6 +578,15 @@ func endpointModelToDestination(
 	}
 	if !m.IPs.IsNull() && !m.IPs.IsUnknown() {
 		diags.Append(m.IPs.ElementsAs(ctx, &ep.IPs, false)...)
+	}
+	if !m.NetworkIDs.IsNull() && !m.NetworkIDs.IsUnknown() {
+		diags.Append(m.NetworkIDs.ElementsAs(ctx, &ep.NetworkIDs, false)...)
+	}
+	if !m.ClientMACs.IsNull() && !m.ClientMACs.IsUnknown() {
+		diags.Append(m.ClientMACs.ElementsAs(ctx, &ep.ClientMACs, false)...)
+	}
+	if !m.WebDomains.IsNull() && !m.WebDomains.IsUnknown() {
+		diags.Append(m.WebDomains.ElementsAs(ctx, &ep.WebDomains, false)...)
 	}
 	return ep
 }
@@ -630,12 +656,21 @@ func apiSourceToEndpointModel(
 		PortGroupID:        types.StringValue(src.PortGroupID),
 		PortMatchingType:   types.StringValue(src.PortMatchingType),
 	}
-	m.NetworkIDs = types.ListNull(types.StringType)
-	m.ClientMACs = types.ListNull(types.StringType)
+	networkIDs, nd := types.ListValueFrom(ctx, types.StringType, src.NetworkIDs)
+	diags.Append(nd...)
+	m.NetworkIDs = networkIDs
+
+	clientMACs, cd := types.ListValueFrom(ctx, types.StringType, src.ClientMACs)
+	diags.Append(cd...)
+	m.ClientMACs = clientMACs
 
 	ips, d := types.ListValueFrom(ctx, types.StringType, src.IPs)
 	diags.Append(d...)
 	m.IPs = ips
+
+	webDomains, wd := types.ListValueFrom(ctx, types.StringType, src.WebDomains)
+	diags.Append(wd...)
+	m.WebDomains = webDomains
 
 	return m
 }
@@ -653,12 +688,21 @@ func apiDestinationToEndpointModel(
 		PortGroupID:        types.StringValue(dst.PortGroupID),
 		PortMatchingType:   types.StringValue(dst.PortMatchingType),
 	}
-	m.NetworkIDs = types.ListNull(types.StringType)
-	m.ClientMACs = types.ListNull(types.StringType)
+	networkIDs, nd := types.ListValueFrom(ctx, types.StringType, dst.NetworkIDs)
+	diags.Append(nd...)
+	m.NetworkIDs = networkIDs
+
+	clientMACs, cd := types.ListValueFrom(ctx, types.StringType, dst.ClientMACs)
+	diags.Append(cd...)
+	m.ClientMACs = clientMACs
 
 	ips, d := types.ListValueFrom(ctx, types.StringType, dst.IPs)
 	diags.Append(d...)
 	m.IPs = ips
+
+	webDomains, wd := types.ListValueFrom(ctx, types.StringType, dst.WebDomains)
+	diags.Append(wd...)
+	m.WebDomains = webDomains
 
 	return m
 }

--- a/unifi/firewall_policy_resource_test.go
+++ b/unifi/firewall_policy_resource_test.go
@@ -187,7 +187,11 @@ func TestFirewallPolicyEndpointListFieldsRoundTrip(t *testing.T) {
 	ctx := context.Background()
 	var diags diag.Diagnostics
 
-	webDomains, _ := types.ListValueFrom(ctx, types.StringType, []string{"example.com", "ads.example.net"})
+	webDomains, _ := types.ListValueFrom(
+		ctx,
+		types.StringType,
+		[]string{"example.com", "ads.example.net"},
+	)
 	networkIDs, _ := types.ListValueFrom(ctx, types.StringType, []string{"net-1", "net-2"})
 	clientMACs, _ := types.ListValueFrom(ctx, types.StringType, []string{"00:11:22:33:44:55"})
 

--- a/unifi/firewall_policy_resource_test.go
+++ b/unifi/firewall_policy_resource_test.go
@@ -177,3 +177,78 @@ func TestFirewallPolicyConnectionStatesRoundTrip(t *testing.T) {
 		t.Errorf("PUT dropped connection_states: %v, want [NEW ESTABLISHED]", out.ConnectionStates)
 	}
 }
+
+// TestFirewallPolicyEndpointListFieldsRoundTrip guards #242 and the wiring of the
+// list-typed match fields. web_domains (FQDN matching, matching_target=WEB) is new;
+// network_ids and client_macs were declared in the schema but never mapped to/from
+// the API (model->API dropped them, API->model forced them to null). This asserts
+// all three survive both conversion directions.
+func TestFirewallPolicyEndpointListFieldsRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	var diags diag.Diagnostics
+
+	webDomains, _ := types.ListValueFrom(ctx, types.StringType, []string{"example.com", "ads.example.net"})
+	networkIDs, _ := types.ListValueFrom(ctx, types.StringType, []string{"net-1", "net-2"})
+	clientMACs, _ := types.ListValueFrom(ctx, types.StringType, []string{"00:11:22:33:44:55"})
+
+	m := firewallPolicyEndpointModel{
+		ZoneID:           types.StringValue("zone-1"),
+		MatchingTarget:   types.StringValue("WEB"),
+		NetworkIDs:       networkIDs,
+		ClientMACs:       clientMACs,
+		IPs:              types.ListNull(types.StringType),
+		WebDomains:       webDomains,
+		Port:             types.Int64Null(),
+		PortGroupID:      types.StringNull(),
+		PortMatchingType: types.StringValue("ANY"),
+	}
+
+	// model -> API (PUT path)
+	src := endpointModelToSource(ctx, m, &diags)
+	if diags.HasError() {
+		t.Fatalf("source conversion errored: %v", diags)
+	}
+	if len(src.WebDomains) != 2 || src.WebDomains[0] != "example.com" {
+		t.Errorf("source WebDomains = %v, want [example.com ads.example.net]", src.WebDomains)
+	}
+	if len(src.NetworkIDs) != 2 || src.NetworkIDs[1] != "net-2" {
+		t.Errorf("source NetworkIDs = %v, want [net-1 net-2]", src.NetworkIDs)
+	}
+	if len(src.ClientMACs) != 1 || src.ClientMACs[0] != "00:11:22:33:44:55" {
+		t.Errorf("source ClientMACs = %v, want [00:11:22:33:44:55]", src.ClientMACs)
+	}
+
+	dst := endpointModelToDestination(ctx, m, &diags)
+	if diags.HasError() {
+		t.Fatalf("destination conversion errored: %v", diags)
+	}
+	if len(dst.WebDomains) != 2 || dst.WebDomains[1] != "ads.example.net" {
+		t.Errorf("destination WebDomains = %v, want [example.com ads.example.net]", dst.WebDomains)
+	}
+
+	// API -> model (read path)
+	apiSrc := &unifi.FirewallPolicySource{
+		ZoneID:         "zone-1",
+		MatchingTarget: "WEB",
+		WebDomains:     []string{"example.com"},
+		NetworkIDs:     []string{"net-9"},
+		ClientMACs:     []string{"aa:bb:cc:dd:ee:ff"},
+	}
+	got := apiSourceToEndpointModel(ctx, apiSrc, &diags)
+	if diags.HasError() {
+		t.Fatalf("apiSourceToEndpointModel errored: %v", diags)
+	}
+	var wd, nids, macs []string
+	got.WebDomains.ElementsAs(ctx, &wd, false)
+	got.NetworkIDs.ElementsAs(ctx, &nids, false)
+	got.ClientMACs.ElementsAs(ctx, &macs, false)
+	if len(wd) != 1 || wd[0] != "example.com" {
+		t.Errorf("read WebDomains = %v, want [example.com]", wd)
+	}
+	if len(nids) != 1 || nids[0] != "net-9" {
+		t.Errorf("read NetworkIDs = %v, want [net-9]", nids)
+	}
+	if len(macs) != 1 || macs[0] != "aa:bb:cc:dd:ee:ff" {
+		t.Errorf("read ClientMACs = %v, want [aa:bb:cc:dd:ee:ff]", macs)
+	}
+}


### PR DESCRIPTION
## Summary
Adds **domain/FQDN matching** to `unifi_firewall_policy` (issue #242): a new `web_domains` list on `source` and `destination`, used with `matching_target = "WEB"`.

Also fixes a pre-existing wiring bug: `network_ids` and `client_macs` were exposed in the endpoint schema but **never mapped to/from the API** (the model→API conversion only sent `ips`, and the API→model read path forced both to `null`). All three list fields now round-trip like `ips`.

Closes #242.

## Changes
- **Schema/model**: new `web_domains` attribute (Optional+Computed, List of String) on source/destination; `WEB` added to the `matching_target` validator.
- **model→API** (`endpointModelToSource`/`endpointModelToDestination`): map `network_ids`, `client_macs`, `web_domains` (previously only `ips`).
- **API→model** (`apiSourceToEndpointModel`/`apiDestinationToEndpointModel`): read `network_ids`, `client_macs`, `web_domains` instead of forcing `null`.
- Unit round-trip test (`TestFirewallPolicyEndpointListFieldsRoundTrip`) and regenerated docs.

## Dependencies
- Requires the go-unifi `web_domains` field (ubiquiti-community/go-unifi#38, merged). This PR bumps go-unifi to pick it up.

## Validation
- `go build ./...`, `go vet ./unifi/`, `gofmt`, and unit tests pass (incl. the new round-trip test).
- Acceptance tests require zone-based firewall + named zones (not available in the dockerized controller); a live-controller check on UniFi Network 8.x+/10.x is recommended before release.