### PR TITLE
fix(firewall-policy): model source/destination port as a string (#288, #286)

### DIFF
--- a/docs/resources/firewall_policy.md
+++ b/docs/resources/firewall_policy.md
@@ -212,7 +212,7 @@ Optional:
 - `client_macs` (List of String) List of client MAC addresses to match. Used when `matching_target` is `CLIENT`.
 - `ips` (List of String) List of IP addresses or CIDR ranges to match. Used when `matching_target` is `IP`.
 - `network_ids` (List of String) List of UniFi network IDs to match. Used when `matching_target` is `NETWORK`.
-- `port` (Number) Specific port to match. Used when `port_matching_type` is `SPECIFIC`.
+- `port` (String) Port(s) to match when `port_matching_type` is `SPECIFIC`. A single port (`161`) or a comma-separated list of ports/ranges (`80,443`, `8000-8100`). Leave unset for no port match.
 - `port_group_id` (String) ID of a `unifi_firewall_group` (port-group type) to match. Used when `port_matching_type` is `OBJECT`.
 - `port_matching_type` (String) How to match ports: `ANY`, `SPECIFIC`, or `OBJECT` (port group).
 - `web_domains` (List of String) List of domains/FQDNs to match. Used when `matching_target` is `WEB`.
@@ -235,7 +235,7 @@ Optional:
 - `client_macs` (List of String) List of client MAC addresses to match. Used when `matching_target` is `CLIENT`.
 - `ips` (List of String) List of IP addresses or CIDR ranges to match. Used when `matching_target` is `IP`.
 - `network_ids` (List of String) List of UniFi network IDs to match. Used when `matching_target` is `NETWORK`.
-- `port` (Number) Specific port to match. Used when `port_matching_type` is `SPECIFIC`.
+- `port` (String) Port(s) to match when `port_matching_type` is `SPECIFIC`. A single port (`161`) or a comma-separated list of ports/ranges (`80,443`, `8000-8100`). Leave unset for no port match.
 - `port_group_id` (String) ID of a `unifi_firewall_group` (port-group type) to match. Used when `port_matching_type` is `OBJECT`.
 - `port_matching_type` (String) How to match ports: `ANY`, `SPECIFIC`, or `OBJECT` (port group).
 - `web_domains` (List of String) List of domains/FQDNs to match. Used when `matching_target` is `WEB`.

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/hashicorp/terraform-plugin-testing v1.16.0
 	github.com/testcontainers/testcontainers-go v0.42.0
 	github.com/testcontainers/testcontainers-go/modules/compose v0.42.0
-	github.com/ubiquiti-community/go-unifi v1.33.43-0.20260612213321-11555e6e2d01
+	github.com/ubiquiti-community/go-unifi v1.33.43-0.20260616111428-503ea8926c74
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -538,8 +538,8 @@ github.com/transparency-dev/formats v0.0.0-20251017110053-404c0d5b696c h1:5a2XDQ
 github.com/transparency-dev/formats v0.0.0-20251017110053-404c0d5b696c/go.mod h1:g85IafeFJZLxlzZCDRu4JLpfS7HKzR+Hw9qRh3bVzDI=
 github.com/transparency-dev/merkle v0.0.2 h1:Q9nBoQcZcgPamMkGn7ghV8XiTZ/kRxn1yCG81+twTK4=
 github.com/transparency-dev/merkle v0.0.2/go.mod h1:pqSy+OXefQ1EDUVmAJ8MUhHB9TXGuzVAT58PqBoHz1A=
-github.com/ubiquiti-community/go-unifi v1.33.43-0.20260612213321-11555e6e2d01 h1:KPogACvXARI4PMtJPe/NyekNWgTRele4YDONhPMQwkQ=
-github.com/ubiquiti-community/go-unifi v1.33.43-0.20260612213321-11555e6e2d01/go.mod h1:QfZDUwKQmGJNNW4af3KHzb7f+VmiSvkyTqC4/D5aPWU=
+github.com/ubiquiti-community/go-unifi v1.33.43-0.20260616111428-503ea8926c74 h1:8pr9ZzmpS2+96ySoAMv362bguKsp5dvAXFKuLC8x8a4=
+github.com/ubiquiti-community/go-unifi v1.33.43-0.20260616111428-503ea8926c74/go.mod h1:QfZDUwKQmGJNNW4af3KHzb7f+VmiSvkyTqC4/D5aPWU=
 github.com/vbatts/tar-split v0.12.2 h1:w/Y6tjxpeiFMR47yzZPlPj/FcPLpXbTUi/9H7d3CPa4=
 github.com/vbatts/tar-split v0.12.2/go.mod h1:eF6B6i6ftWQcDqEn3/iGFRFRo8cBIMSJVOpnNdfTMFA=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=

--- a/unifi/firewall_policy_resource.go
+++ b/unifi/firewall_policy_resource.go
@@ -3,11 +3,12 @@ package unifi
 import (
 	"context"
 	"fmt"
+	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
-	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -30,9 +31,10 @@ import (
 )
 
 var (
-	_ resource.Resource                = &firewallPolicyResource{}
-	_ resource.ResourceWithImportState = &firewallPolicyResource{}
-	_ resource.ResourceWithIdentity    = &firewallPolicyResource{}
+	_ resource.Resource                 = &firewallPolicyResource{}
+	_ resource.ResourceWithImportState  = &firewallPolicyResource{}
+	_ resource.ResourceWithIdentity     = &firewallPolicyResource{}
+	_ resource.ResourceWithUpgradeState = &firewallPolicyResource{}
 )
 
 // Ensure provider defined types fully satisfy list interfaces.
@@ -98,7 +100,7 @@ type firewallPolicyEndpointModel struct {
 	ClientMACs       types.List   `tfsdk:"client_macs"`
 	IPs              types.List   `tfsdk:"ips"`
 	WebDomains       types.List   `tfsdk:"web_domains"`
-	Port             types.Int64  `tfsdk:"port"`
+	Port             types.String `tfsdk:"port"`
 	PortGroupID      types.String `tfsdk:"port_group_id"`
 	PortMatchingType types.String `tfsdk:"port_matching_type"`
 	// Firmware-managed; round-tripped so updates keep it (a PUT that omits
@@ -114,7 +116,7 @@ func (m firewallPolicyEndpointModel) AttributeTypes() map[string]attr.Type {
 		"client_macs":          types.ListType{ElemType: types.StringType},
 		"ips":                  types.ListType{ElemType: types.StringType},
 		"web_domains":          types.ListType{ElemType: types.StringType},
-		"port":                 types.Int64Type,
+		"port":                 types.StringType,
 		"port_group_id":        types.StringType,
 		"port_matching_type":   types.StringType,
 		"matching_target_type": types.StringType,
@@ -185,15 +187,21 @@ func (r *firewallPolicyResource) Schema(
 			Computed:            true,
 			ElementType:         types.StringType,
 		},
-		"port": schema.Int64Attribute{
-			MarkdownDescription: "Specific port to match. Used when `port_matching_type` is `SPECIFIC`.",
-			Optional:            true,
-			Computed:            true,
-			Validators: []validator.Int64{
-				int64validator.Between(1, 65535),
+		"port": schema.StringAttribute{
+			MarkdownDescription: "Port(s) to match when `port_matching_type` is `SPECIFIC`. " +
+				"A single port (`161`) or a comma-separated list of ports/ranges " +
+				"(`80,443`, `8000-8100`). Leave unset for no port match.",
+			Optional: true,
+			Computed: true,
+			Validators: []validator.String{
+				stringvalidator.RegexMatches(
+					regexp.MustCompile(`^[0-9]{1,5}(-[0-9]{1,5})?(,[0-9]{1,5}(-[0-9]{1,5})?)*$`),
+					"must be a port number or a comma-separated list of ports/ranges "+
+						`(e.g. "80,443" or "8000-8100")`,
+				),
 			},
-			PlanModifiers: []planmodifier.Int64{
-				int64planmodifier.UseStateForUnknown(),
+			PlanModifiers: []planmodifier.String{
+				stringplanmodifier.UseStateForUnknown(),
 			},
 		},
 		"port_group_id": schema.StringAttribute{
@@ -221,6 +229,7 @@ func (r *firewallPolicyResource) Schema(
 	}
 
 	resp.Schema = schema.Schema{
+		Version: 1,
 		MarkdownDescription: "Manages a UniFi zone-based firewall policy (UniFi Network 8.x+). " +
 			"Zone-based firewall policies replace the legacy firewall rules and are displayed " +
 			"under Settings → Security → Firewall Policies in the UniFi UI.",
@@ -568,6 +577,136 @@ func (r *firewallPolicyResource) ImportState(
 }
 
 // ---------------------------------------------------------------------------
+// State upgrade (schema v0 -> v1: port int64 -> string)
+// ---------------------------------------------------------------------------
+
+// firewallPolicyEndpointModelV0 mirrors firewallPolicyEndpointModel but with the
+// pre-v1 integer `port`. It exists only to decode prior state during upgrade.
+type firewallPolicyEndpointModelV0 struct {
+	ZoneID             types.String `tfsdk:"zone_id"`
+	MatchingTarget     types.String `tfsdk:"matching_target"`
+	NetworkIDs         types.List   `tfsdk:"network_ids"`
+	ClientMACs         types.List   `tfsdk:"client_macs"`
+	IPs                types.List   `tfsdk:"ips"`
+	WebDomains         types.List   `tfsdk:"web_domains"`
+	Port               types.Int64  `tfsdk:"port"`
+	PortGroupID        types.String `tfsdk:"port_group_id"`
+	PortMatchingType   types.String `tfsdk:"port_matching_type"`
+	MatchingTargetType types.String `tfsdk:"matching_target_type"`
+}
+
+func (r *firewallPolicyResource) UpgradeState(
+	ctx context.Context,
+) map[int64]resource.StateUpgrader {
+	// Build the prior (v0) schema from the current one and swap the
+	// source/destination `port` back to an integer — that is the only
+	// structural difference. Deriving it from the live schema keeps the
+	// upgrader correct as the rest of the schema evolves.
+	var schemaResp resource.SchemaResponse
+	r.Schema(ctx, resource.SchemaRequest{}, &schemaResp)
+	priorSchema := schemaResp.Schema
+	priorSchema.Version = 0
+	for _, key := range []string{"source", "destination"} {
+		nested, ok := priorSchema.Attributes[key].(schema.SingleNestedAttribute)
+		if !ok {
+			continue
+		}
+		attrs := make(map[string]schema.Attribute, len(nested.Attributes))
+		for k, v := range nested.Attributes {
+			attrs[k] = v
+		}
+		attrs["port"] = schema.Int64Attribute{Optional: true, Computed: true}
+		nested.Attributes = attrs
+		priorSchema.Attributes[key] = nested
+	}
+
+	return map[int64]resource.StateUpgrader{
+		// v0 modeled `port` as an integer, which both dropped multi-port values
+		// (#286) and serialized portless endpoints as the invalid "0" (#288).
+		// v1 models it as a string; convert the stored number, treating 0/null
+		// as "no port".
+		0: {
+			PriorSchema: &priorSchema,
+			StateUpgrader: func(
+				ctx context.Context,
+				req resource.UpgradeStateRequest,
+				resp *resource.UpgradeStateResponse,
+			) {
+				var state firewallPolicyModel
+				resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+				if resp.Diagnostics.HasError() {
+					return
+				}
+
+				state.Source = upgradeFirewallPolicyEndpointV0(
+					ctx, state.Source, &resp.Diagnostics,
+				)
+				state.Destination = upgradeFirewallPolicyEndpointV0(
+					ctx, state.Destination, &resp.Diagnostics,
+				)
+				if resp.Diagnostics.HasError() {
+					return
+				}
+
+				resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+			},
+		},
+	}
+}
+
+func upgradeFirewallPolicyEndpointV0(
+	ctx context.Context,
+	obj types.Object,
+	diags *diag.Diagnostics,
+) types.Object {
+	newTypes := firewallPolicyEndpointModel{}.AttributeTypes()
+	if obj.IsNull() {
+		return types.ObjectNull(newTypes)
+	}
+	if obj.IsUnknown() {
+		return types.ObjectUnknown(newTypes)
+	}
+
+	var v0 firewallPolicyEndpointModelV0
+	diags.Append(obj.As(ctx, &v0, basetypes.ObjectAsOptions{})...)
+	if diags.HasError() {
+		return obj
+	}
+
+	port := types.StringNull()
+	if !v0.Port.IsNull() && !v0.Port.IsUnknown() && v0.Port.ValueInt64() != 0 {
+		port = types.StringValue(strconv.FormatInt(v0.Port.ValueInt64(), 10))
+	}
+
+	upgraded := firewallPolicyEndpointModel{
+		ZoneID:             v0.ZoneID,
+		MatchingTarget:     v0.MatchingTarget,
+		NetworkIDs:         v0.NetworkIDs,
+		ClientMACs:         v0.ClientMACs,
+		IPs:                v0.IPs,
+		WebDomains:         v0.WebDomains,
+		Port:               port,
+		PortGroupID:        v0.PortGroupID,
+		PortMatchingType:   v0.PortMatchingType,
+		MatchingTargetType: v0.MatchingTargetType,
+	}
+
+	newObj, d := types.ObjectValueFrom(ctx, newTypes, upgraded)
+	diags.Append(d...)
+	return newObj
+}
+
+// portToStringValue maps the API port string to a Terraform value. The API
+// returns "" for a portless endpoint and historically "0" for policies created
+// by older provider versions (#288); both map to null so plans stay clean.
+func portToStringValue(p string) types.String {
+	if p == "" || p == "0" {
+		return types.StringNull()
+	}
+	return types.StringValue(p)
+}
+
+// ---------------------------------------------------------------------------
 // Conversion helpers
 // ---------------------------------------------------------------------------
 
@@ -631,7 +770,7 @@ func endpointModelToSource(
 		ZoneID:             m.ZoneID.ValueString(),
 		MatchingTarget:     m.MatchingTarget.ValueString(),
 		MatchingTargetType: m.MatchingTargetType.ValueString(),
-		Port:               m.Port.ValueInt64Pointer(),
+		Port:               m.Port.ValueString(),
 		PortGroupID:        m.PortGroupID.ValueString(),
 		PortMatchingType:   m.PortMatchingType.ValueString(),
 	}
@@ -659,7 +798,7 @@ func endpointModelToDestination(
 		ZoneID:             m.ZoneID.ValueString(),
 		MatchingTarget:     m.MatchingTarget.ValueString(),
 		MatchingTargetType: m.MatchingTargetType.ValueString(),
-		Port:               m.Port.ValueInt64Pointer(),
+		Port:               m.Port.ValueString(),
 		PortGroupID:        m.PortGroupID.ValueString(),
 		PortMatchingType:   m.PortMatchingType.ValueString(),
 	}
@@ -739,7 +878,7 @@ func apiSourceToEndpointModel(
 		ZoneID:             types.StringValue(src.ZoneID),
 		MatchingTarget:     types.StringValue(src.MatchingTarget),
 		MatchingTargetType: types.StringValue(src.MatchingTargetType),
-		Port:               types.Int64PointerValue(src.Port),
+		Port:               portToStringValue(src.Port),
 		PortGroupID:        types.StringValue(src.PortGroupID),
 		PortMatchingType:   types.StringValue(src.PortMatchingType),
 	}
@@ -771,7 +910,7 @@ func apiDestinationToEndpointModel(
 		ZoneID:             types.StringValue(dst.ZoneID),
 		MatchingTarget:     types.StringValue(dst.MatchingTarget),
 		MatchingTargetType: types.StringValue(dst.MatchingTargetType),
-		Port:               types.Int64PointerValue(dst.Port),
+		Port:               portToStringValue(dst.Port),
 		PortGroupID:        types.StringValue(dst.PortGroupID),
 		PortMatchingType:   types.StringValue(dst.PortMatchingType),
 	}

--- a/unifi/firewall_policy_resource_test.go
+++ b/unifi/firewall_policy_resource_test.go
@@ -33,7 +33,7 @@ func TestFirewallPolicyEndpointSpecificPort(t *testing.T) {
 		NetworkIDs:       types.ListNull(types.StringType),
 		ClientMACs:       types.ListNull(types.StringType),
 		IPs:              types.ListNull(types.StringType),
-		Port:             types.Int64Value(443),
+		Port:             types.StringValue("443"),
 		PortGroupID:      types.StringNull(),
 		PortMatchingType: types.StringValue("SPECIFIC"),
 	}
@@ -42,23 +42,80 @@ func TestFirewallPolicyEndpointSpecificPort(t *testing.T) {
 	if diags.HasError() {
 		t.Fatalf("source conversion errored: %v", diags)
 	}
-	if src.Port == nil || *src.Port != 443 {
-		t.Errorf("source Port = %v, want 443", src.Port)
+	if src.Port != "443" {
+		t.Errorf("source Port = %q, want 443", src.Port)
 	}
 	if src.PortMatchingType != "SPECIFIC" {
 		t.Errorf("source PortMatchingType = %q, want SPECIFIC", src.PortMatchingType)
 	}
 
-	m.Port = types.Int64Value(8080)
+	m.Port = types.StringValue("8080")
 	dst := endpointModelToDestination(ctx, m, &diags)
 	if diags.HasError() {
 		t.Fatalf("destination conversion errored: %v", diags)
 	}
-	if dst.Port == nil || *dst.Port != 8080 {
-		t.Errorf("destination Port = %v, want 8080", dst.Port)
+	if dst.Port != "8080" {
+		t.Errorf("destination Port = %q, want 8080", dst.Port)
 	}
 	if dst.PortMatchingType != "SPECIFIC" {
 		t.Errorf("destination PortMatchingType = %q, want SPECIFIC", dst.PortMatchingType)
+	}
+}
+
+// TestFirewallPolicyPortStringHandling guards #288 and #286. A portless endpoint
+// must serialize no port at all (an empty Go string the go-unifi marshaler drops)
+// — not "0", which freezes the gateway firewall config (#288). A comma-separated
+// list must survive (#286). On read, the controller's "" and the legacy "0" both
+// map back to a null port so plans stay clean.
+func TestFirewallPolicyPortStringHandling(t *testing.T) {
+	ctx := context.Background()
+	var diags diag.Diagnostics
+
+	base := firewallPolicyEndpointModel{
+		ZoneID:           types.StringValue("z1"),
+		MatchingTarget:   types.StringValue("ANY"),
+		NetworkIDs:       types.ListNull(types.StringType),
+		ClientMACs:       types.ListNull(types.StringType),
+		IPs:              types.ListNull(types.StringType),
+		WebDomains:       types.ListNull(types.StringType),
+		PortGroupID:      types.StringNull(),
+		PortMatchingType: types.StringValue("ANY"),
+	}
+
+	// Portless endpoint: model -> API must produce an empty port (omitted, never "0").
+	for _, port := range []types.String{types.StringNull(), types.StringValue("")} {
+		m := base
+		m.Port = port
+		if got := endpointModelToSource(ctx, m, &diags).Port; got != "" {
+			t.Errorf("portless source Port = %q, want empty", got)
+		}
+	}
+
+	// Comma-separated list survives (#286).
+	m := base
+	m.Port = types.StringValue("80,443")
+	m.PortMatchingType = types.StringValue("SPECIFIC")
+	if got := endpointModelToDestination(ctx, m, &diags).Port; got != "80,443" {
+		t.Errorf("multi-port destination Port = %q, want 80,443", got)
+	}
+	if diags.HasError() {
+		t.Fatalf("conversion errored: %v", diags)
+	}
+
+	// API -> model: "" and the legacy "0" both become null; a real list survives.
+	cases := map[string]bool{"": true, "0": true, "161": false, "1812,1813": false}
+	for apiPort, wantNull := range cases {
+		got := apiSourceToEndpointModel(
+			ctx,
+			&unifi.FirewallPolicySource{ZoneID: "z1", MatchingTarget: "IP", Port: apiPort},
+			&diags,
+		)
+		if got.Port.IsNull() != wantNull {
+			t.Errorf("read port %q: IsNull = %v, want %v", apiPort, got.Port.IsNull(), wantNull)
+		}
+		if !wantNull && got.Port.ValueString() != apiPort {
+			t.Errorf("read port %q: ValueString = %q", apiPort, got.Port.ValueString())
+		}
 	}
 }
 
@@ -91,7 +148,7 @@ func TestFirewallPolicyPreservesFirmwareFields(t *testing.T) {
 			MatchingTarget:     "IP",
 			MatchingTargetType: "OBJECT",
 			PortMatchingType:   "SPECIFIC",
-			Port:               ptrInt64(161),
+			Port:               "161",
 		},
 	}
 
@@ -130,7 +187,7 @@ func TestFirewallPolicyPreservesFirmwareFields(t *testing.T) {
 	if out.Destination == nil || out.Destination.MatchingTargetType != "OBJECT" {
 		t.Errorf("PUT destination MatchingTargetType not preserved: %+v", out.Destination)
 	}
-	if out.Destination == nil || out.Destination.Port == nil || *out.Destination.Port != 161 {
+	if out.Destination == nil || out.Destination.Port != "161" {
 		t.Errorf("PUT destination Port not preserved: %+v", out.Destination)
 	}
 }
@@ -206,7 +263,7 @@ func TestFirewallPolicyEndpointListFieldsRoundTrip(t *testing.T) {
 		ClientMACs:       clientMACs,
 		IPs:              types.ListNull(types.StringType),
 		WebDomains:       webDomains,
-		Port:             types.Int64Null(),
+		Port:             types.StringNull(),
 		PortGroupID:      types.StringNull(),
 		PortMatchingType: types.StringValue("ANY"),
 	}
@@ -350,7 +407,7 @@ func Test_firewallPolicyEndpointModel_AttributeTypes(t *testing.T) {
 				"client_macs":          types.ListType{ElemType: types.StringType},
 				"ips":                  types.ListType{ElemType: types.StringType},
 				"web_domains":          types.ListType{ElemType: types.StringType},
-				"port":                 types.Int64Type,
+				"port":                 types.StringType,
 				"port_group_id":        types.StringType,
 				"port_matching_type":   types.StringType,
 				"matching_target_type": types.StringType,
@@ -549,7 +606,7 @@ func Test_modelToFirewallPolicy(t *testing.T) {
 						ClientMACs:         types.ListNull(types.StringType),
 						IPs:                types.ListNull(types.StringType),
 						WebDomains:         types.ListNull(types.StringType),
-						Port:               types.Int64Null(),
+						Port:               types.StringNull(),
 						PortGroupID:        types.StringNull(),
 						PortMatchingType:   types.StringValue("ANY"),
 					}
@@ -566,7 +623,7 @@ func Test_modelToFirewallPolicy(t *testing.T) {
 						ClientMACs:         types.ListNull(types.StringType),
 						IPs:                types.ListNull(types.StringType),
 						WebDomains:         types.ListNull(types.StringType),
-						Port:               types.Int64Null(),
+						Port:               types.StringNull(),
 						PortGroupID:        types.StringNull(),
 						PortMatchingType:   types.StringValue("ANY"),
 					}
@@ -657,7 +714,7 @@ func Test_endpointModelToSource(t *testing.T) {
 						ClientMACs:         types.ListNull(types.StringType),
 						IPs:                ips,
 						WebDomains:         types.ListNull(types.StringType),
-						Port:               types.Int64Null(),
+						Port:               types.StringNull(),
 						PortGroupID:        types.StringNull(),
 						PortMatchingType:   types.StringValue("ANY"),
 					}
@@ -715,7 +772,7 @@ func Test_endpointModelToDestination(t *testing.T) {
 						ClientMACs:         types.ListNull(types.StringType),
 						IPs:                ips,
 						WebDomains:         types.ListNull(types.StringType),
-						Port:               types.Int64Value(80),
+						Port:               types.StringValue("80"),
 						PortGroupID:        types.StringNull(),
 						PortMatchingType:   types.StringValue("SPECIFIC"),
 					}
@@ -725,7 +782,7 @@ func Test_endpointModelToDestination(t *testing.T) {
 				ZoneID:             "z2",
 				MatchingTarget:     "IP",
 				MatchingTargetType: "OBJECT",
-				Port:               ptrInt64(80),
+				Port:               "80",
 				PortMatchingType:   "SPECIFIC",
 				IPs:                []string{"192.168.1.1"},
 			},
@@ -832,7 +889,7 @@ func Test_apiSourceToEndpointModel(t *testing.T) {
 					MatchingTargetType: "OBJECT",
 					IPs:                []string{"10.0.0.1"},
 					PortMatchingType:   "SPECIFIC",
-					Port:               ptrInt64(443),
+					Port:               "443",
 				},
 			},
 			want: func() firewallPolicyEndpointModel {
@@ -849,7 +906,7 @@ func Test_apiSourceToEndpointModel(t *testing.T) {
 					NetworkIDs:         networkIDs,
 					ClientMACs:         clientMACs,
 					WebDomains:         webDomains,
-					Port:               types.Int64Value(443),
+					Port:               types.StringValue("443"),
 					PortGroupID:        types.StringValue(""),
 					PortMatchingType:   types.StringValue("SPECIFIC"),
 				}
@@ -893,7 +950,7 @@ func Test_apiDestinationToEndpointModel(t *testing.T) {
 					MatchingTarget:     "ANY",
 					MatchingTargetType: "OBJECT",
 					PortMatchingType:   "SPECIFIC",
-					Port:               ptrInt64(8080),
+					Port:               "8080",
 				},
 			},
 			want: func() firewallPolicyEndpointModel {
@@ -910,7 +967,7 @@ func Test_apiDestinationToEndpointModel(t *testing.T) {
 					NetworkIDs:         networkIDs,
 					ClientMACs:         clientMACs,
 					WebDomains:         webDomains,
-					Port:               types.Int64Value(8080),
+					Port:               types.StringValue("8080"),
 					PortGroupID:        types.StringValue(""),
 					PortMatchingType:   types.StringValue("SPECIFIC"),
 				}


### PR DESCRIPTION
## Context
The `port` attribute on a firewall policy's `source`/`destination` was modeled as a number. On current UniFi OS this causes two bugs:

- **#288 (silent, high impact)** — a portless endpoint (`port_matching_type = ANY`) serialized `"port": "0"`. The gateway's config service validates ports to 1-65535 and rejects `0`, **silently freezing the entire firewall ruleset**: `terraform apply` succeeds, the UI looks fine, `cfgversion` advances, but the dataplane keeps the last-good config and no further firewall change applies until the offending policy is removed.
- **#286** — a comma-separated port list (e.g. `"80,443"`) could not be represented and was dropped to `null` on import.

## Changes
- `source.port`/`destination.port` are now **strings**: they omit cleanly when unset (no more `"0"`), accept a single port or a comma-separated list/range, and the legacy `"0"`/`""` read back as `null` so already-imported policies plan clean.
- **State upgrader (schema v1)** migrates existing state: the stored number is converted to a string, with `0` treated as "no port". Existing users upgrade transparently — no manual state edit.
- Regenerated docs; bumped go-unifi to the version with the string-typed port (ubiquiti-community/go-unifi#42).

## Tests
- `TestFirewallPolicyPortStringHandling`: portless → empty (omitted, never `"0"`), comma-separated list survives, API `""`/`"0"` → null. Updated the existing port round-trip tests. `go build`/`go vet`/`go test ./...` clean.

## Live validation
Attempted on a real UCG, but the controller is still on the legacy firewall (`ZONE_BASED_FIREWALL_MIGRATION` feature flag, 0 zones), so a zone-based policy can't be created there without triggering the migration. Validated instead via unit tests (both conversion directions) and by replaying the go-unifi codegen offline.

## ⚠️ Breaking change
`source.port`/`destination.port` change from number to string. Update configs from `port = 161` to `port = "161"`. Existing state is migrated automatically.

Closes #288
Closes #286