### PR TITLE
fix(firewall-policy): resolve inconsistent-result on matching_target_type update (#324)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### 🐛 Bug Fixes
+
+- **`unifi_firewall_policy`: fix `inconsistent result after apply` on `source`/`destination` `matching_target_type` when updating a policy (e.g. changing `action`).** This field is firmware-derived: the controller (and the provider's own derivation for #293) may set it to a concrete value during the update PUT (e.g. `""` → `"SPECIFIC"` for a non-ANY match), which the planned value cannot anticipate when the prior state still carries an empty type. The update path now re-asserts the planned value on the post-apply state, leaving the next refresh to reconcile it with the controller (#324)
+
 ## [v0.52.4] - 2026-06-17
 
 ### 🐛 Bug Fixes

--- a/unifi/firewall_policy_resource.go
+++ b/unifi/firewall_policy_resource.go
@@ -512,6 +512,18 @@ func (r *firewallPolicyResource) Update(
 		return
 	}
 
+	// matching_target_type is firmware-derived: the controller (and the
+	// provider's own firewallPolicyMatchingTargetType helper) may set it to a
+	// concrete value during the PUT (e.g. "" -> "SPECIFIC" for a non-ANY match),
+	// which the planned value cannot anticipate. It is Computed +
+	// UseStateForUnknown, so the planned value is the prior-state value; capture
+	// it now and re-assert it on the post-apply state so Terraform's
+	// "inconsistent result after apply" check passes for policies whose state
+	// still carries an empty type (#324). The next Read reconciles state with the
+	// controller's value.
+	plannedSrcMTT := endpointMatchingTargetType(ctx, plan.Source, &resp.Diagnostics)
+	plannedDstMTT := endpointMatchingTargetType(ctx, plan.Destination, &resp.Diagnostics)
+
 	updated, err := r.client.UpdateFirewallPolicy(ctx, site, fp)
 	if err != nil {
 		resp.Diagnostics.AddError(
@@ -522,6 +534,17 @@ func (r *firewallPolicyResource) Update(
 	}
 
 	resp.Diagnostics.Append(firewallPolicyToModel(ctx, updated, &plan)...)
+
+	// Only re-assert when the plan carried a known value: if it was unknown
+	// (an in-block field changed), the attribute is known-after-apply and the
+	// controller's value is accepted as-is.
+	if !plannedSrcMTT.IsNull() && !plannedSrcMTT.IsUnknown() {
+		plan.Source = withMatchingTargetType(ctx, plan.Source, plannedSrcMTT, &resp.Diagnostics)
+	}
+	if !plannedDstMTT.IsNull() && !plannedDstMTT.IsUnknown() {
+		plan.Destination = withMatchingTargetType(ctx, plan.Destination, plannedDstMTT, &resp.Diagnostics)
+	}
+
 	plan.Site = types.StringValue(site)
 	resp.Diagnostics.Append(resp.Identity.SetAttribute(ctx, path.Root("id"), plan.ID)...)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
@@ -834,6 +857,44 @@ func endpointModelToDestination(
 		diags.Append(m.WebDomains.ElementsAs(ctx, &ep.WebDomains, false)...)
 	}
 	return ep
+}
+
+// endpointMatchingTargetType extracts the matching_target_type out of a
+// source/destination object, or a null string if the object is null/unknown.
+func endpointMatchingTargetType(
+	ctx context.Context,
+	obj types.Object,
+	diags *diag.Diagnostics,
+) types.String {
+	if obj.IsNull() || obj.IsUnknown() {
+		return types.StringNull()
+	}
+	var m firewallPolicyEndpointModel
+	diags.Append(obj.As(ctx, &m, basetypes.ObjectAsOptions{})...)
+	return m.MatchingTargetType
+}
+
+// withMatchingTargetType returns obj with its matching_target_type replaced by
+// mtt, leaving every other attribute untouched.
+func withMatchingTargetType(
+	ctx context.Context,
+	obj types.Object,
+	mtt types.String,
+	diags *diag.Diagnostics,
+) types.Object {
+	if obj.IsNull() || obj.IsUnknown() {
+		return obj
+	}
+	var m firewallPolicyEndpointModel
+	diags.Append(obj.As(ctx, &m, basetypes.ObjectAsOptions{})...)
+	m.MatchingTargetType = mtt
+	newObj, d := types.ObjectValueFrom(
+		ctx,
+		firewallPolicyEndpointModel{}.AttributeTypes(),
+		m,
+	)
+	diags.Append(d...)
+	return newObj
 }
 
 func firewallPolicyToModel(

--- a/unifi/firewall_policy_resource.go
+++ b/unifi/firewall_policy_resource.go
@@ -542,7 +542,12 @@ func (r *firewallPolicyResource) Update(
 		plan.Source = withMatchingTargetType(ctx, plan.Source, plannedSrcMTT, &resp.Diagnostics)
 	}
 	if !plannedDstMTT.IsNull() && !plannedDstMTT.IsUnknown() {
-		plan.Destination = withMatchingTargetType(ctx, plan.Destination, plannedDstMTT, &resp.Diagnostics)
+		plan.Destination = withMatchingTargetType(
+			ctx,
+			plan.Destination,
+			plannedDstMTT,
+			&resp.Diagnostics,
+		)
 	}
 
 	plan.Site = types.StringValue(site)

--- a/unifi/firewall_policy_resource_test.go
+++ b/unifi/firewall_policy_resource_test.go
@@ -10,6 +10,7 @@ import (
 	fwlist "github.com/hashicorp/terraform-plugin-framework/list"
 	fwresource "github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/ubiquiti-community/go-unifi/unifi"
 )
 
@@ -1120,5 +1121,70 @@ func TestFirewallPolicyMatchingTargetType(t *testing.T) {
 	}
 	if got := endpointModelToSource(ctx, m, &diags).MatchingTargetType; got != "SPECIFIC" {
 		t.Errorf("source MatchingTargetType = %q, want SPECIFIC", got)
+	}
+}
+
+// TestFirewallPolicyPreserveMatchingTargetType guards #324: matching_target_type
+// is firmware-derived and may change during an update PUT (e.g. "" -> "SPECIFIC"
+// for a non-ANY match, via the controller or firewallPolicyMatchingTargetType).
+// Since the attribute is Computed + UseStateForUnknown, the planned value is the
+// prior-state value; the Update path captures it and re-asserts it on the
+// post-apply state so Terraform's consistency check passes. This exercises the
+// extract/replace helpers that implement that re-assertion.
+func TestFirewallPolicyPreserveMatchingTargetType(t *testing.T) {
+	ctx := context.Background()
+	var diags diag.Diagnostics
+
+	// A source object as it appears in the plan, with matching_target_type
+	// carried over from prior state as "" (a legacy/empty state).
+	planned := firewallPolicyEndpointModel{
+		ZoneID:             types.StringValue("zone-1"),
+		MatchingTarget:     types.StringValue("IP"),
+		NetworkIDs:         types.ListNull(types.StringType),
+		ClientMACs:         types.ListNull(types.StringType),
+		IPs:                types.ListNull(types.StringType),
+		WebDomains:         types.ListNull(types.StringType),
+		Port:               types.StringValue("443"),
+		PortGroupID:        types.StringNull(),
+		PortMatchingType:   types.StringValue("SPECIFIC"),
+		MatchingTargetType: types.StringValue(""),
+	}
+	plannedObj, d := types.ObjectValueFrom(
+		ctx,
+		firewallPolicyEndpointModel{}.AttributeTypes(),
+		planned,
+	)
+	diags.Append(d...)
+
+	if got := endpointMatchingTargetType(ctx, plannedObj, &diags); got.ValueString() != "" {
+		t.Errorf("endpointMatchingTargetType = %q, want \"\"", got.ValueString())
+	}
+
+	// The controller re-derived matching_target_type to "SPECIFIC" on the apply
+	// response. We must re-assert the planned "" to keep the result consistent.
+	applied := planned
+	applied.MatchingTargetType = types.StringValue("SPECIFIC")
+	appliedObj, d2 := types.ObjectValueFrom(
+		ctx,
+		firewallPolicyEndpointModel{}.AttributeTypes(),
+		applied,
+	)
+	diags.Append(d2...)
+
+	fixed := withMatchingTargetType(ctx, appliedObj, types.StringValue(""), &diags)
+	if diags.HasError() {
+		t.Fatalf("helpers errored: %v", diags)
+	}
+
+	var out firewallPolicyEndpointModel
+	fixed.As(ctx, &out, basetypes.ObjectAsOptions{})
+	if out.MatchingTargetType.ValueString() != "" {
+		t.Errorf("after withMatchingTargetType, matching_target_type = %q, want \"\"",
+			out.MatchingTargetType.ValueString())
+	}
+	// Every other attribute must survive untouched.
+	if out.Port.ValueString() != "443" || out.PortMatchingType.ValueString() != "SPECIFIC" {
+		t.Errorf("withMatchingTargetType clobbered other fields: port=%q pmt=%q",
+			out.Port.ValueString(), out.PortMatchingType.ValueString())
 	}
 }


### PR DESCRIPTION
## Summary

Fixes #324 — `unifi_firewall_policy` fails with **"Provider produced inconsistent result after apply"** on `source.matching_target_type` (e.g. `was "" but now "SPECIFIC"`) when updating a policy, such as flipping `action` from `ALLOW` to `BLOCK`.

## Root cause

`matching_target_type` is firmware-derived. During the update PUT the controller — and now the provider's own `firewallPolicyMatchingTargetType` helper (added for #293) — may set it to a concrete value (e.g. `""` → `"SPECIFIC"` for a non-ANY match). The attribute is `Computed + UseStateForUnknown`, so the planned value is the prior-state value. A policy whose state still carries an **empty** type (created before #293, or never re-applied) therefore trips Terraform's post-apply consistency check on the first update.

## Fix

`Update()` captures the planned `matching_target_type` of `source`/`destination` and re-asserts it on the post-apply state — but only when it was a *known* value. If it was unknown (an in-block field changed), the attribute is known-after-apply and the controller's value is accepted as-is. The next `Read` reconciles state with the controller.

The PUT payload is **unchanged**, so #293 and the #220 HTTP 400 round-trip are unaffected.

## Tests

- New `TestFirewallPolicyPreserveMatchingTargetType` covers the extract/replace helpers (planned `""` re-asserted over a controller `"SPECIFIC"`, other fields untouched).
- Existing suite (incl. `TestFirewallPolicyMatchingTargetType` #293 and `TestFirewallPolicyPreservesFirmwareFields` #220) still passes.

> ⚠️ Validated by unit tests only; not exercised against a live controller (no zone-based-firewall test harness locally). Real-controller confirmation on UniFi 10.4.x welcome.

Supersedes #325 (which was cut from a stale base).