### PR TITLE
feat(firewall-policy): expose ip_group_id on source/destination (#316)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### ✨ Features
+
+- **`unifi_firewall_policy`: match an IP group on `source`/`destination`.** A new `ip_group_id` attribute references a `unifi_firewall_group` of type address-group (used with `matching_target = "IP"` and `matching_target_type = "OBJECT"`), alongside the existing `port_group_id`. Backed by a go-unifi change adding the `ip_group_id` field to the firewall-policy source/destination structs (#316)
+
 ### 🐛 Bug Fixes
 
 - **`unifi_firewall_policy`: fix `inconsistent result after apply` on `source`/`destination` `matching_target_type` when updating a policy (e.g. changing `action`).** This field is firmware-derived: the controller (and the provider's own derivation for #293) may set it to a concrete value during the update PUT (e.g. `""` → `"SPECIFIC"` for a non-ANY match), which the planned value cannot anticipate when the prior state still carries an empty type. The update path now re-asserts the planned value on the post-apply state, leaving the next refresh to reconcile it with the controller (#324)

--- a/docs/resources/firewall_policy.md
+++ b/docs/resources/firewall_policy.md
@@ -210,6 +210,7 @@ Required:
 Optional:
 
 - `client_macs` (List of String) List of client MAC addresses to match. Used when `matching_target` is `CLIENT`.
+- `ip_group_id` (String) ID of a `unifi_firewall_group` (address-group type) to match. Used when `matching_target` is `IP` with `matching_target_type = OBJECT`.
 - `ips` (List of String) List of IP addresses or CIDR ranges to match. Used when `matching_target` is `IP`.
 - `network_ids` (List of String) List of UniFi network IDs to match. Used when `matching_target` is `NETWORK`.
 - `port` (String) Port(s) to match when `port_matching_type` is `SPECIFIC`. A single port (`161`) or a comma-separated list of ports/ranges (`80,443`, `8000-8100`). Leave unset for no port match.
@@ -233,6 +234,7 @@ Required:
 Optional:
 
 - `client_macs` (List of String) List of client MAC addresses to match. Used when `matching_target` is `CLIENT`.
+- `ip_group_id` (String) ID of a `unifi_firewall_group` (address-group type) to match. Used when `matching_target` is `IP` with `matching_target_type = OBJECT`.
 - `ips` (List of String) List of IP addresses or CIDR ranges to match. Used when `matching_target` is `IP`.
 - `network_ids` (List of String) List of UniFi network IDs to match. Used when `matching_target` is `NETWORK`.
 - `port` (String) Port(s) to match when `port_matching_type` is `SPECIFIC`. A single port (`161`) or a comma-separated list of ports/ranges (`80,443`, `8000-8100`). Leave unset for no port match.

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/hashicorp/terraform-plugin-testing v1.16.0
 	github.com/testcontainers/testcontainers-go v0.42.0
 	github.com/testcontainers/testcontainers-go/modules/compose v0.42.0
-	github.com/ubiquiti-community/go-unifi v1.33.43-0.20260623124022-456574d06fff
+	github.com/ubiquiti-community/go-unifi v1.33.43-0.20260624160408-04ec3376cd23
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -538,10 +538,8 @@ github.com/transparency-dev/formats v0.0.0-20251017110053-404c0d5b696c h1:5a2XDQ
 github.com/transparency-dev/formats v0.0.0-20251017110053-404c0d5b696c/go.mod h1:g85IafeFJZLxlzZCDRu4JLpfS7HKzR+Hw9qRh3bVzDI=
 github.com/transparency-dev/merkle v0.0.2 h1:Q9nBoQcZcgPamMkGn7ghV8XiTZ/kRxn1yCG81+twTK4=
 github.com/transparency-dev/merkle v0.0.2/go.mod h1:pqSy+OXefQ1EDUVmAJ8MUhHB9TXGuzVAT58PqBoHz1A=
-github.com/ubiquiti-community/go-unifi v1.33.43-0.20260617194535-a4efb77d2dbe h1:oj/V4vRbZjYkxSWvLXUWZJjXtf2onCbFoz/n9ycxIpU=
-github.com/ubiquiti-community/go-unifi v1.33.43-0.20260617194535-a4efb77d2dbe/go.mod h1:QfZDUwKQmGJNNW4af3KHzb7f+VmiSvkyTqC4/D5aPWU=
-github.com/ubiquiti-community/go-unifi v1.33.43-0.20260623124022-456574d06fff h1:Sh3u2WZs8JQKuYBzg6PjGjVKL9nWITXXUsSXtk3NxDE=
-github.com/ubiquiti-community/go-unifi v1.33.43-0.20260623124022-456574d06fff/go.mod h1:QfZDUwKQmGJNNW4af3KHzb7f+VmiSvkyTqC4/D5aPWU=
+github.com/ubiquiti-community/go-unifi v1.33.43-0.20260624160408-04ec3376cd23 h1:BdwNPLBG4ntwy5qaH6Q69ilfz6A1ArJUV5kSJXhIEJg=
+github.com/ubiquiti-community/go-unifi v1.33.43-0.20260624160408-04ec3376cd23/go.mod h1:QfZDUwKQmGJNNW4af3KHzb7f+VmiSvkyTqC4/D5aPWU=
 github.com/vbatts/tar-split v0.12.2 h1:w/Y6tjxpeiFMR47yzZPlPj/FcPLpXbTUi/9H7d3CPa4=
 github.com/vbatts/tar-split v0.12.2/go.mod h1:eF6B6i6ftWQcDqEn3/iGFRFRo8cBIMSJVOpnNdfTMFA=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=

--- a/unifi/firewall_policy_resource.go
+++ b/unifi/firewall_policy_resource.go
@@ -102,6 +102,7 @@ type firewallPolicyEndpointModel struct {
 	WebDomains       types.List   `tfsdk:"web_domains"`
 	Port             types.String `tfsdk:"port"`
 	PortGroupID      types.String `tfsdk:"port_group_id"`
+	IPGroupID        types.String `tfsdk:"ip_group_id"`
 	PortMatchingType types.String `tfsdk:"port_matching_type"`
 	// Firmware-managed; round-tripped so updates keep it (a PUT that omits
 	// source/destination matching_target_type is rejected with HTTP 400).
@@ -118,6 +119,7 @@ func (m firewallPolicyEndpointModel) AttributeTypes() map[string]attr.Type {
 		"web_domains":          types.ListType{ElemType: types.StringType},
 		"port":                 types.StringType,
 		"port_group_id":        types.StringType,
+		"ip_group_id":          types.StringType,
 		"port_matching_type":   types.StringType,
 		"matching_target_type": types.StringType,
 	}
@@ -206,6 +208,12 @@ func (r *firewallPolicyResource) Schema(
 		},
 		"port_group_id": schema.StringAttribute{
 			MarkdownDescription: "ID of a `unifi_firewall_group` (port-group type) to match. Used when `port_matching_type` is `OBJECT`.",
+			Optional:            true,
+			Computed:            true,
+			Default:             stringdefault.StaticString(""),
+		},
+		"ip_group_id": schema.StringAttribute{
+			MarkdownDescription: "ID of a `unifi_firewall_group` (address-group type) to match. Used when `matching_target` is `IP` with `matching_target_type = OBJECT`.",
 			Optional:            true,
 			Computed:            true,
 			Default:             stringdefault.StaticString(""),
@@ -619,6 +627,7 @@ type firewallPolicyEndpointModelV0 struct {
 	WebDomains         types.List   `tfsdk:"web_domains"`
 	Port               types.Int64  `tfsdk:"port"`
 	PortGroupID        types.String `tfsdk:"port_group_id"`
+	IPGroupID          types.String `tfsdk:"ip_group_id"`
 	PortMatchingType   types.String `tfsdk:"port_matching_type"`
 	MatchingTargetType types.String `tfsdk:"matching_target_type"`
 }
@@ -715,6 +724,7 @@ func upgradeFirewallPolicyEndpointV0(
 		WebDomains:         v0.WebDomains,
 		Port:               port,
 		PortGroupID:        v0.PortGroupID,
+		IPGroupID:          v0.IPGroupID,
 		PortMatchingType:   v0.PortMatchingType,
 		MatchingTargetType: v0.MatchingTargetType,
 	}
@@ -817,6 +827,7 @@ func endpointModelToSource(
 		),
 		Port:             m.Port.ValueString(),
 		PortGroupID:      m.PortGroupID.ValueString(),
+		IPGroupID:        m.IPGroupID.ValueString(),
 		PortMatchingType: m.PortMatchingType.ValueString(),
 	}
 	if !m.IPs.IsNull() && !m.IPs.IsUnknown() {
@@ -847,6 +858,7 @@ func endpointModelToDestination(
 		),
 		Port:             m.Port.ValueString(),
 		PortGroupID:      m.PortGroupID.ValueString(),
+		IPGroupID:        m.IPGroupID.ValueString(),
 		PortMatchingType: m.PortMatchingType.ValueString(),
 	}
 	if !m.IPs.IsNull() && !m.IPs.IsUnknown() {
@@ -965,6 +977,7 @@ func apiSourceToEndpointModel(
 		MatchingTargetType: types.StringValue(src.MatchingTargetType),
 		Port:               portToStringValue(src.Port),
 		PortGroupID:        types.StringValue(src.PortGroupID),
+		IPGroupID:          types.StringValue(src.IPGroupID),
 		PortMatchingType:   types.StringValue(src.PortMatchingType),
 	}
 	networkIDs, nd := types.ListValueFrom(ctx, types.StringType, src.NetworkIDs)
@@ -997,6 +1010,7 @@ func apiDestinationToEndpointModel(
 		MatchingTargetType: types.StringValue(dst.MatchingTargetType),
 		Port:               portToStringValue(dst.Port),
 		PortGroupID:        types.StringValue(dst.PortGroupID),
+		IPGroupID:          types.StringValue(dst.IPGroupID),
 		PortMatchingType:   types.StringValue(dst.PortMatchingType),
 	}
 	networkIDs, nd := types.ListValueFrom(ctx, types.StringType, dst.NetworkIDs)

--- a/unifi/firewall_policy_resource_test.go
+++ b/unifi/firewall_policy_resource_test.go
@@ -404,6 +404,7 @@ func Test_firewallPolicyEndpointModel_AttributeTypes(t *testing.T) {
 				"web_domains":          types.ListType{ElemType: types.StringType},
 				"port":                 types.StringType,
 				"port_group_id":        types.StringType,
+				"ip_group_id":          types.StringType,
 				"port_matching_type":   types.StringType,
 				"matching_target_type": types.StringType,
 			},
@@ -903,6 +904,7 @@ func Test_apiSourceToEndpointModel(t *testing.T) {
 					WebDomains:         webDomains,
 					Port:               types.StringValue("443"),
 					PortGroupID:        types.StringValue(""),
+					IPGroupID:          types.StringValue(""),
 					PortMatchingType:   types.StringValue("SPECIFIC"),
 				}
 			}(),
@@ -964,6 +966,7 @@ func Test_apiDestinationToEndpointModel(t *testing.T) {
 					WebDomains:         webDomains,
 					Port:               types.StringValue("8080"),
 					PortGroupID:        types.StringValue(""),
+					IPGroupID:          types.StringValue(""),
 					PortMatchingType:   types.StringValue("SPECIFIC"),
 				}
 			}(),

--- a/unifi/firewall_policy_resource_test.go
+++ b/unifi/firewall_policy_resource_test.go
@@ -1188,3 +1188,55 @@ func TestFirewallPolicyPreserveMatchingTargetType(t *testing.T) {
 			out.Port.ValueString(), out.PortMatchingType.ValueString())
 	}
 }
+
+// TestFirewallPolicyIPGroupIDRoundTrip guards #316: a source/destination may
+// match an address-group firewall group via ip_group_id, returned by the
+// controller alongside port_group_id. It must round-trip both directions.
+func TestFirewallPolicyIPGroupIDRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	var diags diag.Diagnostics
+
+	m := firewallPolicyEndpointModel{
+		ZoneID:             types.StringValue("zone-1"),
+		MatchingTarget:     types.StringValue("IP"),
+		NetworkIDs:         types.ListNull(types.StringType),
+		ClientMACs:         types.ListNull(types.StringType),
+		IPs:                types.ListNull(types.StringType),
+		WebDomains:         types.ListNull(types.StringType),
+		Port:               types.StringNull(),
+		PortGroupID:        types.StringValue(""),
+		IPGroupID:          types.StringValue("68945578bfcb5d2e51dd0f10"),
+		PortMatchingType:   types.StringValue("ANY"),
+		MatchingTargetType: types.StringValue("OBJECT"),
+	}
+
+	// model -> API (PUT path)
+	src := endpointModelToSource(ctx, m, &diags)
+	if diags.HasError() {
+		t.Fatalf("source conversion errored: %v", diags)
+	}
+	if src.IPGroupID != "68945578bfcb5d2e51dd0f10" {
+		t.Errorf("source IPGroupID = %q, want 68945578bfcb5d2e51dd0f10", src.IPGroupID)
+	}
+	dst := endpointModelToDestination(ctx, m, &diags)
+	if dst.IPGroupID != "68945578bfcb5d2e51dd0f10" {
+		t.Errorf("destination IPGroupID = %q, want 68945578bfcb5d2e51dd0f10", dst.IPGroupID)
+	}
+
+	// API -> model (read path)
+	got := apiSourceToEndpointModel(
+		ctx,
+		&unifi.FirewallPolicySource{
+			ZoneID:         "zone-1",
+			MatchingTarget: "IP",
+			IPGroupID:      "abc123",
+		},
+		&diags,
+	)
+	if diags.HasError() {
+		t.Fatalf("apiSourceToEndpointModel errored: %v", diags)
+	}
+	if got.IPGroupID.ValueString() != "abc123" {
+		t.Errorf("read IPGroupID = %q, want abc123", got.IPGroupID.ValueString())
+	}
+}


### PR DESCRIPTION
## Summary

Closes #316 — `unifi_firewall_policy` couldn't match an **IP group** (a `unifi_firewall_group` of type address-group) on `source`/`destination`. The controller returns it as `ip_group_id`, next to the already-supported `port_group_id`:

```json
"destination": {
  "ip_group_id": "68945578bfcb5d2e51dd0f10",
  "port_group_id": "6894559bbfcb5d2e51dd0f16",
  "matching_target": "IP",
  "matching_target_type": "OBJECT"
}
```

## Changes

- New **`ip_group_id`** attribute on `source`/`destination` (`Optional + Computed`, default `""`, mirroring `port_group_id`).
- Wired through `endpointModelToSource`/`Destination` (write) and `apiSourceToEndpointModel`/`apiDestination…` (read), plus the v0→v1 state upgrader and `AttributeTypes`.
- **go-unifi bumped** to the revision adding `IPGroupID` to `FirewallPolicySource`/`Destination` (ubiquiti-community/go-unifi#48, merged).
- Docs regenerated; new `TestFirewallPolicyIPGroupIDRoundTrip` covers both directions.

> ⚠️ Unit tests only; not exercised against a live controller (no zone-based-firewall harness locally). Confirmation on UniFi 10.4.x welcome.