### PR TITLE
fix(radius-profile): make auth/acct server ip optional (#356)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### 🐛 Bug Fixes
+
+- **`unifi_radius_profile`: make `auth_server` / `acct_server` `ip` optional so the default profile can be imported.** The controller-managed default RADIUS profile (created when a gateway RADIUS/VPN service is enabled, with `use_usg_auth_server = true`) returns a server entry without an IP. `ip` was `Required`, so re-declaring an imported profile failed with `The argument "ip" is required`, and an empty IP read back as `""` instead of null. `ip` is now `Optional` and an absent IP maps to null, so the default profile round-trips cleanly (#356)
+
 ## [v0.54.0] - 2026-07-02
 
 ### ✨ Features

--- a/docs/resources/radius_profile.md
+++ b/docs/resources/radius_profile.md
@@ -89,11 +89,11 @@ resource "unifi_wlan" "corp" {
 
 Required:
 
-- `ip` (String) IP address of accounting service server.
 - `secret` (String, Sensitive) Shared secret for accounting server.
 
 Optional:
 
+- `ip` (String) IP address of the accounting server. Optional: the controller-managed default profile returns a server entry without an IP, so importing it must not force one.
 - `port` (Number) Port of accounting service.
 
 
@@ -102,11 +102,11 @@ Optional:
 
 Required:
 
-- `ip` (String) IP address of authentication service server.
 - `secret` (String, Sensitive) Shared secret for authentication server.
 
 Optional:
 
+- `ip` (String) IP address of the authentication server. Optional: the controller-managed default profile (e.g. the one created when a gateway RADIUS/VPN service is enabled, with `use_usg_auth_server = true`) returns a server entry without an IP, so importing it must not force one.
 - `port` (Number) Port of authentication service.
 
 

--- a/unifi/radius_profile_resource.go
+++ b/unifi/radius_profile_resource.go
@@ -203,8 +203,12 @@ func (r *radiusProfileResource) Schema(
 				NestedObject: schema.NestedBlockObject{
 					Attributes: map[string]schema.Attribute{
 						"ip": schema.StringAttribute{
-							MarkdownDescription: "IP address of authentication service server.",
-							Required:            true,
+							MarkdownDescription: "IP address of the authentication server. " +
+								"Optional: the controller-managed default profile (e.g. the " +
+								"one created when a gateway RADIUS/VPN service is enabled, with " +
+								"`use_usg_auth_server = true`) returns a server entry without an " +
+								"IP, so importing it must not force one.",
+							Optional: true,
 							Validators: []validator.String{
 								validators.IPv4Validator(),
 							},
@@ -231,8 +235,10 @@ func (r *radiusProfileResource) Schema(
 				NestedObject: schema.NestedBlockObject{
 					Attributes: map[string]schema.Attribute{
 						"ip": schema.StringAttribute{
-							MarkdownDescription: "IP address of accounting service server.",
-							Required:            true,
+							MarkdownDescription: "IP address of the accounting server. " +
+								"Optional: the controller-managed default profile returns a " +
+								"server entry without an IP, so importing it must not force one.",
+							Optional: true,
 							Validators: []validator.String{
 								validators.IPv4Validator(),
 							},
@@ -622,7 +628,7 @@ func (r *radiusProfileResource) radiusProfileToModel(
 	model.AuthServer = []radiusServerModel{}
 	for _, authServer := range radiusProfile.AuthServers {
 		model.AuthServer = append(model.AuthServer, radiusServerModel{
-			IP:     types.StringValue(authServer.IP),
+			IP:     util.StringValueOrNull(authServer.IP),
 			Port:   types.Int64PointerValue(authServer.Port),
 			Secret: types.StringValue(authServer.Secret),
 		})
@@ -631,7 +637,7 @@ func (r *radiusProfileResource) radiusProfileToModel(
 	model.AcctServer = []radiusServerModel{}
 	for _, acctServer := range radiusProfile.AcctServers {
 		model.AcctServer = append(model.AcctServer, radiusServerModel{
-			IP:     types.StringValue(acctServer.IP),
+			IP:     util.StringValueOrNull(acctServer.IP),
 			Port:   types.Int64PointerValue(acctServer.Port),
 			Secret: types.StringValue(acctServer.Secret),
 		})

--- a/unifi/radius_profile_resource_test.go
+++ b/unifi/radius_profile_resource_test.go
@@ -784,6 +784,29 @@ func Test_radiusProfileResource_radiusProfileToModel(t *testing.T) {
 		}
 	})
 
+	// #356: the controller-managed default profile returns a server entry with no
+	// IP. It must map to a null (not "") IP so, with ip now Optional, importing then
+	// re-declaring the profile doesn't fail with "ip is required" or churn a diff.
+	t.Run("server without IP maps to null", func(t *testing.T) {
+		port := int64(1812)
+		profile := &unifi.RADIUSProfile{
+			ID:               "prof-default",
+			Name:             "Default",
+			UseUsgAuthServer: true,
+			AuthServers: []unifi.RADIUSProfileAuthServers{
+				{IP: "", Port: &port, Secret: "shhh"},
+			},
+		}
+		model := &radiusProfileResourceModel{}
+		r.radiusProfileToModel(ctx, profile, model, "default")
+		if len(model.AuthServer) != 1 {
+			t.Fatalf("AuthServer length = %d, want 1", len(model.AuthServer))
+		}
+		if !model.AuthServer[0].IP.IsNull() {
+			t.Errorf("AuthServer IP = %q, want null", model.AuthServer[0].IP.ValueString())
+		}
+	})
+
 	t.Run("empty servers produce empty slices not nil", func(t *testing.T) {
 		profile := &unifi.RADIUSProfile{
 			ID:          "prof-2",


### PR DESCRIPTION
## Context

Reported in #356: importing the controller-managed **default** `unifi_radius_profile` (the one created when a gateway RADIUS/VPN service is enabled, `use_usg_auth_server = true`) then re-declaring it fails:

```
Error: Missing required argument
  The argument "ip" is required, but no definition was found.
```

That default profile's server entry has **no IP**. Confirmed against a live UniFi OS 10.x controller: the default profile returns `auth_servers`/`acct_servers` where the IP can be empty. `ip` was `Required`, so the imported config couldn't be re-applied, and an empty IP read back as `""` (not null) — a spurious diff.

## Changes

- `auth_server.ip` / `acct_server.ip`: `Required` → **`Optional`** (the IPv4 validator already skips null/unknown, so a supplied IP is still validated).
- Read path maps an empty server IP to **null** (`util.StringValueOrNull`) so an IP-less server round-trips cleanly.
- Docs/example regenerated; changelog entry.

## Tests

- New `radiusProfileToModel` sub-case asserting an IP-less server maps to a null `ip`.
- `go build` / `go vet` / `golangci-lint` (0 issues) / unit suite pass.

Closes #356

https://claude.ai/code/session_01D83uMn2TM7GdYPchVt7EWV