### PR TITLE
fix(firewall-policy): allow protocol = "icmp" / "icmpv6"

### DIFF
--- a/docs/resources/firewall_policy.md
+++ b/docs/resources/firewall_policy.md
@@ -29,7 +29,7 @@ Manages a UniFi zone-based firewall policy (UniFi Network 8.x+). Zone-based fire
 - `index` (Number) The ordering index of the policy. UniFi auto-assigns this if not set.
 - `ip_version` (String) The IP version to match: `BOTH`, `IPV4`, or `IPV6`. Defaults to `IPV4`.
 - `logging` (Boolean) Whether to log packets matching this policy. Defaults to `false`.
-- `protocol` (String) The protocol to match: `all`, `tcp`, `udp`, or `tcp_udp`. Defaults to `all`.
+- `protocol` (String) The protocol to match: `all`, `tcp`, `udp`, `tcp_udp`, `icmp`, or `icmpv6`. Defaults to `all`. Note: for `icmp`/`icmpv6` policies the controller rejects `create_allow_respond = true` (`FirewallPolicyCreateRespondTrafficPolicyNotAllowed`) — keep it `false` and add an explicit reverse policy if you need the reply.
 - `site` (String) The name of the UniFi site. Defaults to the site configured in the provider.
 
 ### Read-Only

--- a/unifi/firewall_policy_resource.go
+++ b/unifi/firewall_policy_resource.go
@@ -215,12 +215,16 @@ func (r *firewallPolicyResource) Schema(
 				Default:             booldefault.StaticBool(true),
 			},
 			"protocol": schema.StringAttribute{
-				MarkdownDescription: "The protocol to match: `all`, `tcp`, `udp`, or `tcp_udp`. Defaults to `all`.",
-				Optional:            true,
-				Computed:            true,
-				Default:             stringdefault.StaticString("all"),
+				MarkdownDescription: "The protocol to match: `all`, `tcp`, `udp`, `tcp_udp`, " +
+					"`icmp`, or `icmpv6`. Defaults to `all`. Note: for `icmp`/`icmpv6` " +
+					"policies the controller rejects `create_allow_respond = true` " +
+					"(`FirewallPolicyCreateRespondTrafficPolicyNotAllowed`) — keep it " +
+					"`false` and add an explicit reverse policy if you need the reply.",
+				Optional: true,
+				Computed: true,
+				Default:  stringdefault.StaticString("all"),
 				Validators: []validator.String{
-					stringvalidator.OneOf("all", "tcp", "udp", "tcp_udp"),
+					stringvalidator.OneOf("all", "tcp", "udp", "tcp_udp", "icmp", "icmpv6"),
 				},
 			},
 			"description": schema.StringAttribute{

--- a/unifi/firewall_policy_resource_test.go
+++ b/unifi/firewall_policy_resource_test.go
@@ -256,3 +256,45 @@ func TestFirewallPolicyEndpointListFieldsRoundTrip(t *testing.T) {
 		t.Errorf("read ClientMACs = %v, want [aa:bb:cc:dd:ee:ff]", macs)
 	}
 }
+
+// TestFirewallPolicyICMPProtocolRoundTrip guards #259: zone-based firewall ICMP
+// policies (protocol "icmp"/"icmpv6") were rejected by the schema's OneOf
+// validator even though the controller accepts and returns them. This asserts
+// the protocol survives both conversion directions once the validator allows it.
+func TestFirewallPolicyICMPProtocolRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	for _, proto := range []string{"icmp", "icmpv6"} {
+		fp := &unifi.FirewallPolicy{
+			ID:       "p-icmp",
+			Name:     "allow-internal-ping",
+			Action:   "ALLOW",
+			Protocol: proto,
+			Source: &unifi.FirewallPolicySource{
+				ZoneID:           "z1",
+				MatchingTarget:   "IP",
+				PortMatchingType: "ANY",
+			},
+			Destination: &unifi.FirewallPolicyDestination{
+				ZoneID:           "z2",
+				MatchingTarget:   "IP",
+				PortMatchingType: "ANY",
+			},
+		}
+
+		var model firewallPolicyModel
+		if d := firewallPolicyToModel(ctx, fp, &model); d.HasError() {
+			t.Fatalf("[%s] firewallPolicyToModel: %v", proto, d)
+		}
+		if model.Protocol.ValueString() != proto {
+			t.Errorf("[%s] read Protocol = %q, want %q", proto, model.Protocol.ValueString(), proto)
+		}
+
+		out, d := modelToFirewallPolicy(ctx, model)
+		if d.HasError() {
+			t.Fatalf("[%s] modelToFirewallPolicy: %v", proto, d)
+		}
+		if out.Protocol != proto {
+			t.Errorf("[%s] PUT dropped Protocol = %q, want %q", proto, out.Protocol, proto)
+		}
+	}
+}


### PR DESCRIPTION
## Context
`unifi_firewall_policy` rejected `protocol = "icmp"` at plan time — the schema's `OneOf` validator only allowed `all`/`tcp`/`udp`/`tcp_udp`. But UniFi Network zone-based firewall accepts ICMP policies, and the v2 `firewall-policies` API returns them. Reported on a live 10.4.57 controller in #259.

The firmware-managed `icmp_typename` / `icmp_v6_typename` fields are already round-tripped through state, so the validator was the only blocker.

## Changes
- Add `icmp` and `icmpv6` to the `protocol` `OneOf`.
- Document the controller's caveat: it rejects `create_allow_respond = true` for ICMP policies (`FirewallPolicyCreateRespondTrafficPolicyNotAllowed`) — keep it `false` and add an explicit reverse policy for the reply.
- Regenerated `docs/resources/firewall_policy.md`.

## Tests
- New `TestFirewallPolicyICMPProtocolRoundTrip` asserts `protocol` survives model⇄API in both directions for `icmp` and `icmpv6`.
- `go build` / `go test ./unifi/ -run TestFirewallPolicy` / `golangci-lint` clean.
- Not exercised as an acceptance test: zone-based firewall needs named zones, which the dockerized acceptance controller does not provide (same constraint as the other firewall-policy tests).

## Risks
Low — widens an input validator and adds doc text; no behavior change for existing protocols.

Closes #259.