### PR TITLE
fix(client): allow clearing fixed_ip with an empty string (#386)

### DIFF
--- a/docs/resources/client.md
+++ b/docs/resources/client.md
@@ -50,7 +50,7 @@ resource "unifi_client" "test" {
 - `blocked` (Boolean) Specifies whether this client should be blocked from the network.
 - `display_name` (String) The display name of the client.
 - `fixed_ap_mac` (String) The MAC address of the access point to which this client should be fixed.
-- `fixed_ip` (String) A fixed IPv4 address for this client.
+- `fixed_ip` (String) A fixed IPv4 address for this client. Set to an empty string to clear a previously assigned fixed IP.
 - `groups` (List of String) List of network members group names for this client.
 - `local_dns_record` (String) Specifies the local DNS record for this client.
 - `name` (String) The name of the client.

--- a/unifi/client_resource.go
+++ b/unifi/client_resource.go
@@ -9,8 +9,8 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-nettypes/hwtypes"
-	"github.com/hashicorp/terraform-plugin-framework-nettypes/iptypes"
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/list"
@@ -25,11 +25,13 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/ubiquiti-community/go-unifi/unifi"
 	"github.com/ubiquiti-community/terraform-provider-unifi/unifi/util"
+	"github.com/ubiquiti-community/terraform-provider-unifi/unifi/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.
@@ -83,19 +85,19 @@ func (m qosRateModel) AttributeTypes() map[string]attr.Type {
 
 // clientResourceModel describes the resource data model.
 type clientResourceModel struct {
-	ID             types.String        `tfsdk:"id"`
-	Site           types.String        `tfsdk:"site"`
-	MAC            hwtypes.MACAddress  `tfsdk:"mac"`
-	Name           types.String        `tfsdk:"name"`
-	DisplayName    types.String        `tfsdk:"display_name"`
-	QOSRate        types.Object        `tfsdk:"qos_rate"`
-	Note           types.String        `tfsdk:"note"`
-	FixedIP        iptypes.IPv4Address `tfsdk:"fixed_ip"`
-	FixedApMAC     hwtypes.MACAddress  `tfsdk:"fixed_ap_mac"`
-	NetworkID      types.String        `tfsdk:"network_id"`
-	Groups         types.List          `tfsdk:"groups"`
-	Blocked        types.Bool          `tfsdk:"blocked"`
-	LocalDNSRecord types.String        `tfsdk:"local_dns_record"`
+	ID             types.String       `tfsdk:"id"`
+	Site           types.String       `tfsdk:"site"`
+	MAC            hwtypes.MACAddress `tfsdk:"mac"`
+	Name           types.String       `tfsdk:"name"`
+	DisplayName    types.String       `tfsdk:"display_name"`
+	QOSRate        types.Object       `tfsdk:"qos_rate"`
+	Note           types.String       `tfsdk:"note"`
+	FixedIP        types.String       `tfsdk:"fixed_ip"`
+	FixedApMAC     hwtypes.MACAddress `tfsdk:"fixed_ap_mac"`
+	NetworkID      types.String       `tfsdk:"network_id"`
+	Groups         types.List         `tfsdk:"groups"`
+	Blocked        types.Bool         `tfsdk:"blocked"`
+	LocalDNSRecord types.String       `tfsdk:"local_dns_record"`
 
 	// These control import and create behavior to allow the resource to take over existing clients instead of erroring, and to allow it to just be removed from Terraform management without deleting in UniFi.
 	AllowExisting       types.Bool `tfsdk:"allow_existing"`
@@ -239,10 +241,20 @@ Clients are created in the controller when observed on the network, so the resou
 				},
 			},
 			"fixed_ip": schema.StringAttribute{
-				MarkdownDescription: "A fixed IPv4 address for this client.",
-				CustomType:          iptypes.IPv4AddressType{},
-				Optional:            true,
-				Computed:            true,
+				MarkdownDescription: "A fixed IPv4 address for this client. " +
+					"Set to an empty string to clear a previously assigned fixed IP.",
+				Optional: true,
+				Computed: true,
+				// #386: keep validating the IPv4 format but also accept an empty
+				// string, which is the documented way to clear the fixed IP. A typed
+				// IPv4 custom type rejects "" outright, so a plain string with an
+				// empty-or-IPv4 validator is used instead.
+				Validators: []validator.String{
+					stringvalidator.Any(
+						stringvalidator.OneOf(""),
+						validators.IPv4Validator(),
+					),
+				},
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
 				},
@@ -1051,7 +1063,15 @@ func (r *clientResource) clientToModel(
 	model.Name = util.StringValueOrNull(client.Name)
 	model.DisplayName = util.StringValueOrNull(client.DisplayName)
 	model.Note = util.StringValueOrNull(client.Note)
-	model.FixedIP = util.IPv4ValueOrNull(client.FixedIP)
+	// #386: when the fixed IP is disabled the controller keeps echoing the stale
+	// address. Mirror it as a known empty string so an explicit fixed_ip = "" (the
+	// documented way to clear it) round-trips, instead of resending the old IP with
+	// use_fixedip=true (which the controller rejects with api.err.DuplicateFixedIP).
+	if client.UseFixedIP {
+		model.FixedIP = util.StringValueOrNull(client.FixedIP)
+	} else {
+		model.FixedIP = types.StringValue("")
+	}
 	model.FixedApMAC = util.MACValueOrNull(client.FixedApMAC)
 	model.NetworkID = util.StringValueOrNull(client.VirtualNetworkOverrideID)
 

--- a/unifi/client_resource_test.go
+++ b/unifi/client_resource_test.go
@@ -116,6 +116,47 @@ func TestClientToModel_LocalDNSRecordEnabledKeepsValue(t *testing.T) {
 	}
 }
 
+// TestClientToModel_FixedIPDisabledIgnoresEcho guards #386: when the controller
+// reports use_fixedip=false it still echoes the stale address. The provider must
+// ignore that echo and mirror a known empty string so an explicit fixed_ip=""
+// round-trips instead of resending the old IP (api.err.DuplicateFixedIP).
+func TestClientToModel_FixedIPDisabledIgnoresEcho(t *testing.T) {
+	r := &clientResource{}
+	client := &unifi.Client{
+		MAC:        "02:00:00:de:ad:05",
+		FixedIP:    "10.26.20.56",
+		UseFixedIP: false,
+	}
+
+	var model clientResourceModel
+	if diags := r.clientToModel(context.Background(), client, &model, "default"); diags.HasError() {
+		t.Fatalf("clientToModel returned errors: %v", diags)
+	}
+	if model.FixedIP.IsNull() || model.FixedIP.IsUnknown() ||
+		model.FixedIP.ValueString() != "" {
+		t.Errorf("fixed_ip: want known empty string, got %#v", model.FixedIP)
+	}
+}
+
+// TestClientToModel_FixedIPEnabledKeepsValue is the companion to #386: an
+// enabled fixed IP must still surface its real value.
+func TestClientToModel_FixedIPEnabledKeepsValue(t *testing.T) {
+	r := &clientResource{}
+	client := &unifi.Client{
+		MAC:        "02:00:00:de:ad:06",
+		FixedIP:    "10.26.20.56",
+		UseFixedIP: true,
+	}
+
+	var model clientResourceModel
+	if diags := r.clientToModel(context.Background(), client, &model, "default"); diags.HasError() {
+		t.Fatalf("clientToModel returned errors: %v", diags)
+	}
+	if model.FixedIP.ValueString() != "10.26.20.56" {
+		t.Errorf("fixed_ip: want 10.26.20.56, got %q", model.FixedIP.ValueString())
+	}
+}
+
 func TestAccClientFramework_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { preCheck(t) },


### PR DESCRIPTION
Fixes #386.

## Context
Removing a `unifi_client.fixed_ip` was impossible. Setting `fixed_ip = ""` failed validation (the typed IPv4 custom type rejects `""`), and removing/blanking it re-sent the old address with `use_fixedip=true`, giving `api.err.DuplicateFixedIP (400)`.

## Changes
- `fixed_ip` switches from the `iptypes.IPv4Address` custom type to a plain string validated as **empty-or-IPv4** (`stringvalidator.Any(OneOf(""), IPv4Validator())`), so the format is still checked but `""` is accepted as the documented way to clear the fixed IP.
- Read now mirrors a disabled fixed IP (`use_fixedip=false`) as a known empty string instead of the stale echoed address, so `fixed_ip = ""` round-trips cleanly (same approach as #387 for `local_dns_record`).
- Regenerated `docs/resources/client.md` for the updated description.

The underlying state type is unchanged (both serialize as `tftypes.String`), so no state migration / schema version bump is needed; existing `fixed_ip` values keep working.

## Tests
- New unit tests `TestClientToModel_FixedIPDisabledIgnoresEcho` and `TestClientToModel_FixedIPEnabledKeepsValue`.
- `go build`, `go vet`, `go test ./unifi/ -run TestClientToModel`, gofumpt/golines clean on the changed regions.

## Risks
Low. Format validation is preserved via the validator; the only new accepted value is `""` (clear). No state migration.

https://claude.ai/code/session_01D83uMn2TM7GdYPchVt7EWV