### PR TITLE
fix(device): send LED overrides in update PUT, preserve planned values (#337)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### 🐛 Bug Fixes
+
+- **`unifi_device`: fix LED updates failing with `inconsistent result after apply`.** The update PUT body was assembled as a minimal device that dropped the LED override fields (`led_override`, `led_override_color`, `led_override_color_brightness`), so the controller kept the old values and the post-apply read conflicted with the plan. They are now included in the PUT, and — because the controller applies LED changes to APs asynchronously — the update path also re-asserts the planned LED values on the post-apply state, leaving the next refresh to reconcile with the controller (#337)
+
 ## [v0.53.0] - 2026-06-24
 
 ### ✨ Features

--- a/unifi/device_resource.go
+++ b/unifi/device_resource.go
@@ -1348,6 +1348,15 @@ func (r *deviceResource) Update(
 	// Save planned port overrides for post-update restore
 	plannedPortOverride := plan.PortOverride
 
+	// Save planned LED overrides too. The controller applies these to APs
+	// asynchronously, so the immediate post-update read can still report the old
+	// values, which would conflict with the plan (#337). Re-assert the planned
+	// value (when known) after the read; the next refresh reconciles state with
+	// the controller once the AP has applied it.
+	plannedLedOverride := plan.LedOverride
+	plannedLedOverrideColor := plan.LedOverrideColor
+	plannedLedOverrideColorBrightness := plan.LedOverrideColorBrightness
+
 	// Update the device with only user-configured fields
 	diags = r.updateDevice(ctx, &plan)
 	resp.Diagnostics.Append(diags...)
@@ -1369,6 +1378,20 @@ func (r *deviceResource) Update(
 
 	// Restore port_override from plan (API returns all ports, plan has subset)
 	plan.PortOverride = plannedPortOverride
+
+	// Re-assert the planned LED values when the user configured them, so an
+	// asynchronously-applied controller value doesn't trip the consistency
+	// check (#337). The next Read converges state with the controller.
+	if !plannedLedOverride.IsNull() && !plannedLedOverride.IsUnknown() {
+		plan.LedOverride = plannedLedOverride
+	}
+	if !plannedLedOverrideColor.IsNull() && !plannedLedOverrideColor.IsUnknown() {
+		plan.LedOverrideColor = plannedLedOverrideColor
+	}
+	if !plannedLedOverrideColorBrightness.IsNull() &&
+		!plannedLedOverrideColorBrightness.IsUnknown() {
+		plan.LedOverrideColorBrightness = plannedLedOverrideColorBrightness
+	}
 	// allow_adoption / forget_on_destroy were resolved before the update and are
 	// not touched by setResourceData; ensure a concrete value (default true)
 	// rather than overwriting the planned value with prior state.
@@ -1533,6 +1556,33 @@ func (r *deviceResource) ImportState(
 
 // Helper methods
 
+// buildMinimalUpdateDevice assembles the Device sent in an update PUT. The full
+// Device struct carries computed fields (adopted, state, …) whose Go zero-values
+// the API rejects, so only the user-configured / API-required fields are sent.
+// LED overrides MUST be included: omitting them makes the controller keep the
+// old values, so the post-apply read conflicts with the plan (#337). All of the
+// LED fields are `omitempty`, so unset ones are dropped from the body.
+func buildMinimalUpdateDevice(
+	deviceReq, currentDevice *unifi.Device,
+	portOverrides []unifi.DevicePortOverrides,
+) *unifi.Device {
+	minimalDevice := &unifi.Device{
+		ID:                         deviceReq.ID,
+		Type:                       deviceReq.Type,
+		MAC:                        deviceReq.MAC,
+		Name:                       deviceReq.Name,
+		PortOverrides:              portOverrides,
+		LedOverride:                deviceReq.LedOverride,
+		LedOverrideColor:           deviceReq.LedOverrideColor,
+		LedOverrideColorBrightness: deviceReq.LedOverrideColorBrightness,
+	}
+	if currentDevice != nil {
+		minimalDevice.State = currentDevice.State
+		minimalDevice.Adopted = currentDevice.Adopted
+	}
+	return minimalDevice
+}
+
 func (r *deviceResource) updateDevice(
 	ctx context.Context,
 	model *deviceResourceModel,
@@ -1587,20 +1637,7 @@ func (r *deviceResource) updateDevice(
 		)
 	}
 
-	// Build a minimal Device for the PUT request. The full Device struct includes
-	// computed fields (adopted, state, etc.) with Go zero-values that the API rejects.
-	// Only send fields that the user configured or that the API requires.
-	minimalDevice := &unifi.Device{
-		ID:            deviceReq.ID,
-		Type:          deviceReq.Type,
-		MAC:           deviceReq.MAC,
-		Name:          deviceReq.Name,
-		PortOverrides: portOverrides,
-	}
-	if currentDevice != nil {
-		minimalDevice.State = currentDevice.State
-		minimalDevice.Adopted = currentDevice.Adopted
-	}
+	minimalDevice := buildMinimalUpdateDevice(deviceReq, currentDevice, portOverrides)
 
 	if reqJSON, jsonErr := json.Marshal(minimalDevice); jsonErr == nil {
 		tflog.Info(ctx, "Sending device update", map[string]any{

--- a/unifi/device_resource_test.go
+++ b/unifi/device_resource_test.go
@@ -389,6 +389,58 @@ func Test_deviceResource_ImportState(t *testing.T) {
 	}
 }
 
+// Test_buildMinimalUpdateDevice guards #337: the update PUT body must carry the
+// LED override fields. They used to be filled by modelToAPIDevice but dropped
+// when assembling the minimal PUT payload, so the controller kept the old LED
+// values and the post-apply read conflicted with the plan.
+func Test_buildMinimalUpdateDevice(t *testing.T) {
+	deviceReq := &unifi.Device{
+		ID:                         "dev-1",
+		Type:                       "uap",
+		MAC:                        "00:11:22:33:44:55",
+		Name:                       "AP-Hallway",
+		LedOverride:                "on",
+		LedOverrideColor:           "#00ff00",
+		LedOverrideColorBrightness: ptrInt64(20),
+	}
+	current := &unifi.Device{State: 1, Adopted: true}
+	overrides := []unifi.DevicePortOverrides{{PortIDX: ptrInt64(1)}}
+
+	got := buildMinimalUpdateDevice(deviceReq, current, overrides)
+
+	if got.LedOverride != "on" {
+		t.Errorf("LedOverride = %q, want on", got.LedOverride)
+	}
+	if got.LedOverrideColor != "#00ff00" {
+		t.Errorf("LedOverrideColor = %q, want #00ff00", got.LedOverrideColor)
+	}
+	if got.LedOverrideColorBrightness == nil || *got.LedOverrideColorBrightness != 20 {
+		t.Errorf("LedOverrideColorBrightness = %v, want 20", got.LedOverrideColorBrightness)
+	}
+	// State/Adopted carried over from the current device; other fields preserved.
+	if got.State != 1 || !got.Adopted {
+		t.Errorf(
+			"State/Adopted not carried from current: state=%v adopted=%v",
+			got.State,
+			got.Adopted,
+		)
+	}
+	if got.Name != "AP-Hallway" || len(got.PortOverrides) != 1 {
+		t.Errorf(
+			"unexpected name/overrides: name=%q overrides=%d",
+			got.Name,
+			len(got.PortOverrides),
+		)
+	}
+
+	// Unset LED fields stay zero-valued (omitempty drops them from the PUT body).
+	bare := buildMinimalUpdateDevice(&unifi.Device{ID: "d2"}, nil, nil)
+	if bare.LedOverride != "" || bare.LedOverrideColorBrightness != nil {
+		t.Errorf("unset LED fields should be zero: %q %v",
+			bare.LedOverride, bare.LedOverrideColorBrightness)
+	}
+}
+
 func Test_deviceResource_updateDevice(t *testing.T) {
 	type args struct {
 		ctx   context.Context


### PR DESCRIPTION
## Summary

Fixes #337 — `unifi_device` LED updates fail with **"Provider produced inconsistent result after apply"** on APs (e.g. `led_override_color_brightness: was 20, but now 50`; `led_override: was "on", but now "off"`).

## Root cause

`updateDevice` builds a *minimal* `Device` for the PUT to avoid sending zero-valued computed fields the API rejects. That minimal payload carried only `id`/`type`/`mac`/`name`/`port_overrides`/`state`/`adopted` — **the LED fields were dropped**. `modelToAPIDevice` fills them, but they never made it into the PUT body, so the controller kept the old LED values and the post-apply read conflicted with the plan.

This matches the reporter's finding that a direct `PUT /proxy/network/api/s/default/rest/device/<id>` with the LED fields *does* persist them.

It's a different path from #243/#247 (which preserved LED values only when the controller echoed back an **empty** value); here the controller echoes back the **old** value because it was never sent the new one.

## Fix

1. **Include the LED fields in the PUT.** Extracted `buildMinimalUpdateDevice`, which now copies `led_override`, `led_override_color`, `led_override_color_brightness` (all `omitempty`, so unset fields are dropped).
2. **Re-assert planned LED values on the post-apply state.** The controller applies LED changes to APs asynchronously, so the immediate read can still report the old value. Mirroring the existing `port_override` write-preserve, the update path re-asserts the planned LED values (when the user set them); the next `Read` reconciles state with the controller.
3. **Test.** Added `Test_buildMinimalUpdateDevice` (the existing device-update tests were empty table stubs).

> ⚠️ Unit-tested only; no live controller locally. Confirmation on real APs (U7 Pro / U7 Pro XG, per the report) welcome — cc @MysticRyuujin.