### PR TITLE
fix(firewall-policy): set matching_target_type for specific (non-ANY) matches (#293)

### DIFF
--- a/unifi/firewall_policy_resource.go
+++ b/unifi/firewall_policy_resource.go
@@ -761,18 +761,35 @@ func modelToFirewallPolicy(
 	return fp, diags
 }
 
+// firewallPolicyMatchingTargetType ensures a concrete matching_target_type is
+// sent for a specific (non-ANY) match. The controller rejects an IP/NETWORK/etc.
+// match whose matching_target_type is empty (#293,
+// api.err.MissingFirewallPolicySourceMatchingTargetType) — which happens when a
+// source is switched from ANY to a specific target, leaving the round-tripped
+// type empty or a stale "ANY". A controller-assigned type (SPECIFIC/OBJECT/LIST)
+// is preserved.
+func firewallPolicyMatchingTargetType(matchingTarget, currentType string) string {
+	if matchingTarget != "" && matchingTarget != "ANY" &&
+		(currentType == "" || currentType == "ANY") {
+		return "SPECIFIC"
+	}
+	return currentType
+}
+
 func endpointModelToSource(
 	ctx context.Context,
 	m firewallPolicyEndpointModel,
 	diags *diag.Diagnostics,
 ) *unifi.FirewallPolicySource {
 	ep := &unifi.FirewallPolicySource{
-		ZoneID:             m.ZoneID.ValueString(),
-		MatchingTarget:     m.MatchingTarget.ValueString(),
-		MatchingTargetType: m.MatchingTargetType.ValueString(),
-		Port:               m.Port.ValueString(),
-		PortGroupID:        m.PortGroupID.ValueString(),
-		PortMatchingType:   m.PortMatchingType.ValueString(),
+		ZoneID:         m.ZoneID.ValueString(),
+		MatchingTarget: m.MatchingTarget.ValueString(),
+		MatchingTargetType: firewallPolicyMatchingTargetType(
+			m.MatchingTarget.ValueString(), m.MatchingTargetType.ValueString(),
+		),
+		Port:             m.Port.ValueString(),
+		PortGroupID:      m.PortGroupID.ValueString(),
+		PortMatchingType: m.PortMatchingType.ValueString(),
 	}
 	if !m.IPs.IsNull() && !m.IPs.IsUnknown() {
 		diags.Append(m.IPs.ElementsAs(ctx, &ep.IPs, false)...)
@@ -795,12 +812,14 @@ func endpointModelToDestination(
 	diags *diag.Diagnostics,
 ) *unifi.FirewallPolicyDestination {
 	ep := &unifi.FirewallPolicyDestination{
-		ZoneID:             m.ZoneID.ValueString(),
-		MatchingTarget:     m.MatchingTarget.ValueString(),
-		MatchingTargetType: m.MatchingTargetType.ValueString(),
-		Port:               m.Port.ValueString(),
-		PortGroupID:        m.PortGroupID.ValueString(),
-		PortMatchingType:   m.PortMatchingType.ValueString(),
+		ZoneID:         m.ZoneID.ValueString(),
+		MatchingTarget: m.MatchingTarget.ValueString(),
+		MatchingTargetType: firewallPolicyMatchingTargetType(
+			m.MatchingTarget.ValueString(), m.MatchingTargetType.ValueString(),
+		),
+		Port:             m.Port.ValueString(),
+		PortGroupID:      m.PortGroupID.ValueString(),
+		PortMatchingType: m.PortMatchingType.ValueString(),
 	}
 	if !m.IPs.IsNull() && !m.IPs.IsUnknown() {
 		diags.Append(m.IPs.ElementsAs(ctx, &ep.IPs, false)...)

--- a/unifi/firewall_policy_resource_test.go
+++ b/unifi/firewall_policy_resource_test.go
@@ -1078,3 +1078,47 @@ func Test_firewallPolicyResource_ListResourceConfigSchema(t *testing.T) {
 		})
 	}
 }
+
+// TestFirewallPolicyMatchingTargetType guards #293: a specific (non-ANY) match
+// must carry a concrete matching_target_type — the controller rejects an empty
+// one (api.err.MissingFirewallPolicySourceMatchingTargetType) when a source is
+// switched from ANY to e.g. IP. A controller-assigned type is preserved.
+func TestFirewallPolicyMatchingTargetType(t *testing.T) {
+	cases := []struct {
+		matchingTarget, current, want string
+	}{
+		{"IP", "", "SPECIFIC"},         // ANY -> IP, type was dropped
+		{"IP", "ANY", "SPECIFIC"},      // ANY -> IP, stale "ANY" left over
+		{"IP", "SPECIFIC", "SPECIFIC"}, // already correct
+		{"IP", "OBJECT", "OBJECT"},     // controller-assigned object/group preserved
+		{"NETWORK", "", "SPECIFIC"},
+		{"ANY", "", ""}, // ANY source untouched
+		{"ANY", "ANY", "ANY"},
+	}
+	for _, c := range cases {
+		if got := firewallPolicyMatchingTargetType(c.matchingTarget, c.current); got != c.want {
+			t.Errorf("matchingTargetType(%q,%q) = %q, want %q",
+				c.matchingTarget, c.current, got, c.want)
+		}
+	}
+
+	// End-to-end: an IP source whose type was lost serializes SPECIFIC.
+	ctx := context.Background()
+	var diags diag.Diagnostics
+	ips, _ := types.ListValueFrom(ctx, types.StringType, []string{"10.0.40.138"})
+	m := firewallPolicyEndpointModel{
+		ZoneID:             types.StringValue("z1"),
+		MatchingTarget:     types.StringValue("IP"),
+		IPs:                ips,
+		NetworkIDs:         types.ListNull(types.StringType),
+		ClientMACs:         types.ListNull(types.StringType),
+		WebDomains:         types.ListNull(types.StringType),
+		Port:               types.StringNull(),
+		PortGroupID:        types.StringNull(),
+		PortMatchingType:   types.StringValue("ANY"),
+		MatchingTargetType: types.StringValue("ANY"),
+	}
+	if got := endpointModelToSource(ctx, m, &diags).MatchingTargetType; got != "SPECIFIC" {
+		t.Errorf("source MatchingTargetType = %q, want SPECIFIC", got)
+	}
+}


### PR DESCRIPTION
## Context
#293: changing a `unifi_firewall_policy` `source`/`destination` from `matching_target = "ANY"` to a specific target (e.g. `"IP"` with `ips = [...]`) made the `PUT` omit `matching_target_type`. The controller requires it for a specific match and rejects the update with `api.err.MissingFirewallPolicySourceMatchingTargetType (400)`. A UI/API-created IP match carries `matching_target_type: "SPECIFIC"`.

`matching_target_type` is a controller-managed field the provider round-trips, so the ANY→IP switch left it empty (or a stale `"ANY"`), which `omitempty` then dropped.

## Fix
`firewallPolicyMatchingTargetType()`: for a non-ANY `matching_target` whose current type is empty or `"ANY"`, send `"SPECIFIC"` (what the UI/v2 API produce for an IP/list match). A controller-assigned type (`SPECIFIC`/`OBJECT`/`LIST`) is preserved, and ANY endpoints are untouched — so no regression for existing policies. Applied to both source and destination.

## Tests
`TestFirewallPolicyMatchingTargetType` (the mapping table + an end-to-end IP source that had its type dropped → SPECIFIC). `go build`/`go vet`/`go test ./...`/`golangci-lint` clean.

Closes #293