### PR TITLE
fix(network): omit ipv6_client_address_assignment when unset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### 🐛 Bug Fixes
 
+- **`unifi_network`: fix create failing with `api.err.InvalidPayload` when `ipv6_client_address_assignment` is unset.** The attribute (added in v0.45.0) is `Optional + Computed`, so on create it was serialized as an empty string `""`, which the controller rejects — breaking network creation unless the field was pinned to a value. It is now omitted from the payload when unset (#252)
 - **`unifi_wan`: allow `type_v6 = "slaac"`.** The validator only accepted `dhcpv6`/`static`/`disabled`, but the controller also supports `slaac` — and **requires** it when the IPv6 delegation type is `single_network` (`api.err.SingleNetworkMustBeSLAAC` otherwise). This blocked enabling IPv6 on the WAN for ISPs that deliver it by Router Advertisement (e.g. Free/Freebox in bridge mode). Validated live on UniFi Network 10.4.57 (#250)
 
 ---

--- a/unifi/network_resource.go
+++ b/unifi/network_resource.go
@@ -1077,7 +1077,7 @@ func (r *networkResource) modelToNetwork(
 		MdnsEnabled:                 model.MulticastDNS.ValueBool(),
 		GatewayType:                 model.GatewayType.ValueStringPointer(),
 		IPV6InterfaceType:           model.IPv6InterfaceType.ValueStringPointer(),
-		IPV6ClientAddressAssignment: model.IPv6ClientAddressAssignment.ValueStringPointer(),
+		IPV6ClientAddressAssignment: optStr(model.IPv6ClientAddressAssignment),
 		IPV6Subnet:                  model.IPv6StaticSubnet.ValueStringPointer(),
 		IPV6RaEnabled:               model.IPv6RA.ValueBool(),
 		IPV6RaPriority:              model.IPv6RAPriority.ValueStringPointer(),


### PR DESCRIPTION
Closes #252.

## Problem
`ipv6_client_address_assignment` (added in v0.45.0, #233) is `Optional + Computed`. On **create** it is unknown, and `modelToNetwork` serialized it via `ValueStringPointer()` → a non-nil pointer to `""`, which the marshaler sends as `"ipv6_client_address_assignment":""`. The controller rejects that with `api.err.InvalidPayload`, so **creating a network failed** unless the field was pinned to a valid enum value — even on a v4-only network.

## Fix
Guard the serialization with the existing `optStr` helper so an unset/unknown value is omitted from the payload (nil → dropped by `omitempty`). One line.

## Tests
- `go build` / `go vet` / `golangci-lint` clean.
- **Validated live on UniFi Network 10.4.57** (UCG Fiber): creating a v4-only network (`ipv6_interface_type = "none"`, no `ipv6_client_address_assignment`) now succeeds, and `tofu plan` is stable (`No changes`). Test network destroyed afterwards.