### PR TITLE
fix(wan): normalize empty DNS addresses to null to stop inconsistent-result (#333)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### 🐛 Bug Fixes
 
 - **`unifi_device`: fix LED updates failing with `inconsistent result after apply`.** The update PUT body was assembled as a minimal device that dropped the LED override fields (`led_override`, `led_override_color`, `led_override_color_brightness`), so the controller kept the old values and the post-apply read conflicted with the plan. They are now included in the PUT, and — because the controller applies LED changes to APs asynchronously — the update path also re-asserts the planned LED values on the post-apply state, leaving the next refresh to reconcile with the controller (#337)
+- **`unifi_wan`: fix `inconsistent result after apply` on `dns` address fields (`primary`, `secondary`, `ipv6_primary`, `ipv6_secondary`).** When no DNS server is configured the controller persists and returns an empty string `""`, but these Optional fields plan as `null`, so the post-apply read conflicted with the plan (e.g. after import with IPv6 DNS preference `auto`). The read now normalizes `""` (and a nil pointer) to `null`, so unset addresses stay null and a real address still round-trips (#333)
 
 ## [v0.53.0] - 2026-06-24
 

--- a/unifi/wan_resource.go
+++ b/unifi/wan_resource.go
@@ -1548,6 +1548,18 @@ func (r *wanResource) modelToNetwork(
 	return network, diags
 }
 
+// dnsAddrValue maps a controller WAN DNS address pointer to a Terraform value,
+// treating both a nil pointer and an empty string as null. The DNS address
+// fields are Optional (not Computed), so when no server is configured the
+// controller persists and returns "" — which would otherwise conflict with the
+// planned null and fail the consistency check (#333).
+func dnsAddrValue(p *string) types.String {
+	if p == nil || *p == "" {
+		return types.StringNull()
+	}
+	return types.StringValue(*p)
+}
+
 // networkToModel converts from unifi.Network to Terraform model.
 func (r *wanResource) networkToModel(
 	ctx context.Context,
@@ -1618,16 +1630,16 @@ func (r *wanResource) networkToModel(
 			diags.Append(d...)
 		}
 		if network.WANDNS1 != nil {
-			currentDNS.Primary = types.StringValue(*network.WANDNS1)
+			currentDNS.Primary = dnsAddrValue(network.WANDNS1)
 		}
 		if network.WANDNS2 != nil {
-			currentDNS.Secondary = types.StringValue(*network.WANDNS2)
+			currentDNS.Secondary = dnsAddrValue(network.WANDNS2)
 		}
 		if network.WANIPV6DNS1 != nil {
-			currentDNS.IPv6Primary = types.StringValue(*network.WANIPV6DNS1)
+			currentDNS.IPv6Primary = dnsAddrValue(network.WANIPV6DNS1)
 		}
 		if network.WANIPV6DNS2 != nil {
-			currentDNS.IPv6Secondary = types.StringValue(*network.WANIPV6DNS2)
+			currentDNS.IPv6Secondary = dnsAddrValue(network.WANIPV6DNS2)
 		}
 		if network.WANDNSPreference != nil {
 			currentDNS.Preference = types.StringValue(*network.WANDNSPreference)

--- a/unifi/wan_resource_test.go
+++ b/unifi/wan_resource_test.go
@@ -336,6 +336,39 @@ func Test_dhcpOptionModel_AttributeTypes(t *testing.T) {
 	}
 }
 
+// Test_dnsAddrValue guards #333: the controller persists an unset WAN DNS
+// address as "" and returns it, but the Optional address fields plan as null.
+// "" (and a nil pointer) must map to null so the post-apply read matches the
+// plan; a real address must round-trip.
+func Test_dnsAddrValue(t *testing.T) {
+	empty := ""
+	addr := "2001:4860:4860::8888"
+	v4 := "8.8.8.8"
+
+	cases := []struct {
+		name     string
+		in       *string
+		wantNull bool
+		wantStr  string
+	}{
+		{"nil pointer -> null", nil, true, ""},
+		{"empty string -> null", &empty, true, ""},
+		{"ipv6 address survives", &addr, false, addr},
+		{"ipv4 address survives", &v4, false, v4},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := dnsAddrValue(c.in)
+			if got.IsNull() != c.wantNull {
+				t.Errorf("IsNull = %v, want %v", got.IsNull(), c.wantNull)
+			}
+			if !c.wantNull && got.ValueString() != c.wantStr {
+				t.Errorf("ValueString = %q, want %q", got.ValueString(), c.wantStr)
+			}
+		})
+	}
+}
+
 func Test_dnsModel_AttributeTypes(t *testing.T) {
 	tests := []struct {
 		name string


### PR DESCRIPTION
## Summary

Fixes #333 — `unifi_wan` fails with **"Provider produced inconsistent result after apply"** on `dns.ipv6_primary` / `dns.ipv6_secondary` (`was null, but now cty.StringVal("")`), typically right after importing a WAN whose IPv6 DNS preference is `auto` (no manual servers).

## Root cause

`dns.primary`, `dns.secondary`, `dns.ipv6_primary`, `dns.ipv6_secondary` are **Optional** (not Computed), so they plan as `null` when unset. But the controller persists an unconfigured server as an empty string and returns `wan_ipv6_dns1 = ""`. `networkToModel` mapped that straight through (`types.StringValue("")`), so the post-apply read produced `""` where the plan had `null` → consistency check fails.

## Fix

The four DNS **address** fields now go through a small helper `dnsAddrValue`, which maps both a nil pointer and `""` to `null`. Unset addresses stay `null` (matching the plan); a real address still round-trips. `preference` / `ipv6_preference` are untouched — they're `auto`/`manual`, not addresses.

## Tests

- `Test_dnsAddrValue`: nil → null, `""` → null, IPv4/IPv6 addresses survive.
- Full unit suite still passes.

> ⚠️ Unit-tested only; no live controller locally. Confirmation on UDR7 / Network 10.4.57 (per the report) welcome — cc @HalisCz.