### PR TITLE
fix(wlan): make controller-managed fields Computed to stop inconsistent-result (#323)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### 🐛 Bug Fixes
+
+- **`unifi_wlan`: fix `inconsistent result after apply` on controller-managed fields.** `minimum_data_rate_2g_kbps`/`minimum_data_rate_5g_kbps` defaulted to `0`, but the controller assigns its own value in `auto` mode (e.g. `1000`/`6000`); they are now `Computed` (via `UseStateForUnknown`) instead of statically defaulted. `radius_profile_id` and `bc_filter_list` were `Optional`-only yet the controller populates them on its own, so they too became `Optional + Computed`. When these are left unset, the controller's value is now accepted instead of conflicting with a `0`/`null` plan (#323)
+
 ## [v0.52.4] - 2026-06-17
 
 ### 🐛 Bug Fixes

--- a/docs/resources/wlan.md
+++ b/docs/resources/wlan.md
@@ -77,7 +77,7 @@ resource "unifi_wlan" "wifi" {
 
 - `ap_group_ids` (Set of String) List of AP group IDs to apply this WLAN to.
 - `ap_group_mode` (String) Access point group mode.
-- `bc_filter_list` (Set of String) List of MAC addresses for the broadcast filter.
+- `bc_filter_list` (Set of String) List of MAC addresses for the broadcast filter. The controller may populate this on its own, so it is computed when unset.
 - `bss_transition` (Boolean) Improves client roaming by providing connection details of nearby APs.
 - `dtim_6e` (Number) DTIM period for the 6 GHz band (1-255). Only used when `dtim_mode` is `custom`. Computed from the controller when not set.
 - `dtim_mode` (String) DTIM mode. Can be one of `default` or `custom`. Use `custom` together with `dtim_ng`/`dtim_na`/`dtim_6e`.
@@ -93,8 +93,8 @@ resource "unifi_wlan" "wifi" {
 - `is_guest` (Boolean) Indicates that this is a guest WLAN and should use guest behaviors.
 - `l2_isolation` (Boolean) Isolates stations on layer 2 (ethernet) level.
 - `mac_filter` (Attributes) MAC address filtering configuration. (see [below for nested schema](#nestedatt--mac_filter))
-- `minimum_data_rate_2g_kbps` (Number) Minimum data rate for 2G clients in Kbps.
-- `minimum_data_rate_5g_kbps` (Number) Minimum data rate for 5G clients in Kbps.
+- `minimum_data_rate_2g_kbps` (Number) Minimum data rate for 2G clients in Kbps. When unset, the controller assigns a value (e.g. `1000` in `auto` mode), so this is computed rather than defaulted to `0`.
+- `minimum_data_rate_5g_kbps` (Number) Minimum data rate for 5G clients in Kbps. When unset, the controller assigns a value (e.g. `6000` in `auto` mode), so this is computed rather than defaulted to `0`.
 - `minrate_setting_preference` (String) Minimum rate setting preference.
 - `mlo_enabled` (Boolean) Enable Multi-Link Operation (6 GHz).
 - `multicast_enhance` (Boolean) Indicates whether or not Multicast Enhance is turned of for the network.
@@ -108,7 +108,7 @@ resource "unifi_wlan" "wifi" {
 - `private_preshared_keys_enabled` (Boolean) Whether per-key (PPSK) passphrases are enabled for this WLAN. Requires `security = wpapsk`.
 - `proxy_arp` (Boolean) Reduces airtime usage by allowing APs to "proxy" common broadcast frames as unicast.
 - `radius_mac_auth_enabled` (Boolean) Enable RADIUS MAC authentication.
-- `radius_profile_id` (String) ID of the RADIUS profile to use when security `wpaeap`.
+- `radius_profile_id` (String) ID of the RADIUS profile to use when security `wpaeap`. The controller may assign a default profile, so this is computed when unset.
 - `schedule` (Block List) Start and stop schedules for the WLAN (see [below for nested schema](#nestedblock--schedule))
 - `site` (String) The name of the site to associate the WLAN with.
 - `timeouts` (Attributes) (see [below for nested schema](#nestedatt--timeouts))

--- a/unifi/wlan_resource.go
+++ b/unifi/wlan_resource.go
@@ -27,6 +27,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/setdefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/setplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -414,8 +415,13 @@ func (r *wlanFrameworkResource) Schema(
 				},
 			},
 			"radius_profile_id": schema.StringAttribute{
-				MarkdownDescription: "ID of the RADIUS profile to use when security `wpaeap`.",
-				Optional:            true,
+				MarkdownDescription: "ID of the RADIUS profile to use when security `wpaeap`. " +
+					"The controller may assign a default profile, so this is computed when unset.",
+				Optional: true,
+				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"nas_identifier_type": schema.StringAttribute{
 				MarkdownDescription: "NAS identifier type for RADIUS.",
@@ -463,10 +469,14 @@ func (r *wlanFrameworkResource) Schema(
 				Default:             booldefault.StaticBool(false),
 			},
 			"minimum_data_rate_2g_kbps": schema.Int64Attribute{
-				MarkdownDescription: "Minimum data rate for 2G clients in Kbps.",
-				Optional:            true,
-				Computed:            true,
-				Default:             int64default.StaticInt64(0),
+				MarkdownDescription: "Minimum data rate for 2G clients in Kbps. " +
+					"When unset, the controller assigns a value (e.g. `1000` in `auto` mode), " +
+					"so this is computed rather than defaulted to `0`.",
+				Optional: true,
+				Computed: true,
+				PlanModifiers: []planmodifier.Int64{
+					int64planmodifier.UseStateForUnknown(),
+				},
 				Validators: []validator.Int64{
 					int64validator.OneOf(
 						0,
@@ -486,10 +496,14 @@ func (r *wlanFrameworkResource) Schema(
 				},
 			},
 			"minimum_data_rate_5g_kbps": schema.Int64Attribute{
-				MarkdownDescription: "Minimum data rate for 5G clients in Kbps.",
-				Optional:            true,
-				Computed:            true,
-				Default:             int64default.StaticInt64(0),
+				MarkdownDescription: "Minimum data rate for 5G clients in Kbps. " +
+					"When unset, the controller assigns a value (e.g. `6000` in `auto` mode), " +
+					"so this is computed rather than defaulted to `0`.",
+				Optional: true,
+				Computed: true,
+				PlanModifiers: []planmodifier.Int64{
+					int64planmodifier.UseStateForUnknown(),
+				},
 				Validators: []validator.Int64{
 					int64validator.OneOf(0, 6000, 9000, 12000, 18000, 24000, 36000, 48000, 54000),
 				},
@@ -618,9 +632,14 @@ func (r *wlanFrameworkResource) Schema(
 				Default:             booldefault.StaticBool(false),
 			},
 			"bc_filter_list": schema.SetAttribute{
-				MarkdownDescription: "List of MAC addresses for the broadcast filter.",
-				Optional:            true,
-				ElementType:         types.StringType,
+				MarkdownDescription: "List of MAC addresses for the broadcast filter. " +
+					"The controller may populate this on its own, so it is computed when unset.",
+				Optional:    true,
+				Computed:    true,
+				ElementType: types.StringType,
+				PlanModifiers: []planmodifier.Set{
+					setplanmodifier.UseStateForUnknown(),
+				},
 				Validators: []validator.Set{
 					setvalidator.ValueStringsAre(validators.MACAddressValidator()),
 				},

--- a/unifi/wlan_resource_test.go
+++ b/unifi/wlan_resource_test.go
@@ -246,6 +246,33 @@ func Test_wlanFrameworkResource_Schema(t *testing.T) {
 	}
 }
 
+// Test_wlanFrameworkResource_Schema_computedControllerFields guards #323: fields
+// the controller assigns on its own must be Computed so a controller-supplied
+// value doesn't trip "inconsistent result after apply". minimum_data_rate_*_kbps
+// previously defaulted to 0 (rejected/overridden by the controller in auto mode);
+// radius_profile_id and bc_filter_list were Optional-only and got populated by
+// the controller.
+func Test_wlanFrameworkResource_Schema_computedControllerFields(t *testing.T) {
+	resp := &fwresource.SchemaResponse{}
+	(&wlanFrameworkResource{}).Schema(context.Background(), fwresource.SchemaRequest{}, resp)
+
+	for _, key := range []string{
+		"minimum_data_rate_2g_kbps",
+		"minimum_data_rate_5g_kbps",
+		"radius_profile_id",
+		"bc_filter_list",
+	} {
+		attr, ok := resp.Schema.Attributes[key]
+		if !ok {
+			t.Errorf("Schema missing attribute %q", key)
+			continue
+		}
+		if !attr.IsComputed() {
+			t.Errorf("attribute %q must be Computed (controller-managed, #323)", key)
+		}
+	}
+}
+
 func Test_wlanFrameworkResource_UpgradeState(t *testing.T) {
 	r := &wlanFrameworkResource{}
 	got := r.UpgradeState(context.Background())


### PR DESCRIPTION
## Summary

Fixes #323 — `unifi_wlan` fails with **"Provider produced inconsistent result after apply"** on several fields the controller assigns on its own.

| Field | Reported error | Cause |
|---|---|---|
| `minimum_data_rate_2g_kbps` | `was 0, but now 1000` | static `0` default; controller returns its own rate in `auto` minrate mode |
| `minimum_data_rate_5g_kbps` | `was 0, but now 6000` | same |
| `radius_profile_id` | `was null, but now "5b56…"` | `Optional`-only; controller assigns a default profile |
| `bc_filter_list` | `was null, but now ["fc:ec:…"]` / `length changed from 0 to 1` | `Optional`-only; controller populates broadcast-filter MACs |

## Fix

All four become **`Optional + Computed`** with `UseStateForUnknown` (the minrate pair also drops its static `0` default). Left unset, each is *known-after-apply*, so the controller's value is accepted instead of conflicting with a `0`/`null` plan. An explicitly-set value is still honored and round-trips through state on update.

A schema guard test (`Test_wlanFrameworkResource_Schema_computedControllerFields`) asserts the four attributes are `Computed`.

## Notes / scope

- This resolves the *unset* cases (the common ones in the report). The reporter also tried an **explicit empty** `bc_filter_list = []` as a workaround; the null-vs-empty distinction for that edge case is firmware-dependent and best confirmed on a live controller.
- Docs regenerated (`tfplugindocs`).

> ⚠️ Unit tests + schema guard only; not run against a live controller (no WLAN acceptance harness locally). Confirmation on UniFi OS Server / 10.4.x welcome.