### PR TITLE
docs(changelog): release v0.51.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to this project will be documented in this file.
 
+## [v0.51.0] - 2026-06-16
+
+### ✨ Features
+
+- **`unifi_client`: new read-only `last_ip` attribute** — the most recent IP the controller has seen for the client (#287)
+- **`unifi_setting`: new `auto_speedtest` block** — periodic internet speed test (`enabled`, `cron_expr`) (#272)
+- **`unifi_setting`: six more setting categories** (#273):
+  - `dpi` — Deep Packet Inspection (`enabled`, `fingerprinting_enabled`)
+  - `lcm` — device display (`enabled`, `brightness`, `idle_timeout`, `sync`, `touch_event`)
+  - `network_optimization` — automated network optimization (`enabled`)
+  - `ntp` — time servers (`ntp_server_1..4`, `setting_preference`)
+  - `syslog` — remote rsyslog (`enabled`, `ip`, `port`, `contents`, `log_all_contents`, `debug`, `this_controller`/`this_controller_encrypted_only`, `netconsole_*`)
+  - `country` — regulatory `code`
+
+---
+
 ## [v0.50.0] - 2026-06-16
 
 ### ⚠️ Breaking Changes


### PR DESCRIPTION
CHANGELOG for **v0.51.0** — merged since v0.50.0: `unifi_client.last_ip` (#287); `unifi_setting` blocks auto_speedtest (#272) + dpi/lcm/network_optimization/ntp/syslog/country (#273). Merge before tagging `v0.51.0`.