### PR TITLE
test(firewall-zone): guard create body always sends network_ids (#314)

### DIFF
--- a/unifi/firewall_zone_resource_test.go
+++ b/unifi/firewall_zone_resource_test.go
@@ -2,7 +2,9 @@ package unifi
 
 import (
 	"context"
+	"encoding/json"
 	"reflect"
+	"strings"
 	"testing"
 
 	fwlist "github.com/hashicorp/terraform-plugin-framework/list"
@@ -70,6 +72,27 @@ func TestFirewallZoneModelRoundTrip(t *testing.T) {
 	}
 	if len(gotNids) != 2 {
 		t.Errorf("network_ids round-trip = %v, want 2 entries", gotNids)
+	}
+}
+
+// TestFirewallZoneCreateBodyAlwaysSendsNetworkIDs guards #314. On a ZBF-migrated
+// controller, a create POST that omits network_ids triggers a server-side NPE and a
+// generic HTTP 500 (a name-only body fails; the same body with "network_ids":[]
+// succeeds). go-unifi once tagged the field `json:"network_ids,omitempty"`, which
+// dropped the resource's empty []string{} from the payload and produced exactly that
+// bad body. The tag must stay non-omitempty so an empty zone still serializes an
+// explicit empty array — verified live against Network 10.4.57.
+func TestFirewallZoneCreateBodyAlwaysSendsNetworkIDs(t *testing.T) {
+	zone := &unifi.FirewallZone{Name: "ZBF-Probe", NetworkIDs: []string{}}
+	body, err := json.Marshal(zone)
+	if err != nil {
+		t.Fatalf("marshal firewall zone: %v", err)
+	}
+	if !strings.Contains(string(body), `"network_ids":[]`) {
+		t.Errorf(
+			"create body must always include network_ids (empty array), got %s",
+			body,
+		)
 	}
 }
 


### PR DESCRIPTION
## Context

#314 reported `unifi_firewall_zone` create failing with a generic HTTP 500 on a ZBF-migrated controller (Network 10.4.57). Root cause confirmed **live against that controller**: it was a missing `network_ids` field, **not** an auth/session problem.

```
POST /v2/api/site/default/firewall/zone  {"name":"ZBF-Probe"}                  -> 500 (Tomcat NPE)
POST /v2/api/site/default/firewall/zone  {"name":"ZBF-Probe","network_ids":[]} -> 201
```

The resource already initializes `NetworkIDs: []string{}`, but go-unifi tagged the field `json:"network_ids,omitempty"` in v0.52.4, so the empty slice was dropped from the payload — producing the failing name-only body. The go-unifi bump in **v0.53.0** changed the tag to `json:"network_ids"`, so the create now serializes `{"name":"…","network_ids":[]}` and succeeds. **#314 is fixed as of v0.53.0.**

## Changes

This PR adds no behaviour change — it's a **regression guard**. The `omitempty` came from go-unifi's codegen and has already toggled once; a new test asserts the marshaled create body always includes an explicit empty `network_ids` array, so a future codegen run can't silently re-introduce the `omitempty` and bring the 500 back.

## Tests

- New `TestFirewallZoneCreateBodyAlwaysSendsNetworkIDs`.
- `go build`, `go vet`, `golangci-lint` (0 issues) and the unit suite pass.

Refs #314

https://claude.ai/code/session_01D83uMn2TM7GdYPchVt7EWV