### PR TITLE
docs(changelog): release v0.47.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [Unreleased]
+## [v0.47.0] - 2026-06-11
 
 ### ✨ Features
 


### PR DESCRIPTION
Promote the `Unreleased` section to **v0.47.0**: `unifi_firewall_policy` `web_domains` (FQDN) matching + `network_ids`/`client_macs` wiring, plus the `inconsistent result after apply` fixes for `unifi_device`/`unifi_port_profile`/`unifi_wlan`. Merge before tagging `v0.47.0`.