### PR TITLE
fix(site): stop panic on import/read with an unmatched identifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### 🐛 Bug Fixes
 
+- **`unifi_site`: fix provider panic when importing/reading with an unmatched identifier.** Importing a site by an identifier that is neither a 24-hex controller id nor a known site name (e.g. the UUID shown in the UI / Integration API) crashed the provider with a nil-pointer dereference. The read paths now return cleanly on not-found, and `siteToModel` guards against a nil site. Import docs clarify the supported forms (24-hex `_id` or `name=<site-name>`) (#261)
 - **`unifi_wan`: fix spurious plan diff after import.** Two read quirks made an imported WAN unable to reach `No changes` without an apply: `vlan.id` was read as null (so it always wanted `+ id = 0`) and is now mapped to the schema default `0`; and `provider_capabilities` (the detected line rate) became `Optional + Computed` with `UseStateForUnknown`, so omitting it from config no longer tries to clear it (#262)
 
 ---

--- a/docs/resources/site.md
+++ b/docs/resources/site.md
@@ -36,9 +36,15 @@ Import is supported using the following syntax:
 The [` + "`" + `terraform import` + "`" + ` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
 
 ```shell
-# import using the API/UI ID
+# Import using the site's 24-hex controller id (the `_id` from
+# /proxy/network/api/self/sites).
 terraform import unifi_site.mysite 5fe6261995fe130013456a36
 
-# import using the name (short ID)
-terraform import unifi_site.mysite vq98kwez
+# Or import by the site's short name. Any value that is not a 24-hex id is
+# treated as a name; use the `name=` prefix to be explicit (e.g. the default
+# site is named `default`).
+terraform import unifi_site.mysite name=default
+
+# Note: the UUID shown in the UI / Integration API (.../integration/v1/sites)
+# is NOT the import id — use the 24-hex `_id` or the site name above.
 ```

--- a/examples/resources/unifi_site/import.sh
+++ b/examples/resources/unifi_site/import.sh
@@ -1,5 +1,11 @@
-# import using the API/UI ID
+# Import using the site's 24-hex controller id (the `_id` from
+# /proxy/network/api/self/sites).
 terraform import unifi_site.mysite 5fe6261995fe130013456a36
 
-# import using the name (short ID)
-terraform import unifi_site.mysite vq98kwez
+# Or import by the site's short name. Any value that is not a 24-hex id is
+# treated as a name; use the `name=` prefix to be explicit (e.g. the default
+# site is named `default`).
+terraform import unifi_site.mysite name=default
+
+# Note: the UUID shown in the UI / Integration API (.../integration/v1/sites)
+# is NOT the import id — use the 24-hex `_id` or the site name above.

--- a/unifi/site_resource.go
+++ b/unifi/site_resource.go
@@ -181,10 +181,15 @@ func (r *siteFrameworkResource) Read(
 	} else {
 		site, err = r.client.GetSiteByName(ctx, state.Name.ValueString())
 		if err != nil {
+			if _, ok := err.(*unifi.NotFoundError); ok {
+				resp.State.RemoveResource(ctx)
+				return
+			}
 			resp.Diagnostics.AddError(
 				"Error Reading Site",
 				"Could not read site with Name "+state.Name.ValueString()+": "+err.Error(),
 			)
+			return
 		}
 	}
 
@@ -319,6 +324,19 @@ func (r *siteFrameworkResource) siteToModel(
 	model *siteFrameworkResourceModel,
 ) diag.Diagnostics {
 	var diags diag.Diagnostics
+
+	if site == nil {
+		// Defensive: the read paths now return before reaching here on a
+		// not-found, but never dereference a nil site (it previously panicked —
+		// #261, e.g. importing with an identifier that is neither a 24-hex id
+		// nor a known site name).
+		diags.AddError(
+			"Site Not Found",
+			"No site matched the given identifier. Import a site by its 24-hex "+
+				"id, or by name with 'name=<site-name>' (e.g. 'name=default').",
+		)
+		return diags
+	}
 
 	if site.ID == "" && site.Name == "" {
 		// If both ID and Name are empty, we can't import this site

--- a/unifi/site_resource_test.go
+++ b/unifi/site_resource_test.go
@@ -1,6 +1,7 @@
 package unifi
 
 import (
+	"context"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -32,4 +33,16 @@ resource "unifi_site" "test" {
 	description = "tfacc-test"
 }
 `
+}
+
+// TestSiteToModelNilDoesNotPanic guards #261: siteToModel must return an error
+// for a nil site instead of dereferencing it (the read path used to fall
+// through to a nil siteToModel on a not-found, panicking the provider).
+func TestSiteToModelNilDoesNotPanic(t *testing.T) {
+	r := &siteFrameworkResource{}
+	var model siteFrameworkResourceModel
+	diags := r.siteToModel(context.Background(), nil, &model)
+	if !diags.HasError() {
+		t.Fatal("expected an error diagnostic for a nil site, got none")
+	}
 }


### PR DESCRIPTION
Closes #261.

## Problem
Importing a `unifi_site` by an identifier that is neither a 24-hex controller id nor a known site name (e.g. the UUID shown in the UI / Integration API `.../integration/v1/sites`) **crashed the provider** with a nil-pointer dereference (`siteToModel` at `site_resource.go:323`):

```
panic: runtime error: invalid memory address or nil pointer dereference
... siteFrameworkResource).siteToModel ... siteFrameworkResource).Read ...
```

Root cause: `ImportState` puts any non-24-hex value into the `name` attribute, `GetSiteByName` returns `NotFound`, and the `GetSiteByName` read branch added the error **without returning**, falling through to `siteToModel(nil)` which dereferenced the nil site.

## Fix
- The `GetSiteByName` branch now mirrors the id branch: `RemoveResource` on `NotFound`, `return` on any error.
- `siteToModel` guards against a nil site (defense in depth).
- Import docs clarify the supported forms (24-hex `_id`, or `name=<site-name>` such as `name=default`).

## Tests
- New `TestSiteToModelNilDoesNotPanic`; `go build`/`go vet`/`go test`/`golangci-lint` clean; docs regenerated.
- **Validated live on UniFi Network 10.4.57**: importing with the UUID now returns a clean `Cannot import non-existent remote object` (no crash); `name=default` and the 24-hex id both import successfully.