### PR TITLE
test(wireguard): drop provider block from list query ConfigFile

### DIFF
--- a/unifi/wireguard_peer_resource_test.go
+++ b/unifi/wireguard_peer_resource_test.go
@@ -410,7 +410,6 @@ func TestAccWireguardPeerList_basic(t *testing.T) {
 				Query: true,
 				ConfigFile: config.TestStepConfigFunc(func(_ config.TestStepConfigRequest) string {
 					content := fmt.Sprintf(`
-provider "unifi" {}
 list "unifi_wireguard_peer" "test" {
   provider = unifi
   config {


### PR DESCRIPTION
`TestAccWireguardPeerList_basic` fails at TestStep validation — *"Providers must only be specified either at the TestCase or TestStep level"* — which runs **before** the TF_ACC skip, so it reddened the `test` CI check (and `go test ./...`) for every PR even though acceptance tests don't run in CI.

Its `Query` step uses `ConfigFile` (a func, to inject the dynamic `network_id`) whose HCL embedded `provider "unifi" {}` while the provider is already supplied via `ProtoV6ProviderFactories`. In `ConfigFile` mode that combination is rejected; the other list tests use inline `Config` and aren't affected. Drop the redundant block — `provider = unifi` still resolves to the factory provider.

`go test ./...` is green again (the test now SKIPs without TF_ACC as intended).