### PR TITLE
docs(changelog): release v0.52.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file.
 
+## [v0.52.0] - 2026-06-16
+
+### ✨ Features
+
+- **`unifi_setting` `mgmt` block — full management settings** (#274): `advanced_feature_enabled`, `auto_upgrade_hour`, `debug_tools_enabled`, `direct_connect_enabled`, `unifi_idp_enabled`, `wifiman_enabled`, `ssh_username`, `ssh_password` (sensitive), `ssh_auth_password_enabled`. Configured fields are overlaid onto the controller's current settings, so unset fields are preserved.
+- **`unifi_setting` `ips` block — signature alert suppression** (#275): new `suppression_alerts` list (`category`, `gid`, `id`, `signature`, `type`) with a nested `tracking` list (`direction`, `mode`, `value`).
+
+---
+
 ## [v0.51.0] - 2026-06-16
 
 ### ✨ Features


### PR DESCRIPTION
CHANGELOG for **v0.52.0**: `unifi_setting` mgmt block full management settings (#274) + IPS signature alert suppression (#275). Merge before tagging `v0.52.0`.