### PR TITLE
compose: add unifi-emu device simulator sidecar

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,7 @@ The docker, UDM, and UDM-Pro versions are slightly different (the API is proxied
 ### Terraform 1.0 and above
 
 You can use the provider via the [Terraform provider registry](https://registry.terraform.io/providers/paultyng/unifi).
+
+## Acceptance Tests
+
+`TF_ACC=1 go test ./unifi/...` boots the demo-mode controller from `docker-compose.yaml` via testcontainers; a Docker (or Podman) socket is the only prerequisite. The compose file also starts a `unifi-device-sim` sidecar — emulated UniFi devices speaking the real inform protocol, from [unifi-emu](https://github.com/jamesbraid/unifi-emu) — because controllers without demo mode (for example a seeded UniFi OS appliance) expose no devices for the device tests to adopt. The image is a local build until one is published: `docker build -t unifi-emu:dev .` in the unifi-emu repo. With the default demo-mode controller the sidecar's devices are extra inventory the tests don't assert on, so the sidecar just runs; its default MACs deliberately avoid `00:27:22:00:00:02`, which the demo seeder already presents. If the harness ever swaps to a device-less seeded controller, declare that MAC in `SIM_DEVICES` so the device test's adoption contract keeps holding. `UNIFI_SKIP_CONTAINER=1` skips compose entirely and tests against `UNIFI_API` — in that mode, run your own sim against the external controller or skip the device tests.

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -29,3 +29,34 @@ services:
       - 10001:10001/udp
       - 8080:8080
     restart: unless-stopped
+
+  # unifi-device-sim emulates real UniFi devices speaking the inform protocol
+  # to the controller above (unifi-emu, https://github.com/jamesbraid/unifi-emu).
+  #
+  # Why: the demo-mode controller seeds fake "demo" devices, which is enough
+  # for the current acceptance tests. Controllers without demo mode (e.g. a
+  # seeded UniFi OS device) expose no devices at all, and device tests like
+  # TestAccDeviceFramework_basic need real inform-based devices to adopt. This
+  # sidecar provides those without changing the test code.
+  #
+  # MAC collision rule: the demo-mode seeder already presents 00:27:22:00:00:02
+  # (adopted by TestAccDeviceFramework_basic), so the defaults below MUST NOT
+  # declare that MAC. With the demo-mode controller these two extra devices are
+  # harmless: the provider tests don't assert on them. If the harness later
+  # swaps to a device-less seeded controller, change SIM_DEVICES to declare
+  # 00:27:22:00:00:02 so the test's MAC contract keeps holding.
+  #
+  # The sidecar shares the compose network with the controller, so the
+  # controller's own advertised inform address (set post-adoption) resolves
+  # for it; no inform-URL override is needed.
+  unifi-device-sim:
+    image: unifi-emu:dev # local build: `docker build -t unifi-emu:dev .` in the unifi-emu repo; swap for the published image when available
+    environment:
+      SIM_CONTROLLER: http://unifi:8080/inform
+      SIM_DEVICES: |
+        - {mac: "00:27:22:e0:00:51", type: uap, model: U7MP, ip: "192.168.1.251"}
+        - {mac: "00:27:22:e0:00:52", type: usw, model: USM8P, ip: "192.168.1.252"}
+    depends_on:
+      unifi:
+        condition: service_healthy
+    restart: unless-stopped

--- a/docs/superpowers/handoffs/2026-07-22-network-import-refresh-bugs-handoff.md
+++ b/docs/superpowers/handoffs/2026-07-22-network-import-refresh-bugs-handoff.md
@@ -1,0 +1,114 @@
+# Handoff: unifi_network import/refresh bugs (blocks ubitofu E2E suite)
+
+**For:** a session fixing `unifi_network`'s import path on this fork —
+prime upstream-PR material, same class as the `unifi_device`
+carry-dropped-fields fix (a7bcfc4f).
+
+**Found by:** ubitofu's live E2E gate (branch `emdash/testing-6agni`),
+2026-07-22, against registry **v0.55.0** and a classic UniFi Network
+**10.4.57** controller (`ghcr.io/jamesbraid/unifi-network:10.4.57-seeded`).
+Deterministic, 3/3 fresh-site runs. ubitofu's write scenarios are parked
+on these; its `docs/provider-import-bugs.md` carries the consumer-side
+record and un-parking checklist. On fix, ubitofu S1 becomes a live
+regression test.
+
+## Bug 1 — import-refresh Read drops real attributes → spurious update
+
+`ubitofu generate` emits HCL that byte-for-byte mirrors what the classic
+REST API returns, plus `import {}` blocks. `tofu plan` then shows
+`~ update in-place (imported from ...)` on **every** network, because the
+provider's Read during import-refresh returns null/unset for attributes
+the controller genuinely has:
+
+```
+  # unifi_network.default will be updated in-place
+  # (imported from "...")
+  ~ resource "unifi_network" "default" {
+      ~ dhcp_server                    = {
+          + leasetime           = "24h0m0s"
+            ...
+        }
+      + gateway_type                   = "default"
+      + setting_preference             = "auto"
+    }
+
+  # unifi_network.s1_net will be updated in-place
+  ~ resource "unifi_network" "s1_net" {
+      + gateway_type                  = "default"
+      + ipv6_interface_type           = "none"
+    }
+```
+
+Dropped set observed: `gateway_type`, `setting_preference`,
+`dhcp_server.leasetime`, `ipv6_interface_type`. Live values confirmed
+server-side (the rejected PUT payload itself carries
+`"dhcpd_leasetime":86400`).
+
+Where to look: the network resource's Read/flatten path vs the 10.x
+wire fields. go.mod pins go-unifi `v1.33.43-0.20260706191309-bc63776a9ebf`;
+go-unifi's `controller-testing` branch regenerated structs for 10.4.57
+(`b17d01c unifi: regenerate for UniFi Network 10.4.57`,
+`af942d5 unifi: restore dropped device fields`) — the same
+stale-schema-vs-10.x pattern is the likely cause here.
+
+## Bug 2 — consequence: a disabled default network is un-adoptable
+
+`rest/networkconf` is a full-object PUT. The forced "no-op" update from
+Bug 1 echoes the default network's real `enabled: false`, and the classic
+controller rejects ANY default-network PUT carrying `enabled:false` —
+changing or not:
+
+```
+Error Updating network
+  with unifi_network.default,
+api.err.DisablingDefaultNetworkNotAllowed (400) for PUT
+  .../rest/networkconf/<id>
+payload: {"_id": "...", ..., "enabled": false, ..., "name": "Default", ...}
+```
+
+Fixing Bug 1 removes the trigger; independently consider not sending
+`enabled` for the default network when it is not changing (defense in
+depth — same shape as the device dropped-fields fix).
+
+## Bug 3 — domain_name null → "" consistency crash on ordinary networks
+
+On the forced update of a freshly imported network whose config leaves
+`domain_name` unset, the PUT response returns `domain_name: ""` and the
+SDK's plan/apply consistency check aborts:
+
+```
+Error: Provider produced inconsistent result after apply
+When applying changes to unifi_network.s1_net, provider ... produced an
+unexpected new value: .domain_name: was null, but now cty.StringVal("").
+This is a bug in the provider, ...
+```
+
+Fix direction: normalize `""` ↔ null for `domain_name` (plan modifier /
+state normalization), as done for other Optional+Computed strings.
+
+## Reproduction
+
+Fastest (full harness): in ubitofu's branch, remove the `@pytest.mark.skip`
+on `tests/controllertest/test_scenarios_reconcile.py::test_s1_in_sync_reconcile_exits_zero`
+and run `pytest -m controller -k s1` (needs docker/colima; boots the
+seeded image, seeds a site + one VLAN network, generates, applies).
+
+Standalone (no ubitofu): run
+`ghcr.io/jamesbraid/unifi-network:10.4.57-seeded` (admin /
+`unifi-containers-seeded`, cookie login `POST /api/login`), create a site
+(`cmd/sitemgr add-site`) and one network
+(`POST /api/s/<site>/rest/networkconf` with
+`{"name":"x","purpose":"corporate","vlan_enabled":true,"vlan":210,
+"ip_subnet":"10.99.210.1/24","dhcpd_enabled":false}`), then a main.tf
+with the provider (username/password/`allow_insecure`), config mirroring
+the two networks' live values, and `import {}` blocks by `_id`.
+`tofu plan` reproduces Bug 1's spurious updates; `tofu apply` reproduces
+Bugs 2 and 3.
+
+## Acceptance
+
+- `tofu plan` right after import of an untouched network: **zero
+  changes**.
+- ubitofu S1 green (their `docs/provider-import-bugs.md` un-parking
+  checklist), which then unlocks their S2–S10 live scenarios — a free
+  ongoing regression suite for this fork.


### PR DESCRIPTION
TestMain boots `docker-compose.yaml` for acceptance tests and the demo-mode controller seeds fake demo devices, which is all the current tests need. Controllers without demo mode (a seeded UniFi OS appliance is the next harness target) expose no devices at all, leaving device tests like `TestAccDeviceFramework_basic` nothing to adopt.

This adds a `unifi-device-sim` service running [unifi-emu](https://github.com/jamesbraid/unifi-emu), an emulator whose devices speak the real inform protocol to the compose controller and can be adopted through the normal API.

## Notes for reviewers

- **MAC collision rule**: the demo-mode seeder already presents `00:27:22:00:00:02` (which `TestAccDeviceFramework_basic` adopts), so the sidecar's default MACs deliberately avoid it. With the demo controller the extra devices are harmless inventory no test asserts on. If the harness later swaps to a device-less seeded controller, `SIM_DEVICES` should declare `00:27:22:00:00:02` so the test's MAC contract keeps holding.
- **Image availability**: `unifi-emu:dev` is a local build (`docker build -t unifi-emu:dev .` in the unifi-emu repo) until a published image exists; the tag in the compose file should be swapped then.
- **No inform-URL override needed**: the sidecar shares the compose network, so the controller's post-adoption advertised inform address resolves for it.
- One sim-side fix was required for adoption to complete against `jacobalberty/unifi:latest`: the emulator must dial/report the controller by resolved IP, since the controller rejects a hostname `inform_url` post-adoption (`invalid inform_ip unifi` -> HTTP 400). Fixed in unifi-emu@4e35ff6.

## Validation

End to end against `jacobalberty/unifi:latest` with this exact compose file:

- Both sim devices inform and appear pending: `00:27:22:e0:00:51` U7MP and `00:27:22:e0:00:52` USM8P at `state=2, adopted=false`.
- `cmd/devmgr` adopt of `00:27:22:e0:00:51` completes: states 7 -> 4 -> 5 -> 1, final device doc `state=1, adopted=true`.
- Controller log: `Device adoption - initial mgmt_cfg sent` -> `Device[00:27:22:e0:00:51] adoption - completed` (controller even scheduled a firmware upgrade, which the sim emulates).
