### PR TITLE
docs(changelog): release v0.50.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 All notable changes to this project will be documented in this file.
 
+## [v0.50.0] - 2026-06-16
+
+### ⚠️ Breaking Changes
+
+- **`unifi_firewall_policy` `source.port`/`destination.port` are now strings** (were numbers). Update configs from `port = 161` to `port = "161"`. Existing state is migrated automatically by a schema upgrader, so no manual action is required. This is what fixes #288 below and adds comma-separated port lists (#286).
+
+### ✨ Features
+
+- **List resources for 19 more managed resources** (5 → 24 listable), enabling `terraform query` / config-driven import workflows: `radius_user`, `dns_record`, `dynamic_dns`, `radius_profile`, `firewall_group`, `port_forward`, `static_route`, `traffic_route`, `wan`, `vpn_client`, `vpn_server`, `wireguard_peer`, `device`, `client_qos_rate`, `site`, `power_supervisor`, `firewall_rule`, `network`, `port_profile` (#277, #279)
+- **Per-resource operation timeouts** — resources and data sources now accept a standardized `timeouts` block (create/read/update/delete) (#285)
+- **`unifi_firewall_policy` ports accept a comma-separated list** (e.g. `"80,443"`) and round-trip correctly on import (#286)
+
+### 🐛 Bug Fixes
+
+- **`unifi_firewall_policy`: a portless source/destination no longer freezes the gateway firewall.** A policy with `port_matching_type = ANY` was serialized with `port = "0"`, which current UniFi OS rejects (valid ports are 1–65535) — silently dropping the *entire* firewall ruleset while `apply` reported success. Portless endpoints now omit the port field entirely (#288)
+- **`unifi_wlan`: `enhanced_iot = true` no longer fails with "provider produced inconsistent result after apply".** When enhanced IoT is enabled the controller forces `iapp_enabled`, `wpa3_support`, `wpa3_transition`, `pmf_mode` and `dtim_ng`; the provider now pins those fields to the controller's values so apply and subsequent plans stay consistent (#283)
+
+### 🔧 Maintenance
+
+- CI: gate `golangci-lint` on newly-introduced issues only, so a `latest`-tracking linter no longer blocks every PR on pre-existing findings, and clear the existing findings in the test suite (#294)
+- CI: workflow cleanup, coverage reporting, and stricter dependency linting (#278, #285)
+- Build(deps): bump `golangci/golangci-lint-action` 8 → 9.2.1 (#291) and `codecov/codecov-action` 5 → 7 (#289)
+
+---
+
 ## [v0.49.0] - 2026-06-12
 
 ### ✨ Features


### PR DESCRIPTION
CHANGELOG entry for **v0.50.0** — everything merged since v0.49.0:

- ⚠️ Breaking: `unifi_firewall_policy` ports are now strings (auto-migrated state) (#288, #286)
- ✨ List resources for 19 more resources (#277, #279); per-resource `timeouts` (#285)
- 🐛 firewall_policy portless-freeze fix (#288); wlan enhanced_iot consistency (#283)
- 🔧 CI lint gating (#294), workflow cleanup (#278), dep bumps (#289, #291)

Merge before tagging `v0.50.0`.