### PR TITLE
docs(device): document mgmt_network_id tag-upstream-first requirement

### DIFF
--- a/docs/resources/device.md
+++ b/docs/resources/device.md
@@ -84,7 +84,7 @@ resource "unifi_device" "us_24_poe" {
 - `led_override_color_brightness` (Number) LED brightness (0-100).
 - `locked` (Boolean) Specifies whether the device is locked.
 - `mac` (String) The MAC address of the device. This can be specified so that the provider can take control of a device (since devices are created through adoption).
-- `mgmt_network_id` (String) Management network ID.
+- `mgmt_network_id` (String) Management network ID. The network this device uses for its own management traffic (the UI's Network Override). When set, the device tags its management onto this network's VLAN, so that VLAN must already be tagged on the device's upstream switch port(s) before this attribute is applied. Otherwise the device loses its management path, drops off, and the apply fails with an inconsistent-result error. Apply in two steps: tag the VLAN on the uplink (a port_override tagged_networkconf_ids entry) first, then set mgmt_network_id. Leave unset to manage on the uplink's native (untagged) network.
 - `name` (String) The name of the device.
 - `outdoor_mode_override` (String) Outdoor mode override; valid values are `default`, `on`, and `off`.
 - `outlet_enabled` (Boolean) Enable outlet control.

--- a/unifi/device_resource.go
+++ b/unifi/device_resource.go
@@ -540,7 +540,7 @@ func (r *deviceResource) Schema(
 
 			// Management
 			"mgmt_network_id": schema.StringAttribute{
-				Description: "Management network ID.",
+				Description: "Management network ID. The network this device uses for its own management traffic (the UI's Network Override). When set, the device tags its management onto this network's VLAN, so that VLAN must already be tagged on the device's upstream switch port(s) before this attribute is applied. Otherwise the device loses its management path, drops off, and the apply fails with an inconsistent-result error. Apply in two steps: tag the VLAN on the uplink (a port_override tagged_networkconf_ids entry) first, then set mgmt_network_id. Leave unset to manage on the uplink's native (untagged) network.",
 				Optional:    true,
 				Computed:    true,
 			},


### PR DESCRIPTION
## Summary

`mgmt_network_id` is documented today as just "Management network ID." That terseness hides a real footgun: setting the Network Override makes the device tag its management traffic onto the target VLAN, and if that VLAN is not tagged on the device's upstream switch port, the device loses its management path and the apply fails with `Provider produced inconsistent result after apply` (see #329).

This enriches the field's description with the tag-upstream-first sequencing requirement, mirroring the UniFi UI's own warning ("Ensure the selected VLAN is tagged on all upstream switch ports otherwise this device will lose connectivity").

## Changes

- `unifi/device_resource.go`: enriched the `mgmt_network_id` schema description.
- `docs/resources/device.md`: regenerated via `go generate` (tfplugindocs).

Refs #329
