### PR TITLE
fix(wan): stop spurious plan diff after import (vlan.id, provider_capabilities)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### 🐛 Bug Fixes
+
+- **`unifi_wan`: fix spurious plan diff after import.** Two read quirks made an imported WAN unable to reach `No changes` without an apply: `vlan.id` was read as null (so it always wanted `+ id = 0`) and is now mapped to the schema default `0`; and `provider_capabilities` (the detected line rate) became `Optional + Computed` with `UseStateForUnknown`, so omitting it from config no longer tries to clear it (#262)
+
+---
+
 ## [v0.47.1] - 2026-06-11
 
 ### 🔒 Security

--- a/docs/resources/wan.md
+++ b/docs/resources/wan.md
@@ -63,7 +63,7 @@ resource "unifi_wan" "default" {
 - `ipv6_setting_preference` (String) Whether WAN IPv6 settings are managed automatically by the controller or manually. Can be one of `auto` or `manual`.
 - `load_balance` (Attributes) Load balance configuration (see [below for nested schema](#nestedatt--load_balance))
 - `mac_override_enabled` (Boolean) Whether the WAN interface MAC address is overridden.
-- `provider_capabilities` (Attributes) WAN provider capabilities (see [below for nested schema](#nestedatt--provider_capabilities))
+- `provider_capabilities` (Attributes) WAN provider capabilities (line rate). Detected/populated by the controller; preserved when not set in config. (see [below for nested schema](#nestedatt--provider_capabilities))
 - `report_wan_event` (Boolean) Whether to report WAN events
 - `setting_preference` (String) Whether WAN settings are managed automatically by the controller or manually. Can be one of `auto` or `manual`.
 - `single_network_lan` (String) The LAN network used for IPv6 single-network prefix delegation (used when the IPv6 delegation type is `single_network`).
@@ -163,7 +163,7 @@ Optional:
 <a id="nestedatt--provider_capabilities"></a>
 ### Nested Schema for `provider_capabilities`
 
-Required:
+Optional:
 
 - `download_kilobits_per_second` (Number) Download speed in kilobits per second
 - `upload_kilobits_per_second` (Number) Upload speed in kilobits per second

--- a/unifi/wan_resource.go
+++ b/unifi/wan_resource.go
@@ -742,16 +742,29 @@ func (r *wanResource) Schema(
 				},
 			},
 			"provider_capabilities": schema.SingleNestedAttribute{
-				Optional:            true,
-				MarkdownDescription: "WAN provider capabilities",
+				Optional: true,
+				Computed: true,
+				MarkdownDescription: "WAN provider capabilities (line rate). Detected/" +
+					"populated by the controller; preserved when not set in config.",
+				PlanModifiers: []planmodifier.Object{
+					objectplanmodifier.UseStateForUnknown(),
+				},
 				Attributes: map[string]schema.Attribute{
 					"download_kilobits_per_second": schema.Int64Attribute{
-						Required:            true,
+						Optional:            true,
+						Computed:            true,
 						MarkdownDescription: "Download speed in kilobits per second",
+						PlanModifiers: []planmodifier.Int64{
+							int64planmodifier.UseStateForUnknown(),
+						},
 					},
 					"upload_kilobits_per_second": schema.Int64Attribute{
-						Required:            true,
+						Optional:            true,
+						Computed:            true,
 						MarkdownDescription: "Upload speed in kilobits per second",
+						PlanModifiers: []planmodifier.Int64{
+							int64planmodifier.UseStateForUnknown(),
+						},
 					},
 				},
 			},
@@ -1456,10 +1469,16 @@ func (r *wanResource) networkToModel(
 		model.TypeV6 = types.StringValue(*network.WANTypeV6)
 	}
 
-	// VLAN Settings
+	// VLAN Settings. The controller omits the VLAN id when no WAN VLAN is set;
+	// map it to the schema default (0) rather than null so an imported WAN plans
+	// clean without needing an apply (#262).
+	vlanID := int64(0)
+	if network.WANVLAN != nil {
+		vlanID = *network.WANVLAN
+	}
 	vlanValue := vlanModel{
 		Enabled: types.BoolValue(network.WANVLANEnabled),
-		ID:      types.Int64PointerValue(network.WANVLAN),
+		ID:      types.Int64Value(vlanID),
 	}
 	vlanObj, d := types.ObjectValueFrom(ctx, vlanValue.AttributeTypes(), vlanValue)
 	diags.Append(d...)


### PR DESCRIPTION
Closes #262.

## Problem
An imported `unifi_wan` could not reach `No changes` without an apply:
- **`vlan.id`** was read as `null` when the controller omits the WAN VLAN, so a config of `vlan = { enabled = false }` perpetually planned `+ id = 0` (the schema default).
- **`provider_capabilities`** (the controller-detected line rate) was `Optional`-only, so omitting it from config tried to null it.

## Fix
- Map a missing WAN VLAN to `id = 0` on read (matches the schema default).
- Make `provider_capabilities` and its children `Optional + Computed` with `UseStateForUnknown`, so the read-detected values are preserved when not set in config (same pattern as the v0.47.x device/network fixes).

## Tests
- `go build`/`go vet`/`go test`/`golangci-lint` clean; docs regenerated.
- **Validated live on UniFi Network 10.4.57**: importing a WAN and writing matching config without an explicit `vlan.id` or `provider_capabilities` now plans `No changes` (previously both drifted).