### PR TITLE
fix(device): merge declared port_override blocks instead of full-replace

### DIFF
--- a/docs/resources/device.md
+++ b/docs/resources/device.md
@@ -89,7 +89,7 @@ resource "unifi_device" "us_24_poe" {
 - `outlet_enabled` (Boolean) Enable outlet control.
 - `outlet_overrides` (Attributes List) Outlet configuration overrides. (see [below for nested schema](#nestedatt--outlet_overrides))
 - `poe_mode` (String) PoE mode; valid values are `auto`, `pasv24`, `passthrough`, and `off`.
-- `port_override` (Block Set) Settings overrides for specific switch ports. (see [below for nested schema](#nestedblock--port_override))
+- `port_override` (Block Set) Per-port settings overrides, applied only to the ports you declare. Ports without a `port_override` block keep their existing controller-side configuration — the provider merges your declared ports (by `index`) into the device's current overrides rather than replacing the whole set. Removing a block stops managing that port but does not reset it; clear a port by overriding it back to the defaults instead. (see [below for nested schema](#nestedblock--port_override))
 - `radio_table` (Attributes List) Radio configuration table. (see [below for nested schema](#nestedatt--radio_table))
 - `site` (String) The name of the site to associate the device with.
 - `stp_priority` (Number) STP priority.

--- a/unifi/device_resource.go
+++ b/unifi/device_resource.go
@@ -646,7 +646,13 @@ func (r *deviceResource) Schema(
 
 		Blocks: map[string]schema.Block{
 			"port_override": schema.SetNestedBlock{
-				Description: "Settings overrides for specific switch ports.",
+				Description: "Per-port settings overrides, applied only to the ports you " +
+					"declare. Ports without a `port_override` block keep their existing " +
+					"controller-side configuration — the provider merges your declared " +
+					"ports (by `index`) into the device's current overrides rather than " +
+					"replacing the whole set. Removing a block stops managing that port " +
+					"but does not reset it; clear a port by overriding it back to the " +
+					"defaults instead.",
 				NestedObject: schema.NestedBlockObject{
 					Attributes: map[string]schema.Attribute{
 						"index": schema.Int64Attribute{
@@ -1412,6 +1418,20 @@ func (r *deviceResource) updateDevice(
 		deviceReq.Type = currentDevice.Type
 	}
 
+	// The UniFi PUT treats port_overrides as a full-replace array. Sending only the
+	// user-declared subset would wipe every other port's override (#266). When the
+	// user declared at least one port_override, merge the declared blocks (by
+	// port_idx) onto the device's current overrides so undeclared ports keep their
+	// existing controller-side config — i.e. partial management of just the declared
+	// ports. With no override declared we leave the field untouched as before.
+	portOverrides := deviceReq.PortOverrides
+	if currentDevice != nil && len(deviceReq.PortOverrides) > 0 {
+		portOverrides = mergePortOverridesByIndex(
+			currentDevice.PortOverrides,
+			deviceReq.PortOverrides,
+		)
+	}
+
 	// Build a minimal Device for the PUT request. The full Device struct includes
 	// computed fields (adopted, state, etc.) with Go zero-values that the API rejects.
 	// Only send fields that the user configured or that the API requires.
@@ -1420,7 +1440,7 @@ func (r *deviceResource) updateDevice(
 		Type:          deviceReq.Type,
 		MAC:           deviceReq.MAC,
 		Name:          deviceReq.Name,
-		PortOverrides: deviceReq.PortOverrides,
+		PortOverrides: portOverrides,
 	}
 	if currentDevice != nil {
 		minimalDevice.State = currentDevice.State
@@ -1767,6 +1787,49 @@ func (r *deviceResource) modelToAPIDevice(
 	}
 
 	return device, diags
+}
+
+// mergePortOverridesByIndex overlays the user-declared port overrides onto the
+// device's current overrides, keyed by port_idx. The UniFi PUT replaces the whole
+// port_overrides array, so to manage only a subset of ports without clobbering the
+// rest (#266) we start from what the controller already has and replace just the
+// declared ports. Ports present only in the current set are preserved; ports
+// declared but not yet present are appended. Declared order is preserved for the
+// appended entries so the result is deterministic.
+func mergePortOverridesByIndex(
+	current, declared []unifi.DevicePortOverrides,
+) []unifi.DevicePortOverrides {
+	if len(declared) == 0 {
+		return current
+	}
+
+	declaredByIdx := make(map[int64]int, len(declared))
+	for i, po := range declared {
+		if po.PortIDX != nil {
+			declaredByIdx[*po.PortIDX] = i
+		}
+	}
+
+	merged := make([]unifi.DevicePortOverrides, 0, len(current)+len(declared))
+	used := make([]bool, len(declared))
+	for _, po := range current {
+		if po.PortIDX != nil {
+			if i, ok := declaredByIdx[*po.PortIDX]; ok {
+				merged = append(merged, declared[i])
+				used[i] = true
+				continue
+			}
+		}
+		merged = append(merged, po)
+	}
+	// Append declared ports not already merged: newly-managed ports, or any entry
+	// without a port_idx (which we cannot key on).
+	for i, po := range declared {
+		if !used[i] {
+			merged = append(merged, po)
+		}
+	}
+	return merged
 }
 
 // reconcilePortOverrides rebuilds the port_override Set from the API response,

--- a/unifi/device_resource_test.go
+++ b/unifi/device_resource_test.go
@@ -4,7 +4,68 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/ubiquiti-community/go-unifi/unifi"
 )
+
+// TestMergePortOverridesByIndex guards #266: declaring a subset of port_override
+// blocks must not wipe the device's other ports. The UniFi PUT replaces the whole
+// port_overrides array, so the provider merges the declared ports (by port_idx)
+// onto the device's current overrides before sending.
+func TestMergePortOverridesByIndex(t *testing.T) {
+	current := []unifi.DevicePortOverrides{
+		{PortIDX: ptrInt64(3), NATiveNetworkID: "vlan-a"},
+		{PortIDX: ptrInt64(4), NATiveNetworkID: "vlan-b"},
+		{PortIDX: ptrInt64(5), NATiveNetworkID: "vlan-c"},
+	}
+
+	t.Run("subset replaces only its port, keeps the rest", func(t *testing.T) {
+		declared := []unifi.DevicePortOverrides{
+			{PortIDX: ptrInt64(5), NATiveNetworkID: "vlan-z"},
+		}
+		got := mergePortOverridesByIndex(current, declared)
+		byIdx := indexOverrides(got)
+		if len(got) != 3 {
+			t.Fatalf("merged length = %d, want 3 (ports 3,4 must survive): %+v", len(got), got)
+		}
+		if byIdx[3].NATiveNetworkID != "vlan-a" || byIdx[4].NATiveNetworkID != "vlan-b" {
+			t.Errorf("undeclared ports were altered: %+v", got)
+		}
+		if byIdx[5].NATiveNetworkID != "vlan-z" {
+			t.Errorf("declared port 5 = %q, want vlan-z", byIdx[5].NATiveNetworkID)
+		}
+	})
+
+	t.Run("declared new port is appended", func(t *testing.T) {
+		declared := []unifi.DevicePortOverrides{
+			{PortIDX: ptrInt64(7), NATiveNetworkID: "vlan-new"},
+		}
+		got := mergePortOverridesByIndex(current, declared)
+		byIdx := indexOverrides(got)
+		if len(got) != 4 {
+			t.Fatalf("merged length = %d, want 4: %+v", len(got), got)
+		}
+		if byIdx[7].NATiveNetworkID != "vlan-new" {
+			t.Errorf("new port 7 not appended: %+v", got)
+		}
+	})
+
+	t.Run("no declared overrides returns current unchanged", func(t *testing.T) {
+		got := mergePortOverridesByIndex(current, nil)
+		if len(got) != 3 {
+			t.Errorf("merged length = %d, want 3", len(got))
+		}
+	})
+}
+
+func indexOverrides(pos []unifi.DevicePortOverrides) map[int64]unifi.DevicePortOverrides {
+	m := make(map[int64]unifi.DevicePortOverrides, len(pos))
+	for _, po := range pos {
+		if po.PortIDX != nil {
+			m[*po.PortIDX] = po
+		}
+	}
+	return m
+}
 
 func TestAccDeviceFramework_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{


### PR DESCRIPTION
## Context
Declaring a **single** `port_override` block silently wiped every other port's override (#266). The UniFi `PUT /rest/device/<id>` treats `port_overrides` as a full-replace array, and the provider sent only the declared subset — so on a switch with ports 3/4/5 overridden, declaring just port 5 dropped ports 3 and 4 back to the default VLAN (a port carrying an NVR/CloudKey on a CCTV VLAN would lose connectivity). The plan implied partial management; the apply did full-replace.

## Changes
`updateDevice` already fetches the current device. Merge the declared `port_override` blocks (keyed by `port_idx`) onto its existing `port_overrides` before the PUT:
- declared ports replace their current entry,
- undeclared ports keep their controller-side config,
- newly-declared ports are appended,
- with no `port_override` declared the field is left untouched (unchanged behavior).

This makes `port_override` **partial management** — manage only the ports you declare, leave the rest alone — which matches what the plan already implies. Documented the semantics on the block (removing a block stops managing a port but does not reset it).

## Tests
- New `TestMergePortOverridesByIndex` (pure unit): subset replaces only its port and keeps the rest, a new declared port is appended, and an empty declared set returns current unchanged.
- `go build` / full `go test ./unifi/` / `golangci-lint` clean. Regenerated `docs/resources/device.md`.

## Risks
Low. The merge only changes what the PUT sends; state still tracks only the declared ports. Users who already declare every port get an identical set. No change to the no-override path.

Closes #266.