### PR TITLE
fix(device): model port_override networkconf_ids as sets (#384)

### DIFF
--- a/docs/resources/device.md
+++ b/docs/resources/device.md
@@ -153,7 +153,7 @@ Optional:
 - `dot1x_idle_timeout` (String) 802.1X idle timeout, as a Go duration string (e.g. `5m`, `300s`).
 - `egress_rate_limit_kbps` (Number) Egress rate limit in kbps.
 - `egress_rate_limit_kbps_enabled` (Boolean) Enable egress rate limiting.
-- `excluded_networkconf_ids` (List of String) List of network IDs to exclude from this port.
+- `excluded_networkconf_ids` (Set of String) List of network IDs to exclude from this port.
 - `fec_mode` (String) Forward Error Correction mode.
 - `flow_control_enabled` (Boolean) Enable flow control.
 - `forward` (String) Forwarding mode.
@@ -162,7 +162,7 @@ Optional:
 - `lldpmed_enabled` (Boolean) Enable LLDP-MED.
 - `lldpmed_notify_enabled` (Boolean) Enable LLDP-MED notifications.
 - `mirror_port_idx` (Number) Mirror port index.
-- `multicast_router_networkconf_ids` (List of String) List of network IDs for multicast router.
+- `multicast_router_networkconf_ids` (Set of String) List of network IDs for multicast router.
 - `name` (String) Human-readable name of the port.
 - `native_networkconf_id` (String) Native network ID (VLAN).
 - `op_mode` (String) Operating mode of the port: `switch` (default), `mirror`, or `aggregate`. Set `aggregate` on the lead port of an SFP+/link-aggregation (LAG) group and list the member ports in `aggregate_members`. Only written when not `switch`, as gateway devices (UDM) reject op_mode on update.
@@ -188,7 +188,7 @@ Optional:
 - `stormctrl_ucast_level` (Number) Unicast storm control level.
 - `stormctrl_ucast_rate` (Number) Unicast storm control rate.
 - `stp_port_mode` (Boolean) STP port mode.
-- `tagged_networkconf_ids` (List of String) List of network IDs to tag on this port.
+- `tagged_networkconf_ids` (Set of String) List of network IDs to tag on this port.
 - `tagged_vlan_mgmt` (String) Tagged VLAN management.
 - `voice_networkconf_id` (String) Voice network ID.
 

--- a/unifi/client_resource_test.go
+++ b/unifi/client_resource_test.go
@@ -957,6 +957,8 @@ func nullPortOverrideAttrValues() map[string]attr.Value {
 			vals[name] = types.BoolNull()
 		case basetypes.ListType:
 			vals[name] = types.ListNull(tt.ElemType)
+		case basetypes.SetType:
+			vals[name] = types.SetNull(tt.ElemType)
 		case timetypes.GoDurationType:
 			vals[name] = timetypes.NewGoDurationNull()
 		}
@@ -1051,10 +1053,10 @@ func TestFrameworkToPortOverrides_SwitchOpModeOmitted(t *testing.T) {
 
 // TestPortOverridesToFramework_TaggedNetworkIDsTypedNull is a regression test
 // for #235. portOverridesToFramework must initialize the tagged_networkconf_ids
-// model field to a typed null list. Previously it was left as an untyped
-// zero-value types.List, which made types.ObjectValueFrom fail with a
-// "types.ListType[!!! MISSING TYPE !!!]" Value Conversion Error during the
-// Read/refresh (and import) of any unifi_device that has port overrides.
+// model field to a typed null set. Previously it was left as an untyped
+// zero-value collection, which made types.ObjectValueFrom fail with a
+// "!!! MISSING TYPE !!!" Value Conversion Error during the Read/refresh (and
+// import) of any unifi_device that has port overrides. (#384 made this a Set.)
 func TestPortOverridesToFramework_TaggedNetworkIDsTypedNull(t *testing.T) {
 	r := &deviceResource{}
 
@@ -1087,14 +1089,14 @@ func TestPortOverridesToFramework_TaggedNetworkIDsTypedNull(t *testing.T) {
 		t.Fatal("port_override is missing the tagged_networkconf_ids attribute")
 	}
 
-	list, ok := taggedAttr.(types.List)
+	taggedSet, ok := taggedAttr.(types.Set)
 	if !ok {
-		t.Fatalf("expected tagged_networkconf_ids to be types.List, got %T", taggedAttr)
+		t.Fatalf("expected tagged_networkconf_ids to be types.Set, got %T", taggedAttr)
 	}
-	if !list.IsNull() {
-		t.Errorf("expected tagged_networkconf_ids to be a null list, got %v", list)
+	if !taggedSet.IsNull() {
+		t.Errorf("expected tagged_networkconf_ids to be a null set, got %v", taggedSet)
 	}
-	if et := list.ElementType(context.Background()); !et.Equal(types.StringType) {
+	if et := taggedSet.ElementType(context.Background()); !et.Equal(types.StringType) {
 		t.Errorf("expected tagged_networkconf_ids element type to be string, got %v", et)
 	}
 }

--- a/unifi/device_resource.go
+++ b/unifi/device_resource.go
@@ -159,7 +159,7 @@ type portOverrideModel struct {
 	Dot1XIDleTimeout           timetypes.GoDuration `tfsdk:"dot1x_idle_timeout"`
 	EgressRateLimitKbps        types.Int64          `tfsdk:"egress_rate_limit_kbps"`
 	EgressRateLimitKbpsEnabled types.Bool           `tfsdk:"egress_rate_limit_kbps_enabled"`
-	ExcludedNetworkIDs         types.List           `tfsdk:"excluded_networkconf_ids"`
+	ExcludedNetworkIDs         types.Set            `tfsdk:"excluded_networkconf_ids"`
 	FecMode                    types.String         `tfsdk:"fec_mode"`
 	FlowControlEnabled         types.Bool           `tfsdk:"flow_control_enabled"`
 	Forward                    types.String         `tfsdk:"forward"`
@@ -168,7 +168,7 @@ type portOverrideModel struct {
 	LldpmedEnabled             types.Bool           `tfsdk:"lldpmed_enabled"`
 	LldpmedNotifyEnabled       types.Bool           `tfsdk:"lldpmed_notify_enabled"`
 	MirrorPortIDX              types.Int64          `tfsdk:"mirror_port_idx"`
-	MulticastRouterNetworkIDs  types.List           `tfsdk:"multicast_router_networkconf_ids"`
+	MulticastRouterNetworkIDs  types.Set            `tfsdk:"multicast_router_networkconf_ids"`
 	NativeNetworkID            types.String         `tfsdk:"native_networkconf_id"`
 	PortKeepaliveEnabled       types.Bool           `tfsdk:"port_keepalive_enabled"`
 	PortSecurityEnabled        types.Bool           `tfsdk:"port_security_enabled"`
@@ -190,7 +190,7 @@ type portOverrideModel struct {
 	StormctrlUcastLevel        types.Int64          `tfsdk:"stormctrl_ucast_level"`
 	StormctrlUcastRate         types.Int64          `tfsdk:"stormctrl_ucast_rate"`
 	StpPortMode                types.Bool           `tfsdk:"stp_port_mode"`
-	TaggedNetworkIDs           types.List           `tfsdk:"tagged_networkconf_ids"`
+	TaggedNetworkIDs           types.Set            `tfsdk:"tagged_networkconf_ids"`
 	TaggedVLANMgmt             types.String         `tfsdk:"tagged_vlan_mgmt"`
 	VoiceNetworkID             types.String         `tfsdk:"voice_networkconf_id"`
 }
@@ -272,8 +272,10 @@ func (r *deviceResource) Schema(
 ) {
 	resp.Schema = schema.Schema{
 		// v1: lcm_idle_timeout and port_override.dot1x_idle_timeout changed from
-		// Int64 (seconds) to GoDuration strings. See UpgradeState.
-		Version: 1,
+		//     Int64 (seconds) to GoDuration strings.
+		// v2: port_override.{excluded,multicast_router,tagged}_networkconf_ids changed
+		//     from List to Set (#384). See UpgradeState.
+		Version: 2,
 		Description: "`unifi_device` manages a device of the network.\n\n" +
 			"Devices are adopted by the controller, so it is not possible for this resource to be created through " +
 			"Terraform, the create operation instead will simply start managing the device specified by MAC address. " +
@@ -809,7 +811,7 @@ func (r *deviceResource) Schema(
 							Optional:    true,
 							Computed:    true,
 						},
-						"excluded_networkconf_ids": schema.ListAttribute{
+						"excluded_networkconf_ids": schema.SetAttribute{
 							Description: "List of network IDs to exclude from this port.",
 							Optional:    true,
 							ElementType: types.StringType,
@@ -851,7 +853,7 @@ func (r *deviceResource) Schema(
 							Description: "Mirror port index.",
 							Optional:    true,
 						},
-						"multicast_router_networkconf_ids": schema.ListAttribute{
+						"multicast_router_networkconf_ids": schema.SetAttribute{
 							Description: "List of network IDs for multicast router.",
 							Optional:    true,
 							ElementType: types.StringType,
@@ -947,7 +949,7 @@ func (r *deviceResource) Schema(
 							Optional:    true,
 							Computed:    true,
 						},
-						"tagged_networkconf_ids": schema.ListAttribute{
+						"tagged_networkconf_ids": schema.SetAttribute{
 							Description: "List of network IDs to tag on this port.",
 							Optional:    true,
 							ElementType: types.StringType,
@@ -967,9 +969,17 @@ func (r *deviceResource) Schema(
 	}
 }
 
-// UpgradeState migrates v0 state to v1: lcm_idle_timeout and each
-// port_override.dot1x_idle_timeout changed from integer seconds to GoDuration
-// strings.
+// UpgradeState migrates prior device state to the current schema version.
+//
+//	v0 -> current: lcm_idle_timeout and each port_override.dot1x_idle_timeout
+//	    changed from integer seconds to GoDuration strings.
+//	v1 -> current: port_override.{excluded,multicast_router,tagged}_networkconf_ids
+//	    changed from List to Set (#384). No JSON rewrite is needed - a JSON array
+//	    decodes into either collection - so the raw state is simply reconciled
+//	    against the current (Set) schema type.
+//
+// Each upgrader targets the CURRENT schema type, so v0 state also picks up the
+// List->Set change via reconciliation.
 func (r *deviceResource) UpgradeState(
 	ctx context.Context,
 ) map[int64]resource.StateUpgrader {
@@ -1000,6 +1010,29 @@ func (r *deviceResource) UpgradeState(
 							}
 						}
 					},
+				)
+				if err != nil {
+					resp.Diagnostics.AddError("Failed to upgrade device state", err.Error())
+					return
+				}
+				resp.DynamicValue = dv
+			},
+		},
+		1: {
+			StateUpgrader: func(
+				ctx context.Context,
+				req resource.UpgradeStateRequest,
+				resp *resource.UpgradeStateResponse,
+			) {
+				if req.RawState == nil {
+					return
+				}
+				// v1 already stores durations as strings; only the List->Set change
+				// applies, which reconcileType handles against the current schema type.
+				dv, err := util.UpgradeDurationRawState(
+					schemaType,
+					req.RawState.JSON,
+					func(map[string]any) {},
 				)
 				if err != nil {
 					resp.Diagnostics.AddError("Failed to upgrade device state", err.Error())
@@ -2228,13 +2261,13 @@ func (r *deviceResource) reconcilePortOverrides(
 				for i, id := range sorted {
 					vals[i] = types.StringValue(id)
 				}
-				listVal, listDiags := types.ListValue(types.StringType, vals)
-				diags.Append(listDiags...)
-				updated.ExcludedNetworkIDs = listVal
+				setVal, setDiags := types.SetValue(types.StringType, vals)
+				diags.Append(setDiags...)
+				updated.ExcludedNetworkIDs = setVal
 			} else {
-				emptyList, listDiags := types.ListValue(types.StringType, []attr.Value{})
-				diags.Append(listDiags...)
-				updated.ExcludedNetworkIDs = emptyList
+				emptySet, setDiags := types.SetValue(types.StringType, []attr.Value{})
+				diags.Append(setDiags...)
+				updated.ExcludedNetworkIDs = emptySet
 			}
 		}
 		if !pm.PortProfileID.IsNull() {
@@ -2414,7 +2447,7 @@ func (r *deviceResource) portOverridesToFramework(
 		}
 
 		if len(po.ExcludedNetworkIDs) == 0 {
-			model.ExcludedNetworkIDs = types.ListNull(types.StringType)
+			model.ExcludedNetworkIDs = types.SetNull(types.StringType)
 		} else {
 			sortedExcluded := make([]string, len(po.ExcludedNetworkIDs))
 			copy(sortedExcluded, po.ExcludedNetworkIDs)
@@ -2423,34 +2456,34 @@ func (r *deviceResource) portOverridesToFramework(
 			for _, id := range sortedExcluded {
 				excludedValues = append(excludedValues, types.StringValue(id))
 			}
-			listVal, listDiags := types.ListValue(types.StringType, excludedValues)
-			diags.Append(listDiags...)
+			setVal, setDiags := types.SetValue(types.StringType, excludedValues)
+			diags.Append(setDiags...)
 			if diags.HasError() {
 				continue
 			}
-			model.ExcludedNetworkIDs = listVal
+			model.ExcludedNetworkIDs = setVal
 		}
 
 		// FIX (#235): the pinned go-unifi SDK has no TaggedNetworkIDs field, so
 		// nothing populates it below. Without this assignment the model field
-		// stays an untyped zero-value types.List, which makes ObjectValueFrom
-		// emit a "types.ListType[!!! MISSING TYPE !!!]" Value Conversion Error
-		// against the schema's ListAttribute{ElementType: types.StringType}.
-		model.TaggedNetworkIDs = types.ListNull(types.StringType)
+		// stays an untyped zero-value types.Set, which makes ObjectValueFrom
+		// emit a "types.SetType[!!! MISSING TYPE !!!]" Value Conversion Error
+		// against the schema's SetAttribute{ElementType: types.StringType}.
+		model.TaggedNetworkIDs = types.SetNull(types.StringType)
 
 		if len(po.MulticastRouterNetworkIDs) == 0 {
-			model.MulticastRouterNetworkIDs = types.ListNull(types.StringType)
+			model.MulticastRouterNetworkIDs = types.SetNull(types.StringType)
 		} else {
 			multicastValues := make([]attr.Value, 0, len(po.MulticastRouterNetworkIDs))
 			for _, id := range po.MulticastRouterNetworkIDs {
 				multicastValues = append(multicastValues, types.StringValue(id))
 			}
-			listVal, listDiags := types.ListValue(types.StringType, multicastValues)
-			diags.Append(listDiags...)
+			setVal, setDiags := types.SetValue(types.StringType, multicastValues)
+			diags.Append(setDiags...)
 			if diags.HasError() {
 				continue
 			}
-			model.MulticastRouterNetworkIDs = listVal
+			model.MulticastRouterNetworkIDs = setVal
 		}
 
 		if len(po.PortSecurityMACAddress) == 0 {
@@ -2751,7 +2784,7 @@ func portOverrideAttrTypes() map[string]attr.Type {
 		"dot1x_idle_timeout":               timetypes.GoDurationType{},
 		"egress_rate_limit_kbps":           types.Int64Type,
 		"egress_rate_limit_kbps_enabled":   types.BoolType,
-		"excluded_networkconf_ids":         types.ListType{ElemType: types.StringType},
+		"excluded_networkconf_ids":         types.SetType{ElemType: types.StringType},
 		"fec_mode":                         types.StringType,
 		"flow_control_enabled":             types.BoolType,
 		"forward":                          types.StringType,
@@ -2760,7 +2793,7 @@ func portOverrideAttrTypes() map[string]attr.Type {
 		"lldpmed_enabled":                  types.BoolType,
 		"lldpmed_notify_enabled":           types.BoolType,
 		"mirror_port_idx":                  types.Int64Type,
-		"multicast_router_networkconf_ids": types.ListType{ElemType: types.StringType},
+		"multicast_router_networkconf_ids": types.SetType{ElemType: types.StringType},
 		"native_networkconf_id":            types.StringType,
 		"port_keepalive_enabled":           types.BoolType,
 		"port_security_enabled":            types.BoolType,
@@ -2782,7 +2815,7 @@ func portOverrideAttrTypes() map[string]attr.Type {
 		"stormctrl_ucast_level":            types.Int64Type,
 		"stormctrl_ucast_rate":             types.Int64Type,
 		"stp_port_mode":                    types.BoolType,
-		"tagged_networkconf_ids":           types.ListType{ElemType: types.StringType},
+		"tagged_networkconf_ids":           types.SetType{ElemType: types.StringType},
 		"tagged_vlan_mgmt":                 types.StringType,
 		"voice_networkconf_id":             types.StringType,
 	}

--- a/unifi/device_resource_test.go
+++ b/unifi/device_resource_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	fwlist "github.com/hashicorp/terraform-plugin-framework/list"
 	fwresource "github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/ubiquiti-community/go-unifi/unifi"
@@ -498,6 +499,48 @@ func Test_deviceResource_UpgradeState(t *testing.T) {
 				t.Errorf("deviceResource.UpgradeState() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+// TestDeviceNetworkconfIDsAreSets guards #384: the port_override networkconf_ids
+// attributes are order-insensitive Sets, and a v1->v2 state upgrader exists so
+// existing List state migrates instead of erroring on refresh.
+func TestDeviceNetworkconfIDsAreSets(t *testing.T) {
+	ctx := context.Background()
+	r := &deviceResource{}
+
+	var schemaResp fwresource.SchemaResponse
+	r.Schema(ctx, fwresource.SchemaRequest{}, &schemaResp)
+
+	if schemaResp.Schema.Version != 2 {
+		t.Errorf("device schema Version = %d, want 2", schemaResp.Schema.Version)
+	}
+
+	block, ok := schemaResp.Schema.Blocks["port_override"].(schema.SetNestedBlock)
+	if !ok {
+		t.Fatalf(
+			"port_override is not a SetNestedBlock: %T",
+			schemaResp.Schema.Blocks["port_override"],
+		)
+	}
+	for _, name := range []string{
+		"excluded_networkconf_ids",
+		"multicast_router_networkconf_ids",
+		"tagged_networkconf_ids",
+	} {
+		if _, ok := block.NestedObject.Attributes[name].(schema.SetAttribute); !ok {
+			t.Errorf(
+				"port_override.%s must be a SetAttribute, got %T",
+				name, block.NestedObject.Attributes[name],
+			)
+		}
+	}
+
+	ups := r.UpgradeState(ctx)
+	for _, v := range []int64{0, 1} {
+		if _, ok := ups[v]; !ok {
+			t.Errorf("UpgradeState is missing an upgrader for schema version %d", v)
+		}
 	}
 }
 


### PR DESCRIPTION
Fixes #384.

## Context
`unifi_device` `port_override` exposes `excluded_networkconf_ids`, `multicast_router_networkconf_ids` and `tagged_networkconf_ids` as **Lists**, but they are unordered sets of network IDs. Reordering the same IDs (or the controller returning them in a different order) produced spurious diffs. `unifi_port_profile` already models the equivalent fields as Sets.

## Changes
- Switch the three `port_override` attributes from `List` to `Set` (model fields, schema `SetAttribute`, flatten constructors, and the port_override object attribute types).
- Bump the device schema **Version 1 -> 2** and add a `1 -> 2` `StateUpgrader`. A JSON array decodes into either a list or a set, so no field rewrite is needed - the prior raw state is reconciled against the current (Set) schema type. The existing `0 -> current` upgrader already targets the current type and picks up the change too.

## Migration / compatibility
This is a schema-version bump, handled transparently by the added StateUpgrader: existing state stored as lists is migrated to sets on the next plan/apply, no user action required. HCL config (`[...]`) is unchanged - set attributes accept the same literal syntax.

## Tests
- New `TestDeviceNetworkconfIDsAreSets`: asserts the three attributes are `SetAttribute`, the schema is at Version 2, and both the v0 and v1 upgraders are registered (a missing v1 upgrader is exactly what would break existing-state refresh).
- `go build`, `go vet` (no copylocks), device unit tests, gofumpt/golines clean. Regenerated `docs/resources/device.md` (now "Set of String").

https://claude.ai/code/session_01D83uMn2TM7GdYPchVt7EWV