### PR TITLE
fix(port_profile): allow clearing native_networkconf_id to None (#383)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/hashicorp/terraform-plugin-testing v1.16.0
 	github.com/testcontainers/testcontainers-go v0.43.0
 	github.com/testcontainers/testcontainers-go/modules/compose v0.43.0
-	github.com/ubiquiti-community/go-unifi v1.33.43-0.20260706191309-bc63776a9ebf
+	github.com/ubiquiti-community/go-unifi v1.33.43-0.20260727045534-2df04ff820c6
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -539,8 +539,8 @@ github.com/transparency-dev/formats v0.1.1 h1:4bVHJc+KdBgpA1OJD1yjI+g0i5Z1graCpp
 github.com/transparency-dev/formats v0.1.1/go.mod h1:qtZ8goRuJ8FTBG9c9+Bj0rn2rUG7eG/AUTkr+Aw3jFw=
 github.com/transparency-dev/merkle v0.0.2 h1:Q9nBoQcZcgPamMkGn7ghV8XiTZ/kRxn1yCG81+twTK4=
 github.com/transparency-dev/merkle v0.0.2/go.mod h1:pqSy+OXefQ1EDUVmAJ8MUhHB9TXGuzVAT58PqBoHz1A=
-github.com/ubiquiti-community/go-unifi v1.33.43-0.20260706191309-bc63776a9ebf h1:EKNgGAeqTbFll7ddVVFU6JLDtkKZDFytq2k0Cqg/rbk=
-github.com/ubiquiti-community/go-unifi v1.33.43-0.20260706191309-bc63776a9ebf/go.mod h1:QfZDUwKQmGJNNW4af3KHzb7f+VmiSvkyTqC4/D5aPWU=
+github.com/ubiquiti-community/go-unifi v1.33.43-0.20260727045534-2df04ff820c6 h1:XUqf4QY0p9llA1srAm2mQZ2o183aIf8b4Gr7wKUl4IM=
+github.com/ubiquiti-community/go-unifi v1.33.43-0.20260727045534-2df04ff820c6/go.mod h1:ZuuuRhTslDJ6E+OW8u8mobYVCQMvQWspATSGVdzZ+Mw=
 github.com/vbatts/tar-split v0.12.2 h1:w/Y6tjxpeiFMR47yzZPlPj/FcPLpXbTUi/9H7d3CPa4=
 github.com/vbatts/tar-split v0.12.2/go.mod h1:eF6B6i6ftWQcDqEn3/iGFRFRo8cBIMSJVOpnNdfTMFA=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=

--- a/unifi/port_profile_resource.go
+++ b/unifi/port_profile_resource.go
@@ -931,11 +931,13 @@ func (r *portProfileResource) portProfileToModel(
 		model.LLDPMedNotifyEnabled = types.BoolNull()
 	}
 
-	if portProfile.NATiveNetworkID != "" {
-		model.NativeNetworkConfID = types.StringValue(portProfile.NATiveNetworkID)
-	} else {
-		model.NativeNetworkConfID = types.StringNull()
-	}
+	// #383: the controller reports "" when the native network is explicitly set to
+	// None. Surface that as a known empty string (not null) so an explicit
+	// native_networkconf_id = "" round-trips and actually clears the native network,
+	// instead of triggering an inconsistent-result-after-apply. A profile that never
+	// set it gets the controller-assigned ID here (non-empty). Requires the go-unifi
+	// fix that stops dropping the empty value from the request body.
+	model.NativeNetworkConfID = types.StringValue(portProfile.NATiveNetworkID)
 
 	if portProfile.OpMode == "" {
 		model.OpMode = types.StringValue("switch")

--- a/unifi/port_profile_resource_test.go
+++ b/unifi/port_profile_resource_test.go
@@ -507,6 +507,54 @@ func Test_portProfileResource_ListResourceConfigSchema(t *testing.T) {
 	}
 }
 
+// TestPortProfileToModel_NativeNetworkClearedRoundTrips guards #383: the
+// controller reports "" for native_networkconf_id when the native network is
+// explicitly None. portProfileToModel must surface that as a known empty string
+// (not null) so an explicit native_networkconf_id = "" round-trips instead of
+// producing an inconsistent-result-after-apply.
+func TestPortProfileToModel_NativeNetworkClearedRoundTrips(t *testing.T) {
+	r := &portProfileResource{}
+	var model portProfileResourceModel
+	diags := r.portProfileToModel(
+		context.Background(),
+		&unifi.PortProfile{NATiveNetworkID: ""},
+		&model,
+		"default",
+	)
+	if diags.HasError() {
+		t.Fatalf("portProfileToModel returned errors: %v", diags)
+	}
+	if model.NativeNetworkConfID.IsNull() || model.NativeNetworkConfID.IsUnknown() ||
+		model.NativeNetworkConfID.ValueString() != "" {
+		t.Errorf(
+			"native_networkconf_id: want known empty string, got %#v",
+			model.NativeNetworkConfID,
+		)
+	}
+}
+
+// TestPortProfileToModel_NativeNetworkAssignedKept is the companion to #383: a
+// controller-assigned native network ID must still surface its value.
+func TestPortProfileToModel_NativeNetworkAssignedKept(t *testing.T) {
+	r := &portProfileResource{}
+	var model portProfileResourceModel
+	diags := r.portProfileToModel(
+		context.Background(),
+		&unifi.PortProfile{NATiveNetworkID: "net-123"},
+		&model,
+		"default",
+	)
+	if diags.HasError() {
+		t.Fatalf("portProfileToModel returned errors: %v", diags)
+	}
+	if model.NativeNetworkConfID.ValueString() != "net-123" {
+		t.Errorf(
+			"native_networkconf_id: want net-123, got %q",
+			model.NativeNetworkConfID.ValueString(),
+		)
+	}
+}
+
 func TestAccPortProfileList_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { preCheck(t) },


### PR DESCRIPTION
Fixes #383. Provider side of the fix (go-unifi side: ubiquiti-community/go-unifi#65, merged).

## Context
Setting `unifi_port_profile.native_networkconf_id = ""` to move the native (untagged) network to None silently no-oped. Two layers:
1. go-unifi marked `PortProfile.NATiveNetworkID` `omitempty`, so `""` was dropped from the request body (fixed in go-unifi#65).
2. The provider read mapped the controllers `""` back to `null`, so even once `""` was sent, an explicit `native_networkconf_id = ""` triggered `Provider produced inconsistent result after apply` (was `""`, now null).

## Changes
- Bump go-unifi to `v1.33.43-0.20260727045534-2df04ff820c6` (includes go-unifi#65).
- `portProfileToModel`: surface the controllers empty `native_networkconf_id` as a known empty string instead of null, so `""` round-trips and actually clears the native network. A profile that never set it still gets the controller-assigned ID (non-empty).

## Tests
- New unit tests `TestPortProfileToModel_NativeNetworkClearedRoundTrips` (empty -> known "") and `TestPortProfileToModel_NativeNetworkAssignedKept` (assigned ID preserved).
- `go build`, `go vet`, full `go test ./unifi/`, gofumpt/golines clean.

https://claude.ai/code/session_01D83uMn2TM7GdYPchVt7EWV