### PR TITLE
docs(changelog): release v0.54.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [Unreleased]
+## [v0.54.0] - 2026-07-02
 
 ### ✨ Features
 


### PR DESCRIPTION
Promote `[Unreleased]` → **v0.54.0** ahead of tagging.

Since v0.53.0: features — `unifi_firewall_policy` connection_state_type/states author-settable (#351), `unifi_wan` networkgroup / multi-WAN (#334), `unifi_network` purpose corporate/guest/vlan-only (#276); fixes — network multicast_dns (#282), wan dslite (#281), firewall-policy match-list churn (#338), device LED (#337), device mgmt_network_id persist (#329), wan dns null-normalize (#333), firewall-policy index read-only (#348).

Merge, then tag `v0.54.0` to trigger the release workflow.

https://claude.ai/code/session_01D83uMn2TM7GdYPchVt7EWV