### PR TITLE
docs(network): clarify subnet sets the gateway IP (custom gateway supported)

### DIFF
--- a/docs/resources/network.md
+++ b/docs/resources/network.md
@@ -122,7 +122,7 @@ resource "unifi_network" "third_party" {
 - `network_isolation` (Boolean) Specifies whether network isolation is enabled.
 - `setting_preference` (String) Setting preference. Must be one of `auto` or `manual`.
 - `site` (String) The name of the site to associate the network with.
-- `subnet` (String) The IPv4 subnet of the network in CIDR notation. Optional: it is not required for `vlan_only` networks (`third_party_gateway = true`), where the UniFi controller does not manage the subnet.
+- `subnet` (String) The network's gateway IP and prefix in CIDR notation. The host portion is the gateway address the controller assigns — it need not be the first usable address: `10.0.10.1/24` uses gateway `10.0.10.1`, while `10.0.10.254/24` uses gateway `10.0.10.254` on the same subnet. Optional: it is not required for `vlan_only` networks (`third_party_gateway = true`), where the UniFi controller does not manage the subnet.
 - `third_party_gateway` (Boolean) Specifies whether this network uses a third-party gateway. When enabled, the network purpose is set to `vlan-only` and only VLAN ID, DHCP guarding, and basic network settings are configured.
 - `timeouts` (Attributes) (see [below for nested schema](#nestedatt--timeouts))
 - `vlan` (Number) The VLAN ID for the network.

--- a/unifi/network_resource.go
+++ b/unifi/network_resource.go
@@ -347,9 +347,12 @@ func (r *networkResource) Schema(
 				Default:             booldefault.StaticBool(true),
 			},
 			"subnet": schema.StringAttribute{
-				MarkdownDescription: "The IPv4 subnet of the network in CIDR notation. Optional: it is " +
-					"not required for `vlan_only` networks (`third_party_gateway = true`), where the " +
-					"UniFi controller does not manage the subnet.",
+				MarkdownDescription: "The network's gateway IP and prefix in CIDR notation. The host " +
+					"portion is the gateway address the controller assigns — it need not be the first " +
+					"usable address: `10.0.10.1/24` uses gateway `10.0.10.1`, while `10.0.10.254/24` " +
+					"uses gateway `10.0.10.254` on the same subnet. Optional: it is not required for " +
+					"`vlan_only` networks (`third_party_gateway = true`), where the UniFi controller " +
+					"does not manage the subnet.",
 				Optional:   true,
 				CustomType: cidrtypes.IPv4PrefixType{},
 			},


### PR DESCRIPTION
## Context
#308 asks for a custom gateway IP on `unifi_network`, assuming `subnet` forces the first usable address (`.1`).

In fact UniFi's `ip_subnet` field **is** the gateway IP + prefix, and the provider passes `subnet` through unchanged (the `cidrtypes.IPv4Prefix` type accepts host bits and does not normalize to the network address). So a custom gateway already works:

```hcl
resource "unifi_network" "servers" {
  name   = "servers"
  subnet = "10.0.10.254/24"  # gateway 10.0.10.254
}
```

**Live-verified** (UniFi Network 10.x): `subnet = "10.88.0.254/24"` → controller stores `ip_subnet=10.88.0.254/24` (gateway `.254`), and the plan is idempotent.

This PR just clarifies the `subnet` attribute description to document the behavior — no code change.

Refs #308