### PR TITLE
fix(wan): allow type_v6 = "slaac"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### 🐛 Bug Fixes
+
+- **`unifi_wan`: allow `type_v6 = "slaac"`.** The validator only accepted `dhcpv6`/`static`/`disabled`, but the controller also supports `slaac` — and **requires** it when the IPv6 delegation type is `single_network` (`api.err.SingleNetworkMustBeSLAAC` otherwise). This blocked enabling IPv6 on the WAN for ISPs that deliver it by Router Advertisement (e.g. Free/Freebox in bridge mode). Validated live on UniFi Network 10.4.57 (#250)
+
+---
+
 ## [v0.47.0] - 2026-06-11
 
 ### ✨ Features

--- a/docs/resources/wan.md
+++ b/docs/resources/wan.md
@@ -70,7 +70,7 @@ resource "unifi_wan" "default" {
 - `site` (String) The name of the site to associate the WAN network with
 - `smartq` (Attributes) Smart Queue configuration (see [below for nested schema](#nestedatt--smartq))
 - `type` (String) The WAN type (dhcp, static, pppoe)
-- `type_v6` (String) The IPv6 WAN type (dhcpv6, static, disabled)
+- `type_v6` (String) The IPv6 WAN type. One of `dhcpv6`, `slaac`, `static`, or `disabled`. Note: the controller requires `slaac` when the IPv6 delegation type is `single_network` (`api.err.SingleNetworkMustBeSLAAC` otherwise) — common with ISPs that deliver IPv6 by Router Advertisement, e.g. Free/Freebox in bridge mode.
 - `upnp` (Attributes) UPnP configuration (see [below for nested schema](#nestedatt--upnp))
 - `vlan` (Attributes) VLAN configuration (see [below for nested schema](#nestedatt--vlan))
 - `wan_dslite_remote_host` (String) The DS-Lite AFTR remote host. Only used when `wan_dslite_remote_host_auto` is disabled.

--- a/unifi/wan_resource.go
+++ b/unifi/wan_resource.go
@@ -309,14 +309,18 @@ func (r *wanResource) Schema(
 				},
 			},
 			"type_v6": schema.StringAttribute{
-				Optional:            true,
-				Computed:            true,
-				MarkdownDescription: "The IPv6 WAN type (dhcpv6, static, disabled)",
+				Optional: true,
+				Computed: true,
+				MarkdownDescription: "The IPv6 WAN type. One of `dhcpv6`, `slaac`, " +
+					"`static`, or `disabled`. Note: the controller requires `slaac` when " +
+					"the IPv6 delegation type is `single_network` " +
+					"(`api.err.SingleNetworkMustBeSLAAC` otherwise) — common with ISPs that " +
+					"deliver IPv6 by Router Advertisement, e.g. Free/Freebox in bridge mode.",
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
 				},
 				Validators: []validator.String{
-					stringvalidator.OneOf("dhcpv6", "static", "disabled"),
+					stringvalidator.OneOf("dhcpv6", "slaac", "static", "disabled"),
 				},
 			},
 			"vlan": schema.SingleNestedAttribute{


### PR DESCRIPTION
Closes #250.

## Problem
`unifi_wan.type_v6` validator only accepted `dhcpv6`/`static`/`disabled`. The controller also supports `slaac`, and **requires** it when `ipv6_wan_delegation_type = single_network` (`api.err.SingleNetworkMustBeSLAAC`). So WAN IPv6 could not be enabled via the provider for ISPs delivering IPv6 by RA (Free/Freebox in bridge mode, etc.).

## Fix
- Add `slaac` to the `type_v6` `OneOf` validator and document the `single_network` → `slaac` constraint.
- No go-unifi change needed — `wan_type_v6` is already a string with enum `disabled|slaac|dhcpv6|static`.

## Tests
- `go build`/`go vet`/`golangci-lint` clean; docs regenerated.
- **Validated live on UniFi Network 10.4.57** (UCG Fiber, Free/Freebox): `tofu plan` now accepts `type_v6 = "slaac"` (`disabled -> slaac`, no validator error), and the controller accepts `wan_type_v6 = "slaac"` with `single_network` delegation (`rc=ok`, no `SingleNetworkMustBeSLAAC`). Reverted after testing.