### PR TITLE
fix(client): preserve planned values after update

### DIFF
--- a/unifi/client_resource.go
+++ b/unifi/client_resource.go
@@ -688,6 +688,7 @@ func (r *clientResource) Update(
 			if resp.Diagnostics.HasError() {
 				return
 			}
+			r.applyPlanToState(ctx, &plan, &state)
 
 			// Update identity with MAC
 			identityModel := clientIdentityModel{
@@ -733,6 +734,7 @@ func (r *clientResource) Update(
 	if resp.Diagnostics.HasError() {
 		return
 	}
+	r.applyPlanToState(ctx, &plan, &state)
 
 	// Update identity with MAC
 	identityModel := clientIdentityModel{
@@ -746,7 +748,7 @@ func (r *clientResource) Update(
 }
 
 // applyPlanToState merges plan values into state, preserving state values where plan is null/unknown.
-func (r *clientResource) applyPlanToState( //nolint:unused
+func (r *clientResource) applyPlanToState(
 	_ context.Context,
 	plan *clientResourceModel,
 	state *clientResourceModel,

--- a/unifi/client_resource_test.go
+++ b/unifi/client_resource_test.go
@@ -88,6 +88,13 @@ func TestAccClientFramework_basic(t *testing.T) {
 				),
 			},
 			{
+				Config: testAccClientFrameworkConfig_controlFlags(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("unifi_client.test", "allow_existing", "false"),
+					resource.TestCheckResourceAttr("unifi_client.test", "skip_forget_on_destroy", "true"),
+				),
+			},
+			{
 				ResourceName:    "unifi_client.test",
 				ImportState:     true,
 				ImportStateKind: resource.ImportBlockWithResourceIdentity,
@@ -101,6 +108,17 @@ func testAccClientFrameworkConfig_basic() string {
 resource "unifi_client" "test" {
 	name = "tfacc-client"
 	mac  = "01:23:45:67:89:ab"
+}
+`
+}
+
+func testAccClientFrameworkConfig_controlFlags() string {
+	return `
+resource "unifi_client" "test" {
+	name                   = "tfacc-client"
+	mac                    = "01:23:45:67:89:ab"
+	allow_existing         = false
+	skip_forget_on_destroy = true
 }
 `
 }

--- a/unifi/client_resource_test.go
+++ b/unifi/client_resource_test.go
@@ -91,7 +91,11 @@ func TestAccClientFramework_basic(t *testing.T) {
 				Config: testAccClientFrameworkConfig_controlFlags(),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("unifi_client.test", "allow_existing", "false"),
-					resource.TestCheckResourceAttr("unifi_client.test", "skip_forget_on_destroy", "true"),
+					resource.TestCheckResourceAttr(
+						"unifi_client.test",
+						"skip_forget_on_destroy",
+						"true",
+					),
 				),
 			},
 			{


### PR DESCRIPTION
`clientResource.Update` currently leaves Terraform-only fields at their previous state values after an API update. Changing `allow_existing` or `skip_forget_on_destroy` therefore causes an inconsistent-result error even though the UniFi update succeeds.

Use the existing `applyPlanToState` helper in both update paths before saving state. The acceptance test now updates both fields to non-default values.

Tested with `go test ./unifi` and `go vet ./unifi`.