### PR TITLE
feat(firewall-policy): make connection_state_type/connection_states settable (#351)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### ✨ Features
 
+- **`unifi_firewall_policy`: make `connection_state_type` / `connection_states` author-settable.** Both attributes were `Computed`-only, so setting them returned `Invalid Configuration for Read-Only Attribute` — you could not author a policy scoped to a specific connection state. They are now `Optional + Computed`: leave them unset and the controller manages them as before, or set `connection_state_type = "CUSTOM"` with `connection_states = ["NEW", …]` (or `RESPOND_ONLY`) to author, for example, a `NEW`-only logging/deny policy that coexists with stateful returns in a zone-based firewall. Values are validated (`ALL`/`RESPOND_ONLY`/`CUSTOM`; states `NEW`/`ESTABLISHED`/`RELATED`/`INVALID`) and still round-trip on update (#351)
 - **`unifi_wan`: expose `networkgroup` (`WAN`, `WAN2`, …).** A new computed-by-default attribute identifying which WAN group an interface belongs to. The provider previously hard-coded `wan_networkgroup`/`attr_hidden_id` to `WAN`, so updating a **secondary** uplink (`WAN2`) collided with the primary and the controller rejected the PUT (`api.err.WanConfigurationForNetworkGroupAlreadyExists`). The group is now read from the controller and preserved in the update payload (`UseStateForUnknown`, so an imported `WAN2` needs no explicit config), making multi-WAN setups manageable (#334)
 
 ### 🐛 Bug Fixes

--- a/docs/resources/firewall_policy.md
+++ b/docs/resources/firewall_policy.md
@@ -180,6 +180,8 @@ resource "unifi_firewall_policy" "block_web_domains" {
 
 ### Optional
 
+- `connection_state_type` (String) Connection-state matching mode: `ALL` (any state), `RESPOND_ONLY` (established/related returns), or `CUSTOM` (match the states listed in `connection_states`). Optional: if omitted the controller assigns it (defaults to `ALL`) and the provider round-trips the value so updates are accepted.
+- `connection_states` (List of String) Connection states matched when `connection_state_type` is `CUSTOM` (`NEW`, `ESTABLISHED`, `RELATED`, `INVALID`). Optional: leave unset for `ALL`/`RESPOND_ONLY` and the controller manages it; the provider round-trips the value so a `CUSTOM` policy's states are not dropped on update (which the firmware rejects with HTTP 400).
 - `create_allow_respond` (Boolean) When `true`, UniFi automatically creates a matching rule to allow established/related return traffic. Recommended for `ALLOW` policies. Defaults to `false`.
 - `description` (String) A description for the policy.
 - `enabled` (Boolean) Whether the policy is enabled. Defaults to `true`.
@@ -191,8 +193,6 @@ resource "unifi_firewall_policy" "block_web_domains" {
 
 ### Read-Only
 
-- `connection_state_type` (String) Connection-state matching mode (`ALL`, `RESPOND_ONLY`, or `CUSTOM`). Managed by the UniFi controller; the provider round-trips it so updates are accepted.
-- `connection_states` (List of String) Connection states matched when `connection_state_type` is `CUSTOM` (e.g. `NEW`, `ESTABLISHED`, `RELATED`, `INVALID`). Managed by the UniFi controller; the provider round-trips it so a `CUSTOM` policy's states are not dropped on update (which the firmware rejects with HTTP 400).
 - `icmp_typename` (String) ICMP type matching mode. Managed by the UniFi controller; the provider round-trips it so updates are accepted.
 - `icmp_v6_typename` (String) ICMPv6 type matching mode. Managed by the UniFi controller; the provider round-trips it so updates are accepted.
 - `id` (String) The ID of the firewall policy.

--- a/unifi/firewall_policy_resource.go
+++ b/unifi/firewall_policy_resource.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
+	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -340,16 +341,26 @@ func (r *firewallPolicyResource) Schema(
 				},
 			},
 			"connection_state_type": schema.StringAttribute{
-				MarkdownDescription: "Connection-state matching mode (`ALL`, `RESPOND_ONLY`, or `CUSTOM`). Managed by the UniFi controller; the provider round-trips it so updates are accepted.",
+				MarkdownDescription: "Connection-state matching mode: `ALL` (any state), `RESPOND_ONLY` (established/related returns), or `CUSTOM` (match the states listed in `connection_states`). Optional: if omitted the controller assigns it (defaults to `ALL`) and the provider round-trips the value so updates are accepted.",
+				Optional:            true,
 				Computed:            true,
+				Validators: []validator.String{
+					stringvalidator.OneOf("ALL", "RESPOND_ONLY", "CUSTOM"),
+				},
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
 				},
 			},
 			"connection_states": schema.ListAttribute{
-				MarkdownDescription: "Connection states matched when `connection_state_type` is `CUSTOM` (e.g. `NEW`, `ESTABLISHED`, `RELATED`, `INVALID`). Managed by the UniFi controller; the provider round-trips it so a `CUSTOM` policy's states are not dropped on update (which the firmware rejects with HTTP 400).",
+				MarkdownDescription: "Connection states matched when `connection_state_type` is `CUSTOM` (`NEW`, `ESTABLISHED`, `RELATED`, `INVALID`). Optional: leave unset for `ALL`/`RESPOND_ONLY` and the controller manages it; the provider round-trips the value so a `CUSTOM` policy's states are not dropped on update (which the firmware rejects with HTTP 400).",
 				ElementType:         types.StringType,
+				Optional:            true,
 				Computed:            true,
+				Validators: []validator.List{
+					listvalidator.ValueStringsAre(
+						stringvalidator.OneOf("NEW", "ESTABLISHED", "RELATED", "INVALID"),
+					),
+				},
 				PlanModifiers: []planmodifier.List{
 					listplanmodifier.UseStateForUnknown(),
 				},

--- a/unifi/firewall_policy_resource_test.go
+++ b/unifi/firewall_policy_resource_test.go
@@ -515,6 +515,28 @@ func Test_firewallPolicyResource_Schema(t *testing.T) {
 	}
 }
 
+// TestFirewallPolicyConnectionStatesSettable guards #351: connection_state_type
+// and connection_states must be author-settable (Optional+Computed) so a policy
+// can be scoped to NEW-only / RESPOND_ONLY connections, not just read back.
+func TestFirewallPolicyConnectionStatesSettable(t *testing.T) {
+	r := &firewallPolicyResource{}
+	resp := &fwresource.SchemaResponse{}
+	r.Schema(context.Background(), fwresource.SchemaRequest{}, resp)
+
+	for _, key := range []string{"connection_state_type", "connection_states"} {
+		attr, ok := resp.Schema.Attributes[key]
+		if !ok {
+			t.Fatalf("Schema missing %q attribute", key)
+		}
+		if !attr.IsOptional() {
+			t.Errorf("%q must be Optional (author-settable), got Optional=false", key)
+		}
+		if !attr.IsComputed() {
+			t.Errorf("%q must stay Computed (round-trip), got Computed=false", key)
+		}
+	}
+}
+
 func Test_firewallPolicyResource_Configure(t *testing.T) {
 	type args struct {
 		ctx  context.Context


### PR DESCRIPTION
## Summary

`unifi_firewall_policy.connection_state_type` and `connection_states` were `Computed`-only, so any attempt to set them failed with:

```
Error: Invalid Configuration for Read-Only Attribute
```

This made it impossible to author a policy scoped to a specific connection state — e.g. a `NEW`-only logging/deny policy that must coexist with the `RESPOND_ONLY` return companion generated by `create_allow_respond` in a zone-based firewall (per the detailed analysis in #351, a `BLOCK` policy with the default `ALL` state lands at a low per-zone-pair index and shadows established/related returns, breaking the allowed flow).

## Change

- Both attributes are now **`Optional + Computed`**:
  - Leave them unset → the controller manages them exactly as before (round-trip preserved).
  - Set `connection_state_type = "CUSTOM"` + `connection_states = ["NEW", …]` (or `RESPOND_ONLY`) to author stateful/logging policies.
- Added validators: `connection_state_type` ∈ `ALL`/`RESPOND_ONLY`/`CUSTOM`; each `connection_states` element ∈ `NEW`/`ESTABLISHED`/`RELATED`/`INVALID`.
- `UseStateForUnknown` retained on both, so omitted values stay stable across plans.

The write path (`modelToAPI`) already sends both fields from the model, so no change was needed there — this is purely lifting the schema restriction.

## Tests / docs

- New `TestFirewallPolicyConnectionStatesSettable` asserts both attributes are `Optional` and stay `Computed`.
- Existing round-trip guards (`TestFirewallPolicyConnectionStatesRoundTrip` #227, `TestFirewallPolicyPreservesFirmwareFields`) still pass.
- Docs regenerated (both fields move from **Read-Only** to **Optional**).

Closes #351