### PR TITLE
fix(wlan): keep enhanced_iot WLANs consistent after apply (#283)

### DIFF
--- a/docs/resources/wlan.md
+++ b/docs/resources/wlan.md
@@ -84,7 +84,7 @@ resource "unifi_wlan" "wifi" {
 - `dtim_na` (Number) DTIM period for the 5 GHz band (1-255). Only used when `dtim_mode` is `custom`. Computed from the controller when not set.
 - `dtim_ng` (Number) DTIM period for the 2.4 GHz band (1-255). Only used when `dtim_mode` is `custom`. Computed from the controller when not set.
 - `enabled` (Boolean) Enable or disable the WLAN.
-- `enhanced_iot` (Boolean) Enable enhanced IoT connectivity.
+- `enhanced_iot` (Boolean) Enable enhanced IoT connectivity. When `true`, the controller forces `iapp_enabled = true`, `wpa3_support = false`, `wpa3_transition = false`, `pmf_mode = "disabled"` and `dtim_ng = 1`; the provider pins those fields to match, so any conflicting values you set for them are ignored (this disables WPA3 on the SSID).
 - `fast_roaming_enabled` (Boolean) Enable fast roaming, aka 802.11r.
 - `group_rekey` (Number) Group rekey interval in seconds (0 to disable).
 - `hide_ssid` (Boolean) Indicates whether or not to hide the SSID from broadcast.

--- a/unifi/wlan_resource.go
+++ b/unifi/wlan_resource.go
@@ -44,6 +44,7 @@ var (
 	_ resource.ResourceWithImportState  = &wlanFrameworkResource{}
 	_ resource.ResourceWithIdentity     = &wlanFrameworkResource{}
 	_ resource.ResourceWithUpgradeState = &wlanFrameworkResource{}
+	_ resource.ResourceWithModifyPlan   = &wlanFrameworkResource{}
 )
 
 // Ensure provider defined types fully satisfy list interfaces.
@@ -595,10 +596,14 @@ func (r *wlanFrameworkResource) Schema(
 				Default:             booldefault.StaticBool(false),
 			},
 			"enhanced_iot": schema.BoolAttribute{
-				MarkdownDescription: "Enable enhanced IoT connectivity.",
-				Optional:            true,
-				Computed:            true,
-				Default:             booldefault.StaticBool(false),
+				MarkdownDescription: "Enable enhanced IoT connectivity. When `true`, the " +
+					"controller forces `iapp_enabled = true`, `wpa3_support = false`, " +
+					"`wpa3_transition = false`, `pmf_mode = \"disabled\"` and `dtim_ng = 1`; " +
+					"the provider pins those fields to match, so any conflicting values you " +
+					"set for them are ignored (this disables WPA3 on the SSID).",
+				Optional: true,
+				Computed: true,
+				Default:  booldefault.StaticBool(false),
 			},
 			"hotspot2conf_enabled": schema.BoolAttribute{
 				MarkdownDescription: "Enable Hotspot 2.0 configuration.",
@@ -751,6 +756,49 @@ func (r *wlanFrameworkResource) Configure(
 	}
 
 	r.client = client
+}
+
+// ModifyPlan reconciles the fields the controller forces when enhanced IoT is
+// enabled. With `enhanced_iot = true` the controller silently overrides
+// iapp_enabled, wpa3_support, wpa3_transition, pmf_mode and dtim_ng with fixed
+// values, so a plan that kept the configured/default values would fail the
+// post-apply consistency check (and re-propose them on every plan). Pin those
+// fields to what the controller will return. When enhanced_iot is false (the
+// common case) this is a no-op, so non-IoT WLANs are unaffected. See #283.
+func (r *wlanFrameworkResource) ModifyPlan(
+	ctx context.Context,
+	req resource.ModifyPlanRequest,
+	resp *resource.ModifyPlanResponse,
+) {
+	// No plan on destroy.
+	if req.Plan.Raw.IsNull() {
+		return
+	}
+
+	var plan wlanFrameworkResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if applyEnhancedIotOverrides(&plan) {
+		resp.Diagnostics.Append(resp.Plan.Set(ctx, &plan)...)
+	}
+}
+
+// applyEnhancedIotOverrides pins the fields the controller forces when
+// enhanced IoT is enabled. Returns true if it changed the model. A no-op when
+// enhanced_iot is not true.
+func applyEnhancedIotOverrides(plan *wlanFrameworkResourceModel) bool {
+	if !plan.EnhancedIot.ValueBool() {
+		return false
+	}
+	plan.IappEnabled = types.BoolValue(true)
+	plan.WPA3Support = types.BoolValue(false)
+	plan.WPA3Transition = types.BoolValue(false)
+	plan.PMFMode = types.StringValue("disabled")
+	plan.DTIMNg = types.Int64Value(1)
+	return true
 }
 
 // setDefaultWLANGroupID populates wlan.WLANGroupID when it is empty. go-unifi

--- a/unifi/wlan_resource_test.go
+++ b/unifi/wlan_resource_test.go
@@ -483,3 +483,53 @@ func TestWLANPrivatePresharedKeys_emptyIsNull(t *testing.T) {
 		t.Errorf("PrivatePresharedKeys = %v, want null", model.PrivatePresharedKeys)
 	}
 }
+
+// TestApplyEnhancedIotOverrides guards #283: when enhanced_iot is enabled the
+// controller forces iapp_enabled, wpa3_support, wpa3_transition, pmf_mode and
+// dtim_ng, so the provider pins them in the plan to avoid an inconsistent-result
+// error. When enhanced_iot is false it must be a no-op.
+func TestApplyEnhancedIotOverrides(t *testing.T) {
+	t.Run("enhanced_iot true forces the controller-managed fields", func(t *testing.T) {
+		m := &wlanFrameworkResourceModel{
+			EnhancedIot:    types.BoolValue(true),
+			IappEnabled:    types.BoolValue(false),
+			WPA3Support:    types.BoolValue(true),
+			WPA3Transition: types.BoolValue(true),
+			PMFMode:        types.StringValue("optional"),
+			DTIMNg:         types.Int64Value(3),
+		}
+		if !applyEnhancedIotOverrides(m) {
+			t.Fatal("expected overrides to be applied")
+		}
+		if !m.IappEnabled.ValueBool() {
+			t.Errorf("iapp_enabled = %v, want true", m.IappEnabled.ValueBool())
+		}
+		if m.WPA3Support.ValueBool() {
+			t.Errorf("wpa3_support = %v, want false", m.WPA3Support.ValueBool())
+		}
+		if m.WPA3Transition.ValueBool() {
+			t.Errorf("wpa3_transition = %v, want false", m.WPA3Transition.ValueBool())
+		}
+		if m.PMFMode.ValueString() != "disabled" {
+			t.Errorf("pmf_mode = %q, want disabled", m.PMFMode.ValueString())
+		}
+		if m.DTIMNg.ValueInt64() != 1 {
+			t.Errorf("dtim_ng = %d, want 1", m.DTIMNg.ValueInt64())
+		}
+	})
+
+	t.Run("enhanced_iot false is a no-op", func(t *testing.T) {
+		m := &wlanFrameworkResourceModel{
+			EnhancedIot: types.BoolValue(false),
+			WPA3Support: types.BoolValue(true),
+			PMFMode:     types.StringValue("optional"),
+		}
+		if applyEnhancedIotOverrides(m) {
+			t.Fatal("expected no overrides when enhanced_iot is false")
+		}
+		if !m.WPA3Support.ValueBool() || m.PMFMode.ValueString() != "optional" {
+			t.Errorf("non-IoT fields were modified: wpa3=%v pmf=%q",
+				m.WPA3Support.ValueBool(), m.PMFMode.ValueString())
+		}
+	})
+}


### PR DESCRIPTION
## Context
With `enhanced_iot = true`, the controller silently overrides five fields with fixed values:

| field | controller forces |
|---|---|
| `iapp_enabled` | `true` |
| `wpa3_support` | `false` |
| `wpa3_transition` | `false` |
| `pmf_mode` | `"disabled"` |
| `dtim_ng` | `1` |

The provider kept the configured/default values in the plan, so `apply` failed with **"provider produced inconsistent result after apply"** (`.wpa3_support: was cty.True, but now cty.False`, etc.), and every subsequent plan re-proposed them.

## Fix
Add a `ModifyPlan` that pins those five fields to the controller-forced values **whenever `enhanced_iot` is enabled**. When `enhanced_iot` is `false` (the common case) it is a strict no-op, so non-IoT WLANs are completely unaffected — no regression risk. The `enhanced_iot` attribute documents the override.

## Tests
`TestApplyEnhancedIotOverrides` covers both branches (enhanced_iot true forces the five fields; false is a no-op). `go build`/`go vet`/`go test ./...` clean.

Not exercised as an acceptance test — the dockerized acceptance controller doesn't expose enhanced IoT WLANs.

Closes #283