### PR TITLE
fix(client): ignore stale local_dns_record echo when disabled (#387)

### DIFF
--- a/unifi/client_resource.go
+++ b/unifi/client_resource.go
@@ -1106,7 +1106,17 @@ func (r *clientResource) clientToModel(
 	// (false) instead of null; otherwise the schema's Default(false) makes the next
 	// plan propose false → a spurious diff on every create/import.
 	model.Blocked = types.BoolValue(client.Blocked != nil && *client.Blocked)
-	model.LocalDNSRecord = util.StringValueOrNull(client.LocalDNSRecord)
+
+	// #387: when the local DNS record is disabled the controller keeps echoing the
+	// stale record string, so trusting it produces an inconsistent-result-after-apply
+	// against an explicit `local_dns_record = ""` (the documented way to clear it).
+	// Mirror the disabled state as a known empty string instead of the echoed value,
+	// so `""` round-trips cleanly and enabling still surfaces the real record.
+	if client.LocalDNSRecordEnabled {
+		model.LocalDNSRecord = util.StringValueOrNull(client.LocalDNSRecord)
+	} else {
+		model.LocalDNSRecord = types.StringValue("")
+	}
 
 	// Computed attributes
 	model.Hostname = util.StringValueOrNull(client.Hostname)

--- a/unifi/client_resource_test.go
+++ b/unifi/client_resource_test.go
@@ -74,6 +74,48 @@ func TestClientToModel_PreservesBlockedTrue(t *testing.T) {
 	}
 }
 
+// TestClientToModel_LocalDNSRecordDisabledIgnoresEcho guards #387: when the
+// controller reports local_dns_record_enabled=false it still echoes the stale
+// record string. The provider must ignore that echo and mirror a known empty
+// string so an explicit local_dns_record="" round-trips instead of producing an
+// inconsistent-result-after-apply.
+func TestClientToModel_LocalDNSRecordDisabledIgnoresEcho(t *testing.T) {
+	r := &clientResource{}
+	client := &unifi.Client{
+		MAC:                   "02:00:00:de:ad:03",
+		LocalDNSRecord:        "mqtt.home.arpa",
+		LocalDNSRecordEnabled: false,
+	}
+
+	var model clientResourceModel
+	if diags := r.clientToModel(context.Background(), client, &model, "default"); diags.HasError() {
+		t.Fatalf("clientToModel returned errors: %v", diags)
+	}
+	if model.LocalDNSRecord.IsNull() || model.LocalDNSRecord.IsUnknown() ||
+		model.LocalDNSRecord.ValueString() != "" {
+		t.Errorf("local_dns_record: want known empty string, got %#v", model.LocalDNSRecord)
+	}
+}
+
+// TestClientToModel_LocalDNSRecordEnabledKeepsValue is the companion to #387: an
+// enabled record must still surface its real value.
+func TestClientToModel_LocalDNSRecordEnabledKeepsValue(t *testing.T) {
+	r := &clientResource{}
+	client := &unifi.Client{
+		MAC:                   "02:00:00:de:ad:04",
+		LocalDNSRecord:        "nas.home.arpa",
+		LocalDNSRecordEnabled: true,
+	}
+
+	var model clientResourceModel
+	if diags := r.clientToModel(context.Background(), client, &model, "default"); diags.HasError() {
+		t.Fatalf("clientToModel returned errors: %v", diags)
+	}
+	if model.LocalDNSRecord.ValueString() != "nas.home.arpa" {
+		t.Errorf("local_dns_record: want nas.home.arpa, got %q", model.LocalDNSRecord.ValueString())
+	}
+}
+
 func TestAccClientFramework_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { preCheck(t) },


### PR DESCRIPTION
Fixes #387.

## Context
Setting `unifi_client.local_dns_record = ""` (the documented way to clear it) after a non-empty value produced a perpetual `Provider produced inconsistent result after apply` error. Two reported variants: the read surfaced the stale record (`was "", now "mqtt.home.arpa"`) or `null` (`was "", now null`).

The write path already sends `LocalDNSRecordEnabled: localDNSRecord != ""` correctly. The remaining bug is on the read side: when the controller reports `local_dns_record_enabled=false`, it keeps echoing the previously configured record string, and `clientToModel` trusted that echo.

## Changes
- `clientToModel`: when `LocalDNSRecordEnabled` is false, mirror the field as a known empty string instead of the echoed value, so an explicit `""` round-trips cleanly. An enabled record still surfaces its real value.

## Tests
- New unit tests `TestClientToModel_LocalDNSRecordDisabledIgnoresEcho` (disabled + stale echo -> known "") and `TestClientToModel_LocalDNSRecordEnabledKeepsValue` (enabled -> value preserved).
- `go build`, `go test ./unifi/ -run TestClientToModel`, gofumpt/golines clean on the changed region.

## Risks
Low, read-path only. Clients that never set the record now surface `""` instead of `null` in state; `UseStateForUnknown` keeps this diff-free.

https://claude.ai/code/session_01D83uMn2TM7GdYPchVt7EWV