### PR TITLE
feat(client): expose last_ip read-only attribute (#287)

### DIFF
--- a/docs/resources/client.md
+++ b/docs/resources/client.md
@@ -65,6 +65,7 @@ resource "unifi_client" "test" {
 
 - `hostname` (String) The hostname of the client.
 - `id` (String) The ID of the client.
+- `last_ip` (String) The most recent IP address the controller has seen for this client (read-only).
 
 <a id="nestedatt--qos_rate"></a>
 ### Nested Schema for `qos_rate`

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/hashicorp/terraform-plugin-testing v1.16.0
 	github.com/testcontainers/testcontainers-go v0.42.0
 	github.com/testcontainers/testcontainers-go/modules/compose v0.42.0
-	github.com/ubiquiti-community/go-unifi v1.33.43-0.20260616111428-503ea8926c74
+	github.com/ubiquiti-community/go-unifi v1.33.43-0.20260616140026-335a2849e608
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -538,8 +538,8 @@ github.com/transparency-dev/formats v0.0.0-20251017110053-404c0d5b696c h1:5a2XDQ
 github.com/transparency-dev/formats v0.0.0-20251017110053-404c0d5b696c/go.mod h1:g85IafeFJZLxlzZCDRu4JLpfS7HKzR+Hw9qRh3bVzDI=
 github.com/transparency-dev/merkle v0.0.2 h1:Q9nBoQcZcgPamMkGn7ghV8XiTZ/kRxn1yCG81+twTK4=
 github.com/transparency-dev/merkle v0.0.2/go.mod h1:pqSy+OXefQ1EDUVmAJ8MUhHB9TXGuzVAT58PqBoHz1A=
-github.com/ubiquiti-community/go-unifi v1.33.43-0.20260616111428-503ea8926c74 h1:8pr9ZzmpS2+96ySoAMv362bguKsp5dvAXFKuLC8x8a4=
-github.com/ubiquiti-community/go-unifi v1.33.43-0.20260616111428-503ea8926c74/go.mod h1:QfZDUwKQmGJNNW4af3KHzb7f+VmiSvkyTqC4/D5aPWU=
+github.com/ubiquiti-community/go-unifi v1.33.43-0.20260616140026-335a2849e608 h1:UJTU6xbACVc+pY5RPa7VW804HMWeF+XAgIFj5BBOMvU=
+github.com/ubiquiti-community/go-unifi v1.33.43-0.20260616140026-335a2849e608/go.mod h1:QfZDUwKQmGJNNW4af3KHzb7f+VmiSvkyTqC4/D5aPWU=
 github.com/vbatts/tar-split v0.12.2 h1:w/Y6tjxpeiFMR47yzZPlPj/FcPLpXbTUi/9H7d3CPa4=
 github.com/vbatts/tar-split v0.12.2/go.mod h1:eF6B6i6ftWQcDqEn3/iGFRFRo8cBIMSJVOpnNdfTMFA=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=

--- a/unifi/client_resource.go
+++ b/unifi/client_resource.go
@@ -108,6 +108,7 @@ type clientResourceModel struct {
 
 	// Computed attributes
 	Hostname types.String `tfsdk:"hostname"`
+	LastIP   types.String `tfsdk:"last_ip"`
 
 	Timeouts timeouts.Value `tfsdk:"timeouts"`
 }
@@ -310,6 +311,13 @@ Clients are created in the controller when observed on the network, so the resou
 				Default:             booldefault.StaticBool(defaultSkipForgetOnDestroy),
 				PlanModifiers: []planmodifier.Bool{
 					boolplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"last_ip": schema.StringAttribute{
+				MarkdownDescription: "The most recent IP address the controller has seen for this client (read-only).",
+				Computed:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
 				},
 			},
 			"hostname": schema.StringAttribute{
@@ -1100,6 +1108,7 @@ func (r *clientResource) clientToModel(
 
 	// Computed attributes
 	model.Hostname = util.StringValueOrNull(client.Hostname)
+	model.LastIP = util.StringValueOrNull(client.LastIP)
 
 	return diags
 }


### PR DESCRIPTION
## Context
Requested in #287 — surface the IP a client most recently used.

## Changes
Add a read-only `last_ip` attribute to `unifi_client`. The controller returns it on `/rest/user` (confirmed on UniFi Network 10.x); backed by the new `Client.LastIP` field in go-unifi (ubiquiti-community/go-unifi#43). Computed + UseStateForUnknown, so it refreshes on read and never causes a plan diff.

Closes #287