### PR TITLE
docs(changelog): release v0.47.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [Unreleased]
+## [v0.47.2] - 2026-06-12
 
 ### 🐛 Bug Fixes
 


### PR DESCRIPTION
Promote `[Unreleased]` to **v0.47.2**: `unifi_site` import panic fix (#261) and `unifi_wan` spurious plan diff after import (#262).