### PR TITLE
docs(changelog): release v0.53.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [Unreleased]
+## [v0.53.0] - 2026-06-24
 
 ### ✨ Features
 


### PR DESCRIPTION
Promote the `[Unreleased]` section to **v0.53.0**. Merge this, then tag `v0.53.0` to trigger the release workflow.

### Highlights since v0.52.4
- **feat** `unifi_firewall_policy`: `ip_group_id` on source/destination (#316)
- **feat** `unifi_dns_record`: NS / Forward Domain records (#318, #319)
- **fix** `unifi_firewall_policy`: matching_target_type inconsistent-result (#324)
- **fix** `unifi_wlan`: controller-managed fields inconsistent-result (#323)
- **docs** `unifi_device`: mgmt_network_id tag-upstream-first (#329, #330)