### PR TITLE
chore(deps): bump go-unifi for firewall-zone network_ids create fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -228,3 +228,5 @@ tool (
 	github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs
 	gotest.tools/gotestsum
 )
+
+replace github.com/ubiquiti-community/go-unifi => github.com/scottsuch/go-unifi v1.33.43-0.20260618005633-c973a03a5acb

--- a/go.sum
+++ b/go.sum
@@ -456,6 +456,8 @@ github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/santhosh-tekuri/jsonschema/v6 v6.0.1 h1:PKK9DyHxif4LZo+uQSgXNqs0jj5+xZwwfKHgph2lxBw=
 github.com/santhosh-tekuri/jsonschema/v6 v6.0.1/go.mod h1:JXeL+ps8p7/KNMjDQk3TCwPpBy0wYklyWTfbkIzdIFU=
+github.com/scottsuch/go-unifi v1.33.43-0.20260618005633-c973a03a5acb h1:OMfYHpLgONxmY4VjB4IlkWwugzWZAGGk2PkCJ2h20mw=
+github.com/scottsuch/go-unifi v1.33.43-0.20260618005633-c973a03a5acb/go.mod h1:QfZDUwKQmGJNNW4af3KHzb7f+VmiSvkyTqC4/D5aPWU=
 github.com/secure-systems-lab/go-securesystemslib v0.10.0 h1:l+H5ErcW0PAehBNrBxoGv1jjNpGYdZ9RcheFkB2WI14=
 github.com/secure-systems-lab/go-securesystemslib v0.10.0/go.mod h1:MRKONWmRoFzPNQ9USRF9i1mc7MvAVvF1LlW8X5VWDvk=
 github.com/sergi/go-diff v1.4.0 h1:n/SP9D5ad1fORl+llWyN+D6qoUETXNZARKjyY2/KVCw=
@@ -538,8 +540,6 @@ github.com/transparency-dev/formats v0.0.0-20251017110053-404c0d5b696c h1:5a2XDQ
 github.com/transparency-dev/formats v0.0.0-20251017110053-404c0d5b696c/go.mod h1:g85IafeFJZLxlzZCDRu4JLpfS7HKzR+Hw9qRh3bVzDI=
 github.com/transparency-dev/merkle v0.0.2 h1:Q9nBoQcZcgPamMkGn7ghV8XiTZ/kRxn1yCG81+twTK4=
 github.com/transparency-dev/merkle v0.0.2/go.mod h1:pqSy+OXefQ1EDUVmAJ8MUhHB9TXGuzVAT58PqBoHz1A=
-github.com/ubiquiti-community/go-unifi v1.33.43-0.20260617194535-a4efb77d2dbe h1:oj/V4vRbZjYkxSWvLXUWZJjXtf2onCbFoz/n9ycxIpU=
-github.com/ubiquiti-community/go-unifi v1.33.43-0.20260617194535-a4efb77d2dbe/go.mod h1:QfZDUwKQmGJNNW4af3KHzb7f+VmiSvkyTqC4/D5aPWU=
 github.com/vbatts/tar-split v0.12.2 h1:w/Y6tjxpeiFMR47yzZPlPj/FcPLpXbTUi/9H7d3CPa4=
 github.com/vbatts/tar-split v0.12.2/go.mod h1:eF6B6i6ftWQcDqEn3/iGFRFRo8cBIMSJVOpnNdfTMFA=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=


### PR DESCRIPTION
> **Draft — blocked on ubiquiti-community/go-unifi#46.** Pinned to a fork commit via `replace` so it builds now; before merge, drop the `replace` and bump the `require` to the go-unifi release that carries the fix.

## What

Pulls **go-unifi#46**, which fixes `unifi_firewall_zone` creation.

## Why

Creating a firewall zone with no networks assigned yet fails: the v2 `firewall/zone` POST returns **HTTP 500** when the body omits `network_ids`. go-unifi marked `FirewallZone.NetworkIDs` as `omitempty`, so the provider's empty `[]string` was dropped from the request body. This is the failure that remained after #310 fixed the earlier `default_zone` **400**, and it's why zones still have to be created via the v2 API + `terraform import`.

go-unifi#46 drops `omitempty` so an empty list serializes as `"network_ids":[]`, which the controller accepts (201).

**No provider code change is required** — `modelToFirewallZone` already sends `NetworkIDs: []string{}`.

## Testing

Built this branch and ran it against a live UniFi Network controller via a `dev_overrides` binary:

```hcl
resource "unifi_firewall_zone" "canary" {
  name = "tf-canary-prov"   # no network_ids — the case that used to 500
}
```

- `terraform apply` → **Creation complete** (previously HTTP 500).
- `terraform destroy` → clean; controller returned to its original zone set.

Confirmed body-level behavior directly: `{"name":"x"}` → 500, `{"name":"x","network_ids":[]}` → 201.

## Merge checklist

- [ ] go-unifi#46 merged + released
- [ ] drop the `replace`, bump `require github.com/ubiquiti-community/go-unifi` to that release
- [ ] `go mod tidy`