### PR TITLE
fix(setting): omit unset numeric fields instead of serializing 0 (#303)

### DIFF
--- a/unifi/setting_resource.go
+++ b/unifi/setting_resource.go
@@ -2958,13 +2958,20 @@ func (r *settingResource) dpiSettingToModel(s *settings.Dpi) settingDpiModel {
 }
 
 func (r *settingResource) lcmModelToSetting(m *settingLcmModel) *settings.Lcm {
-	return &settings.Lcm{
-		Enabled:     m.Enabled.ValueBool(),
-		Brightness:  m.Brightness.ValueInt64Pointer(),
-		IDleTimeout: m.IdleTimeout.ValueInt64Pointer(),
-		Sync:        m.Sync.ValueBool(),
-		TouchEvent:  m.TouchEvent.ValueBool(),
+	setting := &settings.Lcm{
+		Enabled:    m.Enabled.ValueBool(),
+		Sync:       m.Sync.ValueBool(),
+		TouchEvent: m.TouchEvent.ValueBool(),
 	}
+	// Guard the optional ints: an unknown (unset Optional+Computed) value yields a
+	// 0 pointer, which the controller rejects as out of range (cf. #288/#303).
+	if !m.Brightness.IsNull() && !m.Brightness.IsUnknown() {
+		setting.Brightness = m.Brightness.ValueInt64Pointer()
+	}
+	if !m.IdleTimeout.IsNull() && !m.IdleTimeout.IsUnknown() {
+		setting.IDleTimeout = m.IdleTimeout.ValueInt64Pointer()
+	}
+	return setting
 }
 
 func (r *settingResource) lcmSettingToModel(s *settings.Lcm) settingLcmModel {
@@ -3018,13 +3025,19 @@ func (r *settingResource) syslogModelToSetting(
 		Enabled:                     m.Enabled.ValueBool(),
 		Debug:                       m.Debug.ValueBool(),
 		IP:                          m.IP.ValueString(),
-		Port:                        m.Port.ValueInt64Pointer(),
 		LogAllContents:              m.LogAllContents.ValueBool(),
 		NetconsoleEnabled:           m.NetconsoleEnabled.ValueBool(),
 		NetconsoleHost:              m.NetconsoleHost.ValueString(),
-		NetconsolePort:              m.NetconsolePort.ValueInt64Pointer(),
 		ThisController:              m.ThisController.ValueBool(),
 		ThisControllerEncryptedOnly: m.ThisControllerEncryptedOnly.ValueBool(),
+	}
+	// Guard the optional ports: an unknown (unset Optional+Computed) value yields a
+	// 0 pointer, which the controller rejects as an out-of-range port (#303, cf. #288).
+	if !m.Port.IsNull() && !m.Port.IsUnknown() {
+		setting.Port = m.Port.ValueInt64Pointer()
+	}
+	if !m.NetconsolePort.IsNull() && !m.NetconsolePort.IsUnknown() {
+		setting.NetconsolePort = m.NetconsolePort.ValueInt64Pointer()
 	}
 	if !m.Contents.IsNull() && !m.Contents.IsUnknown() {
 		diags.Append(m.Contents.ElementsAs(ctx, &setting.Contents, false)...)
@@ -3229,10 +3242,15 @@ func (r *settingResource) ipsModelToSetting(
 		for _, a := range alerts {
 			alert := settings.SettingIpsAlerts{
 				Category:  a.Category.ValueString(),
-				Gid:       a.Gid.ValueInt64Pointer(),
-				ID:        a.ID.ValueInt64Pointer(),
 				Signature: a.Signature.ValueString(),
 				Type:      a.Type.ValueString(),
+			}
+			// Omit gid/id when unset rather than sending 0 (cf. #303).
+			if !a.Gid.IsNull() && !a.Gid.IsUnknown() {
+				alert.Gid = a.Gid.ValueInt64Pointer()
+			}
+			if !a.ID.IsNull() && !a.ID.IsUnknown() {
+				alert.ID = a.ID.ValueInt64Pointer()
 			}
 			if !a.Tracking.IsNull() && !a.Tracking.IsUnknown() {
 				var tracking []settingIpsTrackingModel

--- a/unifi/setting_resource_test.go
+++ b/unifi/setting_resource_test.go
@@ -1426,3 +1426,50 @@ func TestIpsSuppressionAlertsRoundTrip(t *testing.T) {
 		t.Errorf("read-back alerts mismatch: %+v", outAlerts)
 	}
 }
+
+// TestSyslogOmitsUnsetPorts guards #303: an unset port / netconsole_port must be
+// omitted (nil pointer), not serialized as 0 — the controller rejects port 0.
+func TestSyslogOmitsUnsetPorts(t *testing.T) {
+	ctx := context.Background()
+	var diags diag.Diagnostics
+	r := &settingResource{}
+
+	m := &settingSyslogModel{
+		Enabled:        types.BoolValue(true),
+		IP:             types.StringValue("10.0.10.15"),
+		Port:           types.Int64Value(1514),
+		NetconsolePort: types.Int64Null(), // netconsole disabled / unset
+		Contents:       types.ListNull(types.StringType),
+	}
+	setting := r.syslogModelToSetting(ctx, m, &diags)
+	if diags.HasError() {
+		t.Fatalf("modelToSetting: %v", diags)
+	}
+	if setting.NetconsolePort != nil {
+		t.Errorf("netconsole_port must be omitted when unset, got %d", *setting.NetconsolePort)
+	}
+	if setting.Port == nil || *setting.Port != 1514 {
+		t.Errorf("port = %v, want 1514", setting.Port)
+	}
+
+	// Unknown (Optional+Computed at create) must also omit, not send 0.
+	m.Port = types.Int64Unknown()
+	setting = r.syslogModelToSetting(ctx, m, &diags)
+	if setting.Port != nil {
+		t.Errorf("unknown port must be omitted, got %d", *setting.Port)
+	}
+}
+
+// TestLcmOmitsUnsetInts guards the same #303 pattern for the lcm block.
+func TestLcmOmitsUnsetInts(t *testing.T) {
+	r := &settingResource{}
+	setting := r.lcmModelToSetting(&settingLcmModel{
+		Enabled:     types.BoolValue(true),
+		Brightness:  types.Int64Null(),
+		IdleTimeout: types.Int64Unknown(),
+	})
+	if setting.Brightness != nil || setting.IDleTimeout != nil {
+		t.Errorf("unset lcm ints must be omitted: brightness=%v idle=%v",
+			setting.Brightness, setting.IDleTimeout)
+	}
+}


### PR DESCRIPTION
## Context
#303: managing the `syslog` block with netconsole disabled made the provider send `netconsole_port: 0`, which the controller rejects with `api.err.InvalidPayload (400)`. Same zero-value serialization class as #288 — an unset Optional+Computed integer (unknown at create) becomes a `0` pointer via `ValueInt64Pointer()` instead of being omitted.

## Fix
Guard the optional integer conversions so the field is only set when the value is known and non-null (otherwise the `*int64` stays nil and is dropped by `omitempty`):
- **syslog**: `port`, `netconsole_port` (#303)
- **lcm**: `brightness`, `idle_timeout` (same latent bug)
- **ips** alert: `gid`, `id` (same latent bug)

These all shipped in v0.51.0/v0.52.0; this is a follow-up patch.

## Tests
`TestSyslogOmitsUnsetPorts` (unset + unknown port omitted, set port preserved) and `TestLcmOmitsUnsetInts`. `go build`/`go vet`/`go test ./...`/`golangci-lint` clean.

Closes #303