### PR TITLE
fix(wlan): stop perpetual passphrase diff with passphrase_wo (#392)

### DIFF
--- a/unifi/wlan_resource.go
+++ b/unifi/wlan_resource.go
@@ -1002,11 +1002,23 @@ func (r *wlanFrameworkResource) Read(
 		}
 	}
 
+	// #392: passphrase is an Optional (non-computed) secret. When it is managed via
+	// the write-only passphrase_wo attribute (or not managed at all) it is null in
+	// config and state, yet the controller echoes the stored secret on read.
+	// Persisting that echo makes every subsequent plan show
+	// `passphrase = (sensitive) -> null`. Preserve the prior null so the write-only
+	// workflow stays stable; a config-managed passphrase keeps round-tripping normally.
+	priorPassphraseNull := state.Passphrase.IsNull()
+
 	// Convert API response to model
 	diags = r.wlanToModel(ctx, wlan, &state, site)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
+	}
+
+	if priorPassphraseNull {
+		state.Passphrase = types.StringNull()
 	}
 
 	resp.Diagnostics.Append(resp.Identity.SetAttribute(ctx, path.Root("id"), state.ID)...)


### PR DESCRIPTION
Fixes #392.

## Context
When managing WLAN secrets via the write-only `passphrase_wo` (or out-of-band in the UI), every `terraform apply` showed a perpetual no-op diff:
```
~ resource "unifi_wlan" "wifi" {
  - passphrase = (sensitive value) -> null
}
```
`passphrase` is an Optional (non-computed) secret. Create and Update already null it in state when `passphrase_wo` is used, but `Read` repopulated it from the controller echo through `wlanToModel`. On the next plan the config wanted `null` while state held the echoed secret, hence the standing diff.

## Changes
- `Read`: capture whether `passphrase` was null in prior state, and restore null after `wlanToModel` if so. A config-managed `passphrase` (prior state non-null) keeps round-tripping through the echo unchanged.

## Tests
- `go build` clean, gofumpt/golines clean.
- Not covered by an acceptance step: WLAN `create` currently fails in the dockerized acceptance controller with a pre-existing `api.err.InvalidPayload` (documented on the existing WLAN tests, which are import-only), so a create+re-plan regression step is not runnable there; live validation was avoided as it would broadcast a test SSID on a production network. The fix is a read-path guard verified by build and by the reported reproduction.

## Risks
Low, read-path only. Only affects clients where `passphrase` was already null in state (write-only or unmanaged); a config-set passphrase is unchanged.

https://claude.ai/code/session_01D83uMn2TM7GdYPchVt7EWV