### PR TITLE
fix(schema): UseStateForUnknown on controller-managed device/setting lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 - **`unifi_ap_group`: manage AP group membership.** Full CRUD, complementing the existing read-only data source. Which APs belong to a group was fixed in the controller UI: the data source could read a group, but nothing could create or edit one, so `unifi_wlan.ap_group_ids` could only reference groups built by hand. The resource writes membership through the v2 `apgroups` API. `device_macs` reuses the `unifi_client` MAC type, so `AA-BB-…` and `aa:bb:…` read back equal rather than churning the plan on every refresh. Import takes the group ID, or `site:id` for a non-default site (#359, go-unifi#52).
 
+### 🐛 Bug Fixes
+
+- **`unifi_device` / `unifi_setting`: stop controller-managed lists churning to "known after apply" on unrelated edits.** Several `Optional + Computed` lists were replanned as `(known after apply)` whenever any other field on the same resource changed — a spurious diff (the same class as #338). They now use `UseStateForUnknown`, keeping their prior value unless explicitly changed: `unifi_device` `radio_table` and `outlet_overrides`, and `unifi_setting` `contents` (syslog facilities), `server_names` (DoH), `enabled_categories` / `enabled_networks` (IPS), and `network_ids` (IGMP snooping).
+
 ## [v0.54.1] - 2026-07-05
 
 ### 🐛 Bug Fixes

--- a/unifi/device_resource.go
+++ b/unifi/device_resource.go
@@ -24,6 +24,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
@@ -568,6 +569,12 @@ func (r *deviceResource) Schema(
 				Description: "Radio configuration table.",
 				Optional:    true,
 				Computed:    true,
+				// Controller-managed radio config: keep the prior value when the plan
+				// leaves it unknown, so editing an unrelated device field doesn't replan
+				// the whole table to "(known after apply)".
+				PlanModifiers: []planmodifier.List{
+					listplanmodifier.UseStateForUnknown(),
+				},
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
 						"radio": schema.StringAttribute{
@@ -674,6 +681,12 @@ func (r *deviceResource) Schema(
 				Description: "Outlet configuration overrides.",
 				Optional:    true,
 				Computed:    true,
+				// Keep the prior value when the plan leaves it unknown, so editing an
+				// unrelated device field doesn't replan every outlet to
+				// "(known after apply)".
+				PlanModifiers: []planmodifier.List{
+					listplanmodifier.UseStateForUnknown(),
+				},
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
 						"index": schema.Int64Attribute{

--- a/unifi/setting_resource.go
+++ b/unifi/setting_resource.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
@@ -592,6 +593,9 @@ func (r *settingResource) Schema(
 						Optional:            true,
 						Computed:            true,
 						ElementType:         types.StringType,
+						PlanModifiers: []planmodifier.List{
+							listplanmodifier.UseStateForUnknown(),
+						},
 					},
 					"log_all_contents": schema.BoolAttribute{
 						MarkdownDescription: "Log all available facilities.",
@@ -657,6 +661,9 @@ func (r *settingResource) Schema(
 						Optional:            true,
 						Computed:            true,
 						ElementType:         types.StringType,
+						PlanModifiers: []planmodifier.List{
+							listplanmodifier.UseStateForUnknown(),
+						},
 					},
 					"custom_servers": schema.ListNestedAttribute{
 						MarkdownDescription: "Custom DNS servers specified via DNS stamp.",
@@ -704,12 +711,18 @@ func (r *settingResource) Schema(
 						Optional:            true,
 						Computed:            true,
 						ElementType:         types.StringType,
+						PlanModifiers: []planmodifier.List{
+							listplanmodifier.UseStateForUnknown(),
+						},
 					},
 					"enabled_networks": schema.ListAttribute{
 						MarkdownDescription: "Network IDs to apply IPS inspection to.",
 						Optional:            true,
 						Computed:            true,
 						ElementType:         types.StringType,
+						PlanModifiers: []planmodifier.List{
+							listplanmodifier.UseStateForUnknown(),
+						},
 					},
 					"honeypot_enabled": schema.BoolAttribute{
 						MarkdownDescription: "Enable honeypot to detect internal port scans.",
@@ -1242,6 +1255,9 @@ func (r *settingResource) Schema(
 						ElementType:         types.StringType,
 						Optional:            true,
 						Computed:            true,
+						PlanModifiers: []planmodifier.List{
+							listplanmodifier.UseStateForUnknown(),
+						},
 					},
 				},
 			},


### PR DESCRIPTION
## Context

A proactive audit for the recurring inconsistent-result / spurious-diff patterns turned up several `Optional + Computed` lists that lacked a plan modifier. Like the firewall-policy match lists fixed in #338, they replan to `(known after apply)` whenever any *other* field on the same resource changes — a spurious diff, and a risk of the controller recomputing the value.

## Changes

Add `listplanmodifier.UseStateForUnknown()` so each list keeps its prior value unless explicitly changed:

- **`unifi_device`**: `radio_table`, `outlet_overrides`
- **`unifi_setting`**: `contents` (syslog facilities), `server_names` (DoH), `enabled_categories` / `enabled_networks` (IPS), `network_ids` (IGMP snooping)

This is the same safe, plan-only pattern already used across the provider (#323, #338); it never affects apply.

## Verified, not a bug

`firewall_policy` `source`/`destination` `matching_target` and `zone_id` (both `Required`) were also flagged by the audit as potential import breakers. Checked against a real UniFi OS 10.x controller: across 395 policies (790 endpoints) `matching_target` is always `ANY`/`IP` and `zone_id` always populated — **never empty** — so they are correctly left `Required` and untouched.

## Deferred (need judgment/verification, not in this PR)

- `unifi_setting.ssh_password` and `unifi_vpn_server.radius_profile_id` can't be *cleared* once set (fetch-then-overlay only writes non-null) — a behavior change worth its own discussion.
- Several `Required` write-only secrets (`vpn_server.pre_shared_key`, `vpn_client.private_key`) may break pure `import` — needs a VPN setup to confirm.

## Tests

`go build` / `go vet` / `golangci-lint` (0 issues) / unit suite pass. UseStateForUnknown is a plan-time modifier not represented in generated docs, so no doc changes.

https://claude.ai/code/session_01D83uMn2TM7GdYPchVt7EWV