### PR TITLE
feat(firewall_zone): import zones by name (#396)

### DIFF
--- a/docs/resources/firewall_zone.md
+++ b/docs/resources/firewall_zone.md
@@ -95,4 +95,8 @@ The [` + "`" + `terraform import` + "`" + ` command](https://developer.hashicorp
 ```shell
 # Firewall zones can be imported using the zone ID, or site:id for a non-default site.
 terraform import unifi_firewall_zone.dmz 5f3e9b2c4ee8cb0f1f4a1234
+
+# Built-in zones (e.g. Hotspot, Internal) can also be imported by name, which
+# resolves the controller-assigned ID for you. Prefix with "site:" for a non-default site.
+terraform import unifi_firewall_zone.hotspot name=Hotspot
 ```

--- a/examples/resources/unifi_firewall_zone/import.sh
+++ b/examples/resources/unifi_firewall_zone/import.sh
@@ -1,2 +1,6 @@
 # Firewall zones can be imported using the zone ID, or site:id for a non-default site.
 terraform import unifi_firewall_zone.dmz 5f3e9b2c4ee8cb0f1f4a1234
+
+# Built-in zones (e.g. Hotspot, Internal) can also be imported by name, which
+# resolves the controller-assigned ID for you. Prefix with "site:" for a non-default site.
+terraform import unifi_firewall_zone.hotspot name=Hotspot

--- a/unifi/firewall_zone_resource.go
+++ b/unifi/firewall_zone_resource.go
@@ -336,20 +336,63 @@ func (r *firewallZoneResource) ImportState(
 	req resource.ImportStateRequest,
 	resp *resource.ImportStateResponse,
 ) {
-	// Import format: "site:id" or just "id" for the default site.
-	idParts := strings.Split(req.ID, ":")
-	switch len(idParts) {
-	case 2:
-		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("site"), idParts[0])...)
-		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), idParts[1])...)
-	case 1:
-		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), req.ID)...)
-	default:
-		resp.Diagnostics.AddError(
-			"Invalid Import ID",
-			"Import ID must be in format 'site:id' or 'id'",
-		)
+	// Import formats:
+	//   "id"            - zone id on the default site
+	//   "site:id"       - zone id on an explicit site
+	//   "name=<name>"   - resolve the zone id by name on the default site
+	//   "site:name=<name>" - resolve by name on an explicit site
+	// The name forms let the built-in zones (e.g. "Hotspot") be imported without
+	// first looking up their controller-assigned id (#396).
+	id := req.ID
+	var site string
+	if parts := strings.SplitN(req.ID, ":", 2); len(parts) == 2 {
+		site, id = parts[0], parts[1]
 	}
+
+	if name, ok := strings.CutPrefix(id, "name="); ok {
+		lookupSite := site
+		if lookupSite == "" {
+			lookupSite = r.client.Site
+		}
+		zones, err := r.client.ListFirewallZone(ctx, lookupSite)
+		if err != nil {
+			resp.Diagnostics.AddError(
+				"Error Importing Firewall Zone",
+				fmt.Sprintf("Could not list firewall zones on site %q: %s", lookupSite, err),
+			)
+			return
+		}
+		var matches []string
+		for _, z := range zones {
+			if z.Name == name {
+				matches = append(matches, z.ID)
+			}
+		}
+		switch len(matches) {
+		case 0:
+			resp.Diagnostics.AddError(
+				"Firewall Zone Not Found",
+				fmt.Sprintf("No firewall zone named %q on site %q.", name, lookupSite),
+			)
+			return
+		case 1:
+			id, site = matches[0], lookupSite
+		default:
+			resp.Diagnostics.AddError(
+				"Ambiguous Firewall Zone Name",
+				fmt.Sprintf(
+					"Multiple firewall zones named %q on site %q; import by id instead.",
+					name, lookupSite,
+				),
+			)
+			return
+		}
+	}
+
+	if site != "" {
+		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("site"), site)...)
+	}
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), id)...)
 }
 
 // modelToFirewallZone converts the Terraform model to the API struct.


### PR DESCRIPTION
Addresses the import half of #396.

## Context
The built-in firewall zones (Hotspot, Internal, ...) have controller-assigned IDs users do not know up front, so importing them (e.g. to reference the Hotspot zone for a guest network) was awkward. `terraform import ... name=Hotspot` previously failed with a generic error.

## Changes
- `firewall_zone` `ImportState` now accepts:
  - `id` and `site:id` (unchanged),
  - `name=<zone name>` - resolves the ID via `ListFirewallZone` on the default site,
  - `site:name=<zone name>` - same on an explicit site.
- Unknown or ambiguous names return a clear diagnostic instead of a generic failure.
- Updated the import example and generated doc.

## Tests
- `go build`, gofumpt/golines clean.
- No unit test: `ImportState` name resolution calls the controller API and zone-based firewall is not available in the dockerized acceptance controller. Validated **read-only against a live UDM**: `name=Hotspot` resolved to its ID and imported successfully; `name=DoesNotExist` returned `Firewall Zone Not Found`.

## Note
This does not address the other half of #396 (a `unifi_network` with `purpose=guest` reverting to `corporate`), which is tracked in #276 / #353 and stems from a go-unifi network marshaler limitation. The existing `unifi_firewall_zone` data source already lets you reference a zone by name without importing it.

https://claude.ai/code/session_01D83uMn2TM7GdYPchVt7EWV