### PR TITLE
feat(wan): preserve wan_networkgroup so secondary WAN (WAN2) updates work (#334)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### ✨ Features
+
+- **`unifi_wan`: expose `networkgroup` (`WAN`, `WAN2`, …).** A new computed-by-default attribute identifying which WAN group an interface belongs to. The provider previously hard-coded `wan_networkgroup`/`attr_hidden_id` to `WAN`, so updating a **secondary** uplink (`WAN2`) collided with the primary and the controller rejected the PUT (`api.err.WanConfigurationForNetworkGroupAlreadyExists`). The group is now read from the controller and preserved in the update payload (`UseStateForUnknown`, so an imported `WAN2` needs no explicit config), making multi-WAN setups manageable (#334)
+
 ### 🐛 Bug Fixes
 
 - **`unifi_device`: fix LED updates failing with `inconsistent result after apply`.** The update PUT body was assembled as a minimal device that dropped the LED override fields (`led_override`, `led_override_color`, `led_override_color_brightness`), so the controller kept the old values and the post-apply read conflicted with the plan. They are now included in the PUT, and — because the controller applies LED changes to APs asynchronously — the update path also re-asserts the planned LED values on the post-apply state, leaving the next refresh to reconcile with the controller (#337)

--- a/docs/resources/wan.md
+++ b/docs/resources/wan.md
@@ -98,6 +98,7 @@ resource "unifi_wan" "secondary" {
 - `ipv6_setting_preference` (String) Whether WAN IPv6 settings are managed automatically by the controller or manually. Can be one of `auto` or `manual`.
 - `load_balance` (Attributes) Load balance configuration (see [below for nested schema](#nestedatt--load_balance))
 - `mac_override_enabled` (Boolean) Whether the WAN interface MAC address is overridden.
+- `networkgroup` (String) The WAN network group this interface belongs to (`WAN`, `WAN2`, …). The primary uplink is `WAN`; a secondary/SFP uplink is `WAN2`. Computed from the controller when unset (so an imported `WAN2` is preserved), defaulting to `WAN` on create. Required to manage multi-WAN (WAN2+) setups, where a hard-coded `WAN` collides with the primary (`api.err.WanConfigurationForNetworkGroupAlreadyExists`).
 - `provider_capabilities` (Attributes) WAN provider capabilities (line rate). Detected/populated by the controller; preserved when not set in config. (see [below for nested schema](#nestedatt--provider_capabilities))
 - `report_wan_event` (Boolean) Whether to report WAN events
 - `setting_preference` (String) Whether WAN settings are managed automatically by the controller or manually. Can be one of `auto` or `manual`.

--- a/unifi/wan_resource.go
+++ b/unifi/wan_resource.go
@@ -62,9 +62,10 @@ type wanResource struct {
 
 // wanResourceModel describes the resource data model.
 type wanResourceModel struct {
-	ID   types.String `tfsdk:"id"`
-	Site types.String `tfsdk:"site"`
-	Name types.String `tfsdk:"name"`
+	ID           types.String `tfsdk:"id"`
+	Site         types.String `tfsdk:"site"`
+	Name         types.String `tfsdk:"name"`
+	NetworkGroup types.String `tfsdk:"networkgroup"`
 
 	// WAN Type Settings
 	Type   types.String `tfsdk:"type"`
@@ -343,6 +344,26 @@ func (r *wanResource) Schema(
 			"name": schema.StringAttribute{
 				Required:            true,
 				MarkdownDescription: "The name of the WAN network",
+			},
+			"networkgroup": schema.StringAttribute{
+				Optional: true,
+				Computed: true,
+				MarkdownDescription: "The WAN network group this interface belongs to " +
+					"(`WAN`, `WAN2`, …). The primary uplink is `WAN`; a secondary/SFP " +
+					"uplink is `WAN2`. Computed from the controller when unset (so an " +
+					"imported `WAN2` is preserved), defaulting to `WAN` on create. " +
+					"Required to manage multi-WAN (WAN2+) setups, where a hard-coded " +
+					"`WAN` collides with the primary " +
+					"(`api.err.WanConfigurationForNetworkGroupAlreadyExists`).",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(
+						regexp.MustCompile(`^WAN([2-9])?$|^WAN_LTE_FAILOVER$`),
+						"must be WAN, WAN2-WAN9, or WAN_LTE_FAILOVER",
+					),
+				},
 			},
 			"type": schema.StringAttribute{
 				Optional:            true,
@@ -967,16 +988,26 @@ func (r *wanResource) adoptExistingWAN(
 		return nil, fmt.Errorf("listing networks: %w", err)
 	}
 
+	// Match the WAN that owns the same network group we are creating (WAN, WAN2,
+	// …), not just the primary "WAN" — otherwise a WAN2 conflict adopts the wrong
+	// interface (#334).
+	wantGroup := "WAN"
+	if network.WANNetworkGroup != nil && *network.WANNetworkGroup != "" {
+		wantGroup = *network.WANNetworkGroup
+	}
 	var existing *unifi.Network
 	for _, n := range networks {
 		if n.Purpose == unifi.PurposeWAN && n.WANNetworkGroup != nil &&
-			*n.WANNetworkGroup == "WAN" {
+			*n.WANNetworkGroup == wantGroup {
 			existing = &n
 			break
 		}
 	}
 	if existing == nil {
-		return nil, fmt.Errorf("existing WAN network not found despite creation conflict")
+		return nil, fmt.Errorf(
+			"existing WAN network (group %s) not found despite creation conflict",
+			wantGroup,
+		)
 	}
 
 	network.ID = existing.ID
@@ -1307,11 +1338,21 @@ func (r *wanResource) modelToNetwork(
 ) (*unifi.Network, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
+	// Preserve the interface's WAN network group (WAN, WAN2, …). Hard-coding "WAN"
+	// breaks a secondary uplink: its PUT collides with the primary WAN and the
+	// controller rejects it (WanConfigurationForNetworkGroupAlreadyExists) (#334).
+	// attr_hidden_id mirrors the group. Defaults to "WAN" via the schema default.
+	networkGroup := "WAN"
+	if !model.NetworkGroup.IsNull() && !model.NetworkGroup.IsUnknown() &&
+		model.NetworkGroup.ValueString() != "" {
+		networkGroup = model.NetworkGroup.ValueString()
+	}
+
 	network := &unifi.Network{
 		Name:            model.Name.ValueStringPointer(),
 		Purpose:         unifi.PurposeWAN, // Statically set to "wan"
-		WANNetworkGroup: util.Ptr("WAN"),  // Statically set to "WAN"
-		HiddenID:        "WAN",            // Statically set to "WAN"
+		WANNetworkGroup: util.Ptr(networkGroup),
+		HiddenID:        networkGroup,
 		Enabled:         model.Enabled.ValueBool(),
 	}
 
@@ -1572,6 +1613,14 @@ func (r *wanResource) networkToModel(
 	model.ID = types.StringValue(network.ID)
 	model.Site = types.StringValue(site)
 	model.Name = types.StringPointerValue(network.Name)
+
+	// Preserve the WAN network group (WAN, WAN2, …) so updates target the right
+	// interface instead of always defaulting to "WAN" (#334).
+	if network.WANNetworkGroup != nil && *network.WANNetworkGroup != "" {
+		model.NetworkGroup = types.StringValue(*network.WANNetworkGroup)
+	} else {
+		model.NetworkGroup = types.StringValue("WAN")
+	}
 
 	// WAN Type Settings — only overwrite when API returns a value
 	if network.WANType != nil {

--- a/unifi/wan_resource_test.go
+++ b/unifi/wan_resource_test.go
@@ -336,6 +336,51 @@ func Test_dhcpOptionModel_AttributeTypes(t *testing.T) {
 	}
 }
 
+// Test_wanResource_networkGroup guards #334: the WAN network group must be
+// preserved in the update PUT (and attr_hidden_id mirror it), instead of being
+// hard-coded to "WAN" — otherwise a secondary uplink (WAN2) collides with the
+// primary and the controller rejects it.
+func Test_wanResource_networkGroup(t *testing.T) {
+	r := &wanResource{}
+	ctx := context.Background()
+
+	base := wanResourceModel{
+		Name:    types.StringValue("CC Internet SFP"),
+		Enabled: types.BoolValue(true),
+		Type:    types.StringValue("dhcp"),
+	}
+
+	t.Run("WAN2 is preserved and mirrored to hidden id", func(t *testing.T) {
+		m := base
+		m.NetworkGroup = types.StringValue("WAN2")
+		n, d := r.modelToNetwork(ctx, &m)
+		if d.HasError() {
+			t.Fatalf("modelToNetwork: %v", d)
+		}
+		if n.WANNetworkGroup == nil || *n.WANNetworkGroup != "WAN2" {
+			t.Errorf("WANNetworkGroup = %v, want WAN2", n.WANNetworkGroup)
+		}
+		if n.HiddenID != "WAN2" {
+			t.Errorf("HiddenID = %q, want WAN2", n.HiddenID)
+		}
+	})
+
+	t.Run("unset defaults to WAN", func(t *testing.T) {
+		m := base
+		m.NetworkGroup = types.StringNull()
+		n, d := r.modelToNetwork(ctx, &m)
+		if d.HasError() {
+			t.Fatalf("modelToNetwork: %v", d)
+		}
+		if n.WANNetworkGroup == nil || *n.WANNetworkGroup != "WAN" {
+			t.Errorf("WANNetworkGroup = %v, want WAN", n.WANNetworkGroup)
+		}
+		if n.HiddenID != "WAN" {
+			t.Errorf("HiddenID = %q, want WAN", n.HiddenID)
+		}
+	})
+}
+
 // Test_dnsAddrValue guards #333: the controller persists an unset WAN DNS
 // address as "" and returns it, but the Optional address fields plan as null.
 // "" (and a nil pointer) must map to null so the post-apply read matches the


### PR DESCRIPTION
## Summary

Fixes #334 — `unifi_wan` can't update a **secondary** WAN: every PUT hard-coded `wan_networkgroup` and `attr_hidden_id` to `WAN`, so a WAN2 interface collided with the primary and the controller rejected it:

```
api.err.WanConfigurationForNetworkGroupAlreadyExists (400)
payload: { ..., "attr_hidden_id":"WAN", ..., "wan_networkgroup":"WAN", ... }
```

## Changes

- **New `networkgroup` attribute** (`Optional + Computed`, `UseStateForUnknown`, validated against `WAN[2-9]?` / `WAN_LTE_FAILOVER`). It's read from the controller on refresh/import, so an **imported WAN2 is preserved with no explicit config**; it defaults to `WAN` on create. Existing single-WAN configs are unaffected.
- **`modelToNetwork`** now sends the model's network group (and mirrors it to `attr_hidden_id`) instead of a hard-coded `WAN`.
- **`adoptExistingWAN`** matches the WAN that owns the *same* group, not just `WAN`.
- Docs regenerated; added `Test_wanResource_networkGroup` (WAN2 preserved + mirrored to hidden id; unset → WAN).

## Design note

Used `UseStateForUnknown` rather than a static `WAN` default on purpose: a default would replan an imported WAN2 (left unset in config) back to `WAN` and reintroduce the collision. With `UseStateForUnknown`, the refreshed controller value is preserved.

> ⚠️ Unit-tested only; no live controller locally. Confirmation on a real dual-WAN UDR7 / Network 10.4.57 welcome — cc @HalisCz.