### PR TITLE
docs(changelog): release v0.54.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [Unreleased]
+## [v0.54.1] - 2026-07-05
 
 ### 🐛 Bug Fixes
 


### PR DESCRIPTION
Promote `[Unreleased]` → **v0.54.1**.

Patch release: `unifi_radius_profile` auth/acct server `ip` made optional so the controller-managed default profile imports cleanly (#356).

Merge, then tag `v0.54.1`.

https://claude.ai/code/session_01D83uMn2TM7GdYPchVt7EWV