### PR TITLE
fix(client): stop duplicate network members groups under parallelism (#389)

### DIFF
--- a/unifi/client_resource.go
+++ b/unifi/client_resource.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"slices"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-nettypes/hwtypes"
@@ -63,10 +62,6 @@ func NewClientListResource() list.ListResource {
 // clientResource defines the resource implementation.
 type clientResource struct {
 	client *Client
-
-	// Cache group name → ID lookups per site to avoid repeated API calls during List.
-	groupCacheMu sync.Mutex
-	groupCache   map[string]map[string]string // site → (name → id)
 }
 
 // qosRateModel describes the nested qos_rate attribute.
@@ -1195,15 +1190,15 @@ func (r *clientResource) resolveGroupNames(
 	site string,
 	ids []string,
 ) ([]string, error) {
-	r.groupCacheMu.Lock()
-	defer r.groupCacheMu.Unlock()
+	r.client.groupCacheMu.Lock()
+	defer r.client.groupCacheMu.Unlock()
 
-	if r.groupCache == nil {
-		r.groupCache = make(map[string]map[string]string)
+	if r.client.groupCache == nil {
+		r.client.groupCache = make(map[string]map[string]string)
 	}
 
 	// Ensure cache is populated for this site.
-	if _, ok := r.groupCache[site]; !ok {
+	if _, ok := r.client.groupCache[site]; !ok {
 		groups, err := r.client.ListNetworkMembersGroups(ctx, site)
 		if err != nil {
 			return nil, fmt.Errorf("listing network members groups: %w", err)
@@ -1212,11 +1207,11 @@ func (r *clientResource) resolveGroupNames(
 		for _, g := range groups {
 			siteCache[g.Name] = g.ID
 		}
-		r.groupCache[site] = siteCache
+		r.client.groupCache[site] = siteCache
 	}
 
 	// Build reverse map id → name from cache.
-	siteCache := r.groupCache[site]
+	siteCache := r.client.groupCache[site]
 	idToName := make(map[string]string, len(siteCache))
 	for name, id := range siteCache {
 		idToName[id] = name
@@ -1239,14 +1234,14 @@ func (r *clientResource) resolveGroupID(
 	ctx context.Context,
 	site, groupName string,
 ) (string, error) {
-	r.groupCacheMu.Lock()
-	defer r.groupCacheMu.Unlock()
+	r.client.groupCacheMu.Lock()
+	defer r.client.groupCacheMu.Unlock()
 
-	if r.groupCache == nil {
-		r.groupCache = make(map[string]map[string]string)
+	if r.client.groupCache == nil {
+		r.client.groupCache = make(map[string]map[string]string)
 	}
 
-	if siteCache, ok := r.groupCache[site]; ok {
+	if siteCache, ok := r.client.groupCache[site]; ok {
 		if id, ok := siteCache[groupName]; ok {
 			return id, nil
 		}
@@ -1262,7 +1257,7 @@ func (r *clientResource) resolveGroupID(
 	for _, g := range groups {
 		siteCache[g.Name] = g.ID
 	}
-	r.groupCache[site] = siteCache
+	r.client.groupCache[site] = siteCache
 
 	id, ok := siteCache[groupName]
 	if ok {

--- a/unifi/provider.go
+++ b/unifi/provider.go
@@ -3,6 +3,7 @@ package unifi
 import (
 	"context"
 	"os"
+	"sync"
 
 	"github.com/hashicorp/terraform-plugin-framework/action"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
@@ -41,6 +42,14 @@ type unifiProviderModel struct {
 type Client struct {
 	*ui.ApiClient
 	Site string
+
+	// groupCache memoizes network members group name<->ID lookups per site. It lives
+	// on the shared *Client (one per provider configuration) rather than on the
+	// resource because the framework builds a fresh clientResource per RPC: keeping it
+	// here serializes concurrent group resolution across parallel unifi_client creates
+	// so they stop each creating a duplicate group with the same name (#389).
+	groupCacheMu sync.Mutex
+	groupCache   map[string]map[string]string // site -> (name -> id)
 }
 
 // GetSiteName returns the site name for this client.


### PR DESCRIPTION
Fixes #389 (the duplicate-group / "group ID not found" bug; the dedicated `NetworkMembersGroups` resource the issue also asks for is tracked separately).

## Context
Provisioning many `unifi_client` resources that share a group name (e.g. `groups = ["homelab"]` across a `for_each`) produced one duplicate group per client (same name, different IDs) and then `network members group with ID "..." not found` on refresh. A single client worked fine.

Root cause: `resolveGroupID`/`resolveGroupNames` cached group name<->ID lookups on the `clientResource`, but the framework builds a fresh `clientResource` per RPC. Under Terraforms default parallelism each concurrent create saw an empty cache, listed groups, found the shared name absent, and created its own group.

## Changes
- Move the group cache and its mutex from the per-RPC `clientResource` onto the shared `*Client` (one per provider configuration, handed to every resource via `Configure`). The lock now serializes group get-or-create across parallel client creates, so a shared name resolves to exactly one group.
- Multi-controller setups (`provider = unifi.foo` / `unifi.bar`) stay isolated: each alias has its own `*Client` and therefore its own cache.

## Tests
- `go build`, `go vet` (no copylocks on the new mutex), existing client unit tests, gofumpt/golines clean on the changed regions.
- Not covered by a new acceptance step: the bug only manifests under concurrent creates, and asserting "exactly one group exists" needs a controller-side count; the existing `TestAccClientFramework_groups` still exercises the resolve/create/read path. Validated here by build/vet and the frameworks per-RPC instance lifecycle.

## Risks
Low. Group resolution is now serialized per controller (fast, infrequent); no behavior change for single-client or single-group configs.

https://claude.ai/code/session_01D83uMn2TM7GdYPchVt7EWV