### PR TITLE
fix(firewall-zone): stop sending computed default_zone on create (#310)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/hashicorp/terraform-plugin-testing v1.16.0
 	github.com/testcontainers/testcontainers-go v0.42.0
 	github.com/testcontainers/testcontainers-go/modules/compose v0.42.0
-	github.com/ubiquiti-community/go-unifi v1.33.43-0.20260616140026-335a2849e608
+	github.com/ubiquiti-community/go-unifi v1.33.43-0.20260617194535-a4efb77d2dbe
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -538,8 +538,8 @@ github.com/transparency-dev/formats v0.0.0-20251017110053-404c0d5b696c h1:5a2XDQ
 github.com/transparency-dev/formats v0.0.0-20251017110053-404c0d5b696c/go.mod h1:g85IafeFJZLxlzZCDRu4JLpfS7HKzR+Hw9qRh3bVzDI=
 github.com/transparency-dev/merkle v0.0.2 h1:Q9nBoQcZcgPamMkGn7ghV8XiTZ/kRxn1yCG81+twTK4=
 github.com/transparency-dev/merkle v0.0.2/go.mod h1:pqSy+OXefQ1EDUVmAJ8MUhHB9TXGuzVAT58PqBoHz1A=
-github.com/ubiquiti-community/go-unifi v1.33.43-0.20260616140026-335a2849e608 h1:UJTU6xbACVc+pY5RPa7VW804HMWeF+XAgIFj5BBOMvU=
-github.com/ubiquiti-community/go-unifi v1.33.43-0.20260616140026-335a2849e608/go.mod h1:QfZDUwKQmGJNNW4af3KHzb7f+VmiSvkyTqC4/D5aPWU=
+github.com/ubiquiti-community/go-unifi v1.33.43-0.20260617194535-a4efb77d2dbe h1:oj/V4vRbZjYkxSWvLXUWZJjXtf2onCbFoz/n9ycxIpU=
+github.com/ubiquiti-community/go-unifi v1.33.43-0.20260617194535-a4efb77d2dbe/go.mod h1:QfZDUwKQmGJNNW4af3KHzb7f+VmiSvkyTqC4/D5aPWU=
 github.com/vbatts/tar-split v0.12.2 h1:w/Y6tjxpeiFMR47yzZPlPj/FcPLpXbTUi/9H7d3CPa4=
 github.com/vbatts/tar-split v0.12.2/go.mod h1:eF6B6i6ftWQcDqEn3/iGFRFRo8cBIMSJVOpnNdfTMFA=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=

--- a/unifi/firewall_zone_resource.go
+++ b/unifi/firewall_zone_resource.go
@@ -379,7 +379,7 @@ func (r *firewallZoneResource) firewallZoneToModel(
 	model.Site = types.StringValue(site)
 	model.Name = types.StringValue(zone.Name)
 	model.ZoneKey = types.StringValue(zone.ZoneKey)
-	model.DefaultZone = types.BoolValue(zone.DefaultZone)
+	model.DefaultZone = types.BoolPointerValue(zone.DefaultZone)
 
 	networkIDs, diags := types.ListValueFrom(ctx, types.StringType, zone.NetworkIDs)
 	model.NetworkIDs = networkIDs

--- a/unifi/firewall_zone_resource_test.go
+++ b/unifi/firewall_zone_resource_test.go
@@ -11,6 +11,8 @@ import (
 	"github.com/ubiquiti-community/go-unifi/unifi"
 )
 
+func boolPtr(b bool) *bool { return &b }
+
 // TestFirewallZoneModelRoundTrip validates the model <-> go-unifi struct
 // conversion for the unifi_firewall_zone resource (#214). It is a unit test
 // rather than an acceptance test because zone-based firewall is not available
@@ -44,7 +46,7 @@ func TestFirewallZoneModelRoundTrip(t *testing.T) {
 		Name:        "DMZ",
 		NetworkIDs:  []string{"net-a", "net-b"},
 		ZoneKey:     "dmz",
-		DefaultZone: false,
+		DefaultZone: boolPtr(false),
 	}
 	var out firewallZoneResourceModel
 	if diags := r.firewallZoneToModel(ctx, apiZone, &out, "default"); diags.HasError() {
@@ -354,7 +356,7 @@ func Test_firewallZoneResource_firewallZoneToModel(t *testing.T) {
 				ID:          "z1",
 				Name:        "LAN",
 				ZoneKey:     "lan",
-				DefaultZone: true,
+				DefaultZone: boolPtr(true),
 				NetworkIDs:  []string{"n1"},
 			},
 			site:            "default",
@@ -370,7 +372,7 @@ func Test_firewallZoneResource_firewallZoneToModel(t *testing.T) {
 				ID:          "z2",
 				Name:        "DMZ",
 				ZoneKey:     "dmz",
-				DefaultZone: false,
+				DefaultZone: boolPtr(false),
 				NetworkIDs:  []string{},
 			},
 			site:            "site1",


### PR DESCRIPTION
## Context
#310: `unifi_firewall_zone` create fails on UniFi Network 10.4.x with `400 "Unrecognized field default_zone"`. `default_zone` is server-computed/read-only, but go-unifi's field was a no-`omitempty` `bool`, so the create POST always sent `"default_zone":false` — which the v2 `firewall/zone` endpoint rejects (a name-only body is accepted).

## Fix
- go-unifi: `FirewallZone.DefaultZone` is now `*bool` with `omitempty` (ubiquiti-community/go-unifi#45). The provider never sets it on write (`modelToFirewallZone` only sends name/network_ids), so it's now omitted from the request.
- provider: read it back with `types.BoolPointerValue` into the computed `default_zone` attribute; bumped go-unifi.

## Validation
- Unit: `TestFirewallZoneModelRoundTrip` updated (`*bool` fixtures).
- Live (UCG, Network 10.x): the create no longer returns the `default_zone` 400. (This controller isn't ZBF-migrated so it 500s on any zone create — the field rejection is gone, which is the bug; the reporter confirmed a name-only create returns 200 on a migrated 10.4.57 controller.)

Closes #310