### PR TITLE
Add write-only VPN client private key

### DIFF
--- a/docs/resources/vpn_client.md
+++ b/docs/resources/vpn_client.md
@@ -50,6 +50,33 @@ resource "unifi_vpn_client" "wireguard_manual" {
   }
 }
 
+variable "wireguard_private_key" {
+  type      = string
+  sensitive = true
+  ephemeral = true
+}
+
+resource "unifi_vpn_client" "wireguard_write_only" {
+  name          = "my-write-only-wireguard"
+  enabled       = true
+  subnet        = "10.0.2.2/24"
+  default_route = false
+  pull_dns      = true
+
+  wireguard = {
+    private_key_wo         = var.wireguard_private_key
+    private_key_wo_version = 1
+    interface              = "wan"
+    dns_servers            = ["1.1.1.1"]
+
+    peer = {
+      ip         = "203.0.113.1"
+      port       = 51820
+      public_key = "your_peer_public_key_here"
+    }
+  }
+}
+
 resource "unifi_vpn_client" "wireguard_with_psk" {
   name          = "secure-wireguard"
   enabled       = true
@@ -97,10 +124,6 @@ resource "unifi_vpn_client" "wireguard_with_psk" {
 <a id="nestedatt--wireguard"></a>
 ### Nested Schema for `wireguard`
 
-Required:
-
-- `private_key` (String, Sensitive) WireGuard private key for this client.
-
 Optional:
 
 - `configuration` (Attributes) File-based WireGuard configuration. Provide a complete WireGuard .conf file. (see [below for nested schema](#nestedatt--wireguard--configuration))
@@ -109,6 +132,9 @@ Optional:
 - `peer` (Attributes) Manual WireGuard peer configuration. Specify peer endpoint and public key. (see [below for nested schema](#nestedatt--wireguard--peer))
 - `preshared_key` (String, Sensitive) WireGuard preshared key. Required when preshared_key_enabled is true.
 - `preshared_key_enabled` (Boolean) Specifies whether to use a preshared key for additional security.
+- `private_key` (String, Sensitive) WireGuard private key for this client. Stored in state; use `private_key_wo` to avoid persisting the secret.
+- `private_key_wo` (String, Sensitive, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) Write-only equivalent of `private_key` (Terraform 1.11+). Used at apply time but never written to state. Mutually exclusive with `private_key`.
+- `private_key_wo_version` (Number) Version counter for `private_key_wo`. Increment this value to trigger a private key update.
 
 <a id="nestedatt--wireguard--configuration"></a>
 ### Nested Schema for `wireguard.configuration`

--- a/examples/resources/unifi_vpn_client/resource.tf
+++ b/examples/resources/unifi_vpn_client/resource.tf
@@ -36,6 +36,33 @@ resource "unifi_vpn_client" "wireguard_manual" {
   }
 }
 
+variable "wireguard_private_key" {
+  type      = string
+  sensitive = true
+  ephemeral = true
+}
+
+resource "unifi_vpn_client" "wireguard_write_only" {
+  name          = "my-write-only-wireguard"
+  enabled       = true
+  subnet        = "10.0.2.2/24"
+  default_route = false
+  pull_dns      = true
+
+  wireguard = {
+    private_key_wo         = var.wireguard_private_key
+    private_key_wo_version = 1
+    interface              = "wan"
+    dns_servers            = ["1.1.1.1"]
+
+    peer = {
+      ip         = "203.0.113.1"
+      port       = 51820
+      public_key = "your_peer_public_key_here"
+    }
+  }
+}
+
 resource "unifi_vpn_client" "wireguard_with_psk" {
   name          = "secure-wireguard"
   enabled       = true

--- a/unifi/vpn_client_resource.go
+++ b/unifi/vpn_client_resource.go
@@ -25,6 +25,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/ubiquiti-community/go-unifi/unifi"
@@ -104,6 +105,8 @@ func (m wireguardPeerModel) AttributeTypes() map[string]attr.Type {
 // wireguardModel describes the WireGuard VPN configuration.
 type wireguardModel struct {
 	PrivateKey          types.String `tfsdk:"private_key"`
+	PrivateKeyWO        types.String `tfsdk:"private_key_wo"`
+	PrivateKeyWOVersion types.Int64  `tfsdk:"private_key_wo_version"`
 	Configuration       types.Object `tfsdk:"configuration"`
 	Peer                types.Object `tfsdk:"peer"`
 	PresharedKeyEnabled types.Bool   `tfsdk:"preshared_key_enabled"`
@@ -114,7 +117,9 @@ type wireguardModel struct {
 
 func (m wireguardModel) AttributeTypes() map[string]attr.Type {
 	return map[string]attr.Type{
-		"private_key": types.StringType,
+		"private_key":            types.StringType,
+		"private_key_wo":         types.StringType,
+		"private_key_wo_version": types.Int64Type,
 		"configuration": types.ObjectType{
 			AttrTypes: wireguardConfigurationModel{}.AttributeTypes(),
 		},
@@ -219,9 +224,43 @@ func (r *vpnClientResource) Schema(
 				Required:            true,
 				Attributes: map[string]schema.Attribute{
 					"private_key": schema.StringAttribute{
-						MarkdownDescription: "WireGuard private key for this client.",
-						Required:            true,
+						MarkdownDescription: "WireGuard private key for this client. Stored in state; use `private_key_wo` to avoid persisting the secret.",
+						Optional:            true,
 						Sensitive:           true,
+						Validators: []validator.String{
+							stringvalidator.AtLeastOneOf(
+								path.MatchRelative().AtParent().AtName("private_key"),
+								path.MatchRelative().AtParent().AtName("private_key_wo"),
+							),
+							stringvalidator.ConflictsWith(
+								path.MatchRelative().AtParent().AtName("private_key_wo"),
+							),
+						},
+					},
+					"private_key_wo": schema.StringAttribute{
+						MarkdownDescription: "Write-only equivalent of `private_key` (Terraform 1.11+). Used at apply time but never written to state. Mutually exclusive with `private_key`.",
+						Optional:            true,
+						Sensitive:           true,
+						WriteOnly:           true,
+						Validators: []validator.String{
+							stringvalidator.AtLeastOneOf(
+								path.MatchRelative().AtParent().AtName("private_key"),
+								path.MatchRelative().AtParent().AtName("private_key_wo"),
+							),
+							stringvalidator.ConflictsWith(
+								path.MatchRelative().AtParent().AtName("private_key"),
+							),
+						},
+					},
+					"private_key_wo_version": schema.Int64Attribute{
+						MarkdownDescription: "Version counter for `private_key_wo`. Increment this value to trigger a private key update.",
+						Optional:            true,
+						Validators: []validator.Int64{
+							int64validator.AtLeast(1),
+							int64validator.AlsoRequires(
+								path.MatchRelative().AtParent().AtName("private_key_wo"),
+							),
+						},
 					},
 					"configuration": schema.SingleNestedAttribute{
 						MarkdownDescription: "File-based WireGuard configuration. Provide a complete WireGuard .conf file.",
@@ -355,6 +394,13 @@ func (r *vpnClientResource) Create(
 	if resp.Diagnostics.HasError() {
 		return
 	}
+	privateKeyWO := r.readPrivateKeyWO(ctx, req.Config, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	if !privateKeyWO.IsNull() && !privateKeyWO.IsUnknown() {
+		network.WireguardPrivateKey = privateKeyWO.ValueStringPointer()
+	}
 
 	site := data.Site.ValueString()
 	if site == "" {
@@ -486,6 +532,13 @@ func (r *vpnClientResource) Update(
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
+	}
+	privateKeyWO := r.readPrivateKeyWO(ctx, req.Config, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	if !privateKeyWO.IsNull() && !privateKeyWO.IsUnknown() {
+		network.WireguardPrivateKey = privateKeyWO.ValueStringPointer()
 	}
 
 	site := data.Site.ValueString()
@@ -807,6 +860,7 @@ func (r *vpnClientResource) networkToModel(
 	// For private key and preshared key: when file mode was used, preserve the
 	// values from prior state since the API may return different representations.
 	privateKeyVal := strPtrToType(network.WireguardPrivateKey)
+	privateKeyWOVersion := types.Int64Null()
 	presharedKeyVal := strPtrToType(network.WireguardClientPresharedKey)
 	presharedKeyEnabled := types.BoolValue(network.WireguardClientPresharedKeyEnabled)
 
@@ -821,8 +875,25 @@ func (r *vpnClientResource) networkToModel(
 		}
 	}
 
+	// A null private_key in prior state means the write-only alternative was
+	// used. Never copy the controller's echoed private key into state.
+	if priorState != nil && !priorState.Wireguard.IsNull() &&
+		!priorState.Wireguard.IsUnknown() {
+		var priorWG wireguardModel
+		d := priorState.Wireguard.As(ctx, &priorWG, basetypes.ObjectAsOptions{})
+		diags.Append(d...)
+		if !diags.HasError() && priorWG.PrivateKey.IsNull() {
+			privateKeyVal = types.StringNull()
+		}
+		if !diags.HasError() {
+			privateKeyWOVersion = priorWG.PrivateKeyWOVersion
+		}
+	}
+
 	wireguardValue := wireguardModel{
 		PrivateKey:          privateKeyVal,
+		PrivateKeyWO:        types.StringNull(),
+		PrivateKeyWOVersion: privateKeyWOVersion,
 		Configuration:       configurationObj,
 		Peer:                peerObj,
 		PresharedKeyEnabled: presharedKeyEnabled,
@@ -840,6 +911,22 @@ func (r *vpnClientResource) networkToModel(
 	model.Wireguard = wireguardObj
 
 	return diags
+}
+
+// readPrivateKeyWO reads the write-only key from configuration. Write-only
+// values are never available through plan or state.
+func (r *vpnClientResource) readPrivateKeyWO(
+	ctx context.Context,
+	config tfsdk.Config,
+	diags *diag.Diagnostics,
+) types.String {
+	var privateKeyWO types.String
+	diags.Append(config.GetAttribute(
+		ctx,
+		path.Root("wireguard").AtName("private_key_wo"),
+		&privateKeyWO,
+	)...)
+	return privateKeyWO
 }
 
 // ListResourceConfigSchema implements [list.ListResource].

--- a/unifi/vpn_client_resource_test.go
+++ b/unifi/vpn_client_resource_test.go
@@ -2,13 +2,16 @@ package unifi
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-framework-nettypes/cidrtypes"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	fwlist "github.com/hashicorp/terraform-plugin-framework/list"
 	fwresource "github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/querycheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfversion"
@@ -149,6 +152,32 @@ func TestAccVPNClient_with_preshared_key(t *testing.T) {
 	})
 }
 
+func TestAccVPNClient_write_only_private_key(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { preCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVPNClientConfig_write_only_private_key(1, "WPiBa/Ak1W+8Sp8L5yvbyhHeRO2o5kJvihq2VtJ+kFg="),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("unifi_vpn_client.test", "enabled", "false"),
+					resource.TestCheckNoResourceAttr("unifi_vpn_client.test", "wireguard.private_key"),
+					resource.TestCheckNoResourceAttr("unifi_vpn_client.test", "wireguard.private_key_wo"),
+					resource.TestCheckResourceAttr("unifi_vpn_client.test", "wireguard.private_key_wo_version", "1"),
+				),
+			},
+			{
+				Config: testAccVPNClientConfig_write_only_private_key(2, "uGEwDKZ2Hf2s2Dg59c9K+qYzJEBN5s8fNWVTxZx9kUo="),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckNoResourceAttr("unifi_vpn_client.test", "wireguard.private_key"),
+					resource.TestCheckNoResourceAttr("unifi_vpn_client.test", "wireguard.private_key_wo"),
+					resource.TestCheckResourceAttr("unifi_vpn_client.test", "wireguard.private_key_wo_version", "2"),
+				),
+			},
+		},
+	})
+}
+
 func testAccVPNClientConfig_file_mode() string {
 	return `
 resource "unifi_vpn_client" "test" {
@@ -221,6 +250,31 @@ resource "unifi_vpn_client" "test" {
 `
 }
 
+func testAccVPNClientConfig_write_only_private_key(version int, privateKey string) string {
+	return fmt.Sprintf(`
+resource "unifi_vpn_client" "test" {
+  name          = "test-wireguard-write-only"
+  enabled       = false
+  subnet        = "10.0.3.2/24"
+  default_route = false
+  pull_dns      = false
+
+  wireguard = {
+    private_key_wo         = %q
+    private_key_wo_version = %d
+    interface              = "wan"
+    dns_servers            = ["8.8.8.8"]
+
+    peer = {
+      ip         = "192.0.2.1"
+      port       = 51820
+      public_key = "7B+2Z3odPbDNsfVr+F8invj6/mBKLVaolOHXZoCaBA0="
+    }
+  }
+}
+`, privateKey, version)
+}
+
 func TestNewVPNClientResource(t *testing.T) {
 	r := NewVPNClientResource()
 	if r == nil {
@@ -284,7 +338,7 @@ func Test_wireguardModel_AttributeTypes(t *testing.T) {
 	m := wireguardModel{}
 	got := m.AttributeTypes()
 	for _, key := range []string{
-		"private_key", "configuration", "peer",
+		"private_key", "private_key_wo", "private_key_wo_version", "configuration", "peer",
 		"preshared_key_enabled", "preshared_key", "interface", "dns_servers",
 	} {
 		if _, ok := got[key]; !ok {
@@ -443,6 +497,37 @@ func Test_vpnClientResource_modelToNetwork(t *testing.T) {
 	})
 }
 
+func Test_vpnClientResource_privateKeyWriteOnlySchema(t *testing.T) {
+	ctx := context.Background()
+	r := &vpnClientResource{}
+	var resp fwresource.SchemaResponse
+	r.Schema(ctx, fwresource.SchemaRequest{}, &resp)
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("schema diagnostics: %v", resp.Diagnostics)
+	}
+
+	wg, ok := resp.Schema.Attributes["wireguard"].(schema.SingleNestedAttribute)
+	if !ok {
+		t.Fatal("wireguard is not a single nested attribute")
+	}
+	privateKeyWO, ok := wg.Attributes["private_key_wo"].(schema.StringAttribute)
+	if !ok {
+		t.Fatal("wireguard.private_key_wo is not a string attribute")
+	}
+	privateKeyWOVersion, ok := wg.Attributes["private_key_wo_version"].(schema.Int64Attribute)
+	if !ok || !privateKeyWOVersion.Optional {
+		t.Fatal("wireguard.private_key_wo_version is not an optional int64 attribute")
+	}
+	if !privateKeyWO.WriteOnly || !privateKeyWO.Sensitive || !privateKeyWO.Optional {
+		t.Fatalf(
+			"private_key_wo flags = write-only:%t sensitive:%t optional:%t",
+			privateKeyWO.WriteOnly,
+			privateKeyWO.Sensitive,
+			privateKeyWO.Optional,
+		)
+	}
+}
+
 func Test_vpnClientResource_networkToModel(t *testing.T) {
 	ctx := context.Background()
 	r := &vpnClientResource{}
@@ -478,6 +563,61 @@ func Test_vpnClientResource_networkToModel(t *testing.T) {
 		}
 		if model.Wireguard.IsNull() {
 			t.Error("Wireguard should not be null")
+		}
+	})
+
+	t.Run("write-only private key is not copied from API into state", func(t *testing.T) {
+		mode := "manual"
+		ip := "1.2.3.4"
+		port := int64(51820)
+		pubKey := "pubkey=="
+		apiPrivateKey := "must-not-enter-state=="
+		subnet := "10.0.0.2/24"
+		name := "write-only-vpn"
+		network := &unifi.Network{
+			ID:                           "net-wo",
+			Name:                         &name,
+			Enabled:                      true,
+			IPSubnet:                     &subnet,
+			WireguardClientMode:          &mode,
+			WireguardClientPeerIP:        &ip,
+			WireguardClientPeerPort:      &port,
+			WireguardClientPeerPublicKey: &pubKey,
+			WireguardPrivateKey:          &apiPrivateKey,
+		}
+
+		priorWG := wireguardModel{
+			PrivateKey:          types.StringNull(),
+			PrivateKeyWO:        types.StringNull(),
+			PrivateKeyWOVersion: types.Int64Value(7),
+			Configuration:       types.ObjectNull(wireguardConfigurationModel{}.AttributeTypes()),
+			Peer:                types.ObjectNull(wireguardPeerModel{}.AttributeTypes()),
+			PresharedKeyEnabled: types.BoolValue(false),
+			PresharedKey:        types.StringNull(),
+			Interface:           types.StringValue("wan"),
+			DnsServers:          types.ListNull(types.StringType),
+		}
+		priorWGObj, d := types.ObjectValueFrom(ctx, priorWG.AttributeTypes(), priorWG)
+		if d.HasError() {
+			t.Fatalf("building prior wireguard state: %v", d)
+		}
+		prior := &vpnClientResourceModel{Wireguard: priorWGObj}
+
+		var model vpnClientResourceModel
+		diags := r.networkToModel(ctx, network, &model, "default", prior)
+		if diags.HasError() {
+			t.Fatalf("unexpected diags: %v", diags)
+		}
+		var gotWG wireguardModel
+		diags = model.Wireguard.As(ctx, &gotWG, basetypes.ObjectAsOptions{})
+		if diags.HasError() {
+			t.Fatalf("reading wireguard state: %v", diags)
+		}
+		if !gotWG.PrivateKey.IsNull() {
+			t.Fatalf("private key entered state: %q", gotWG.PrivateKey.ValueString())
+		}
+		if gotWG.PrivateKeyWOVersion.ValueInt64() != 7 {
+			t.Fatalf("private key version = %d, want 7", gotWG.PrivateKeyWOVersion.ValueInt64())
 		}
 	})
 

--- a/unifi/vpn_client_resource_test.go
+++ b/unifi/vpn_client_resource_test.go
@@ -158,20 +158,46 @@ func TestAccVPNClient_write_only_private_key(t *testing.T) {
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccVPNClientConfig_write_only_private_key(1, "WPiBa/Ak1W+8Sp8L5yvbyhHeRO2o5kJvihq2VtJ+kFg="),
+				Config: testAccVPNClientConfig_write_only_private_key(
+					1,
+					"WPiBa/Ak1W+8Sp8L5yvbyhHeRO2o5kJvihq2VtJ+kFg=",
+				),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("unifi_vpn_client.test", "enabled", "false"),
-					resource.TestCheckNoResourceAttr("unifi_vpn_client.test", "wireguard.private_key"),
-					resource.TestCheckNoResourceAttr("unifi_vpn_client.test", "wireguard.private_key_wo"),
-					resource.TestCheckResourceAttr("unifi_vpn_client.test", "wireguard.private_key_wo_version", "1"),
+					resource.TestCheckNoResourceAttr(
+						"unifi_vpn_client.test",
+						"wireguard.private_key",
+					),
+					resource.TestCheckNoResourceAttr(
+						"unifi_vpn_client.test",
+						"wireguard.private_key_wo",
+					),
+					resource.TestCheckResourceAttr(
+						"unifi_vpn_client.test",
+						"wireguard.private_key_wo_version",
+						"1",
+					),
 				),
 			},
 			{
-				Config: testAccVPNClientConfig_write_only_private_key(2, "uGEwDKZ2Hf2s2Dg59c9K+qYzJEBN5s8fNWVTxZx9kUo="),
+				Config: testAccVPNClientConfig_write_only_private_key(
+					2,
+					"uGEwDKZ2Hf2s2Dg59c9K+qYzJEBN5s8fNWVTxZx9kUo=",
+				),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckNoResourceAttr("unifi_vpn_client.test", "wireguard.private_key"),
-					resource.TestCheckNoResourceAttr("unifi_vpn_client.test", "wireguard.private_key_wo"),
-					resource.TestCheckResourceAttr("unifi_vpn_client.test", "wireguard.private_key_wo_version", "2"),
+					resource.TestCheckNoResourceAttr(
+						"unifi_vpn_client.test",
+						"wireguard.private_key",
+					),
+					resource.TestCheckNoResourceAttr(
+						"unifi_vpn_client.test",
+						"wireguard.private_key_wo",
+					),
+					resource.TestCheckResourceAttr(
+						"unifi_vpn_client.test",
+						"wireguard.private_key_wo_version",
+						"2",
+					),
 				),
 			},
 		},


### PR DESCRIPTION
## Changes

The VPN client resource currently takes its WireGuard private key through a sensitive attribute. Terraform hides sensitive values in normal output, but still stores them in state. That is not ideal for a private key.

This adds `private_key_wo` as a write-only alternative. The key is available while the provider creates or updates the VPN client, but it is not written into state afterward. The existing `private_key` field still works, so this should not break current configurations.

There is also a `private_key_wo_version` field for rotations. The version counter is the kinda awkward but important part, but I couldn't figure out how to make it better. Terraform seems to purposefully forget a write-only value, so it can't compare the old and new keys later. Incrementing the version makes the rotation explicit and gives Terraform a normal state-backed value that can trigger the update.

The controller echoes the private key when the resource is read, so the read path also makes sure that value is not accidentally copied back into state for configurations using the write-only field.

## Testing

I added unit coverage for the schema and for the API-to-state conversion, including a controller response containing a private key that must remain absent from state.

I also ran an acceptance test against the disposable UniFi controller. It creates a disabled VPN client using `private_key_wo`, confirms that neither key field is present in state, rotates to a different key by incrementing `private_key_wo_version`, checks state again, and removes the fixture.

The other testing that I've done has been by running in my own stack, sorry I don't know how else to test this.
