### PR TITLE
fix(setting): stabilize empty NTP server state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### 🐛 Bug Fixes
+
+- **`unifi_setting.ntp`: stop empty NTP server slots causing perpetual diffs or inconsistent results.** The controller stores unused `ntp_server_1..4` values as empty strings, but the provider read them back as `null`, conflicting with an explicitly configured `""`. The server attributes now preserve prior state during unrelated plans and normalize controller empty strings to known empty Terraform values (#382)
+
 ## [v0.55.0] - 2026-07-10
 
 ### ✨ Features

--- a/unifi/setting_resource.go
+++ b/unifi/setting_resource.go
@@ -545,21 +545,33 @@ func (r *settingResource) Schema(
 						MarkdownDescription: "Primary NTP server.",
 						Optional:            true,
 						Computed:            true,
+						PlanModifiers: []planmodifier.String{
+							stringplanmodifier.UseStateForUnknown(),
+						},
 					},
 					"ntp_server_2": schema.StringAttribute{
 						MarkdownDescription: "Second NTP server.",
 						Optional:            true,
 						Computed:            true,
+						PlanModifiers: []planmodifier.String{
+							stringplanmodifier.UseStateForUnknown(),
+						},
 					},
 					"ntp_server_3": schema.StringAttribute{
 						MarkdownDescription: "Third NTP server.",
 						Optional:            true,
 						Computed:            true,
+						PlanModifiers: []planmodifier.String{
+							stringplanmodifier.UseStateForUnknown(),
+						},
 					},
 					"ntp_server_4": schema.StringAttribute{
 						MarkdownDescription: "Fourth NTP server.",
 						Optional:            true,
 						Computed:            true,
+						PlanModifiers: []planmodifier.String{
+							stringplanmodifier.UseStateForUnknown(),
+						},
 					},
 				},
 			},
@@ -3024,10 +3036,10 @@ func (r *settingResource) ntpModelToSetting(m *settingNtpModel) *settings.Ntp {
 
 func (r *settingResource) ntpSettingToModel(s *settings.Ntp) settingNtpModel {
 	return settingNtpModel{
-		NtpServer1:        util.StringValueOrNull(s.NtpServer1),
-		NtpServer2:        util.StringValueOrNull(s.NtpServer2),
-		NtpServer3:        util.StringValueOrNull(s.NtpServer3),
-		NtpServer4:        util.StringValueOrNull(s.NtpServer4),
+		NtpServer1:        types.StringValue(s.NtpServer1),
+		NtpServer2:        types.StringValue(s.NtpServer2),
+		NtpServer3:        types.StringValue(s.NtpServer3),
+		NtpServer4:        types.StringValue(s.NtpServer4),
 		SettingPreference: util.StringValueOrNull(s.SettingPreference),
 	}
 }

--- a/unifi/setting_resource_test.go
+++ b/unifi/setting_resource_test.go
@@ -8,7 +8,11 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	fwresource "github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/ubiquiti-community/go-unifi/unifi/settings"
 )
@@ -654,6 +658,51 @@ func Test_settingResource_Schema(t *testing.T) {
 	}
 }
 
+// TestSettingNtpServersUseStateForUnknown guards #382: omitted
+// Optional+Computed server fields must retain their prior values instead of
+// repeatedly planning as "known after apply" when the NTP block is configured.
+func TestSettingNtpServersUseStateForUnknown(t *testing.T) {
+	resp := &fwresource.SchemaResponse{}
+	(&settingResource{}).Schema(context.Background(), fwresource.SchemaRequest{}, resp)
+
+	ntp, ok := resp.Schema.Attributes["ntp"].(schema.SingleNestedAttribute)
+	if !ok {
+		t.Fatal("ntp is not a SingleNestedAttribute")
+	}
+	for _, key := range []string{"ntp_server_1", "ntp_server_2", "ntp_server_3", "ntp_server_4"} {
+		server, ok := ntp.Attributes[key].(schema.StringAttribute)
+		if !ok {
+			t.Errorf("ntp.%s is not a StringAttribute", key)
+			continue
+		}
+		if !server.Optional || !server.Computed {
+			t.Errorf("ntp.%s must remain Optional+Computed", key)
+		}
+		if len(server.PlanModifiers) == 0 {
+			t.Errorf("ntp.%s must use UseStateForUnknown (#382)", key)
+			continue
+		}
+
+		req := planmodifier.StringRequest{
+			ConfigValue: types.StringNull(),
+			PlanValue:   types.StringUnknown(),
+			State: tfsdk.State{
+				Raw: tftypes.NewValue(tftypes.String, ""),
+			},
+			StateValue: types.StringValue(""),
+		}
+		modified := &planmodifier.StringResponse{PlanValue: req.PlanValue}
+		server.PlanModifiers[0].PlanModifyString(context.Background(), req, modified)
+		if modified.Diagnostics.HasError() {
+			t.Errorf("ntp.%s plan modifier returned errors: %v", key, modified.Diagnostics)
+		}
+		if modified.PlanValue.IsNull() || modified.PlanValue.IsUnknown() ||
+			modified.PlanValue.ValueString() != "" {
+			t.Errorf("ntp.%s plan = %v, want prior known empty state", key, modified.PlanValue)
+		}
+	}
+}
+
 func Test_settingResource_UpgradeState(t *testing.T) {
 	r := &settingResource{}
 	ctx := context.Background()
@@ -1280,6 +1329,34 @@ func TestAutoSpeedtestSettingRoundTrip(t *testing.T) {
 	out := r.autoSpeedtestSettingToModel(setting)
 	if !out.Enabled.ValueBool() || out.CronExpr.ValueString() != "0 3 * * *" {
 		t.Errorf("settingToModel = %+v, want enabled cron preserved", out)
+	}
+}
+
+// TestNtpSettingStateNormalization guards #382: the controller represents
+// unset NTP servers as "", which is a valid configured value and must not be
+// rewritten to null during the post-apply read.
+func TestNtpSettingStateNormalization(t *testing.T) {
+	r := &settingResource{}
+	apiSetting := r.ntpModelToSetting(&settingNtpModel{
+		NtpServer1:        types.StringValue("pool.ntp.org"),
+		NtpServer2:        types.StringValue(""),
+		NtpServer3:        types.StringNull(),
+		NtpServer4:        types.StringNull(),
+		SettingPreference: types.StringValue("manual"),
+	})
+
+	state := r.ntpSettingToModel(apiSetting)
+	if state.NtpServer1.ValueString() != "pool.ntp.org" {
+		t.Errorf("ntp_server_1 = %q, want pool.ntp.org", state.NtpServer1.ValueString())
+	}
+	for key, value := range map[string]types.String{
+		"ntp_server_2": state.NtpServer2,
+		"ntp_server_3": state.NtpServer3,
+		"ntp_server_4": state.NtpServer4,
+	} {
+		if value.IsNull() || value.IsUnknown() || value.ValueString() != "" {
+			t.Errorf("%s = %v, want known empty string", key, value)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes #382.

`unifi_setting.ntp.ntp_server_1..4` are `Optional + Computed`, while UniFi persists unused slots as empty strings. Two normalization gaps made that state unstable:

- omitted nested server fields replanned as `(known after apply)` on later changes
- the read conversion changed controller `""` into Terraform `null`, conflicting with an explicitly configured empty string

This adds `UseStateForUnknown` to each NTP server attribute and keeps controller empty strings as known empty Terraform values. `setting_preference` and the surrounding flatten/expand behavior are unchanged.

## Tests

- focused schema/state regression tests, including direct execution of the plan modifier against prior `""` state
- `go tool gotestsum --junitfile ... -- -coverprofile=... -covermode=atomic -race -count=1 -timeout 120m ./...` (1,297 passed; 161 expected skips)
- `go test ./unifi -count=1 -timeout 30m`
- `go vet ./...`
- `go build ./...`
- `go generate ./...` (no generated diff)
- `golangci-lint run --new-from-rev=upstream/main` (0 issues)
- `git diff --check`

Live controller acceptance was not run; the regression is covered deterministically through the provider schema and API/state conversion fixtures.
