### PR TITLE
fix(wlan): preserve configured PPSK state on partial reads

### DIFF
--- a/unifi/wlan_resource.go
+++ b/unifi/wlan_resource.go
@@ -1534,8 +1534,75 @@ func (r *wlanFrameworkResource) planToWLAN(
 	return wlan, diags
 }
 
+func privatePresharedKeysState(
+	ctx context.Context,
+	wlan *unifi.WLAN,
+	prior types.List,
+) (types.List, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	ppskType := types.ObjectType{AttrTypes: wlanPrivatePresharedKeyModel{}.AttributeTypes()}
+
+	// Disabled PPSK has no key state.
+	if !wlan.PrivatePresharedKeysEnabled {
+		return types.ListNull(ppskType), diags
+	}
+	if len(wlan.PrivatePresharedKeys) == 0 {
+		return types.ListNull(ppskType), diags
+	}
+
+	// Build the state used for imports and real controller-side changes.
+	values := make([]wlanPrivatePresharedKeyModel, len(wlan.PrivatePresharedKeys))
+	for i, key := range wlan.PrivatePresharedKeys {
+		values[i] = wlanPrivatePresharedKeyModel{
+			NetworkID: types.StringValue(key.NetworkID),
+			Password:  types.StringValue(key.Password),
+		}
+	}
+	remote, d := types.ListValueFrom(ctx, ppskType, values)
+	diags.Append(d...)
+	if prior.IsNull() || prior.IsUnknown() || len(values) != len(prior.Elements()) {
+		return remote, diags
+	}
+
+	// Keep prior secrets when the same bindings return in another order or without passwords.
+	var keys []wlanPrivatePresharedKeyModel
+	diags.Append(prior.ElementsAs(ctx, &keys, false)...)
+	if diags.HasError() {
+		return remote, diags
+	}
+
+	matched := make([]bool, len(keys))
+	match := func(current unifi.WLANPrivatePresharedKeys) bool {
+		for i, old := range keys {
+			if matched[i] || old.NetworkID.ValueString() != current.NetworkID {
+				continue
+			}
+			if current.Password != "" && old.Password.ValueString() != current.Password {
+				continue
+			}
+			matched[i] = true
+			return true
+		}
+		return false
+	}
+
+	// Match visible passwords before an omitted password can consume their entry.
+	for _, current := range wlan.PrivatePresharedKeys {
+		if current.Password != "" && !match(current) {
+			return remote, diags
+		}
+	}
+	for _, current := range wlan.PrivatePresharedKeys {
+		if current.Password == "" && !match(current) {
+			return remote, diags
+		}
+	}
+
+	return prior, diags
+}
+
 func (r *wlanFrameworkResource) wlanToModel(
-	_ context.Context,
+	ctx context.Context,
 	wlan *unifi.WLAN,
 	model *wlanFrameworkResourceModel,
 	site string,
@@ -1630,26 +1697,8 @@ func (r *wlanFrameworkResource) wlanToModel(
 	// refresh and import.
 	model.PrivatePresharedKeysEnabled = types.BoolValue(wlan.PrivatePresharedKeysEnabled)
 
-	ppskType := types.ObjectType{AttrTypes: wlanPrivatePresharedKeyModel{}.AttributeTypes()}
-	if len(wlan.PrivatePresharedKeys) > 0 {
-		ppskValues := make([]attr.Value, len(wlan.PrivatePresharedKeys))
-		for i, ppsk := range wlan.PrivatePresharedKeys {
-			obj, d := types.ObjectValue(
-				wlanPrivatePresharedKeyModel{}.AttributeTypes(),
-				map[string]attr.Value{
-					"network_id": types.StringValue(ppsk.NetworkID),
-					"password":   types.StringValue(ppsk.Password),
-				},
-			)
-			diags.Append(d...)
-			ppskValues[i] = obj
-		}
-		ppskList, d := types.ListValue(ppskType, ppskValues)
-		diags.Append(d...)
-		model.PrivatePresharedKeys = ppskList
-	} else {
-		model.PrivatePresharedKeys = types.ListNull(ppskType)
-	}
+	model.PrivatePresharedKeys, d = privatePresharedKeysState(ctx, wlan, model.PrivatePresharedKeys)
+	diags.Append(d...)
 
 	if wlan.RADIUSProfileID != "" {
 		model.RadiusProfileID = types.StringValue(wlan.RADIUSProfileID)

--- a/unifi/wlan_resource_test.go
+++ b/unifi/wlan_resource_test.go
@@ -511,6 +511,248 @@ func TestWLANPrivatePresharedKeys_emptyIsNull(t *testing.T) {
 	}
 }
 
+func TestWLANPrivatePresharedKeys_preservesStateForPartialResponse(t *testing.T) {
+	ctx := context.Background()
+	ppskType := types.ObjectType{AttrTypes: wlanPrivatePresharedKeyModel{}.AttributeTypes()}
+	prior, diags := types.ListValueFrom(ctx, ppskType, []wlanPrivatePresharedKeyModel{
+		{NetworkID: types.StringValue("net-a"), Password: types.StringValue("secretpass1")},
+		{NetworkID: types.StringValue("net-b"), Password: types.StringValue("secretpass2")},
+	})
+	if diags.HasError() {
+		t.Fatalf("building prior PPSK list: %v", diags)
+	}
+
+	for name, keys := range map[string][]unifi.WLANPrivatePresharedKeys{
+		"passwords omitted and list reordered": {
+			{NetworkID: "net-b"},
+			{NetworkID: "net-a"},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			model := wlanFrameworkResourceModel{PrivatePresharedKeys: prior}
+			wlan := &unifi.WLAN{
+				PrivatePresharedKeysEnabled: true,
+				PrivatePresharedKeys:        keys,
+			}
+
+			if diags := (&wlanFrameworkResource{}).wlanToModel(
+				ctx,
+				wlan,
+				&model,
+				"default",
+			); diags.HasError() {
+				t.Fatalf("wlanToModel: %v", diags)
+			}
+			if !model.PrivatePresharedKeys.Equal(prior) {
+				t.Fatalf("PrivatePresharedKeys = %v, want %v", model.PrivatePresharedKeys, prior)
+			}
+		})
+	}
+}
+
+func TestWLANPrivatePresharedKeys_usesControllerChanges(t *testing.T) {
+	ctx := context.Background()
+	ppskType := types.ObjectType{AttrTypes: wlanPrivatePresharedKeyModel{}.AttributeTypes()}
+	list := func(keys ...wlanPrivatePresharedKeyModel) types.List {
+		value, diags := types.ListValueFrom(ctx, ppskType, keys)
+		if diags.HasError() {
+			t.Fatalf("building PPSK list: %v", diags)
+		}
+		return value
+	}
+	prior := list(
+		wlanPrivatePresharedKeyModel{
+			NetworkID: types.StringValue("net-a"),
+			Password:  types.StringValue("secretpass1"),
+		},
+	)
+	duplicateBindings := list(
+		wlanPrivatePresharedKeyModel{
+			NetworkID: types.StringValue("net-a"),
+			Password:  types.StringValue("secretpass1"),
+		},
+		wlanPrivatePresharedKeyModel{
+			NetworkID: types.StringValue("net-a"),
+			Password:  types.StringValue("secretpass2"),
+		},
+	)
+
+	tests := []struct {
+		name  string
+		wlan  *unifi.WLAN
+		prior types.List
+		want  types.List
+	}{
+		{
+			name:  "disabled",
+			wlan:  &unifi.WLAN{},
+			prior: prior,
+			want:  types.ListNull(ppskType),
+		},
+		{
+			name:  "list omitted",
+			wlan:  &unifi.WLAN{PrivatePresharedKeysEnabled: true},
+			prior: prior,
+			want:  types.ListNull(ppskType),
+		},
+		{
+			name: "explicit deletion",
+			wlan: &unifi.WLAN{
+				PrivatePresharedKeysEnabled: true,
+				PrivatePresharedKeys:        []unifi.WLANPrivatePresharedKeys{},
+			},
+			prior: prior,
+			want:  types.ListNull(ppskType),
+		},
+		{
+			name: "import",
+			wlan: &unifi.WLAN{
+				PrivatePresharedKeysEnabled: true,
+				PrivatePresharedKeys: []unifi.WLANPrivatePresharedKeys{
+					{NetworkID: "net-a", Password: "secretpass1"},
+				},
+			},
+			prior: types.ListNull(ppskType),
+			want:  prior,
+		},
+		{
+			name: "key added",
+			wlan: &unifi.WLAN{
+				PrivatePresharedKeysEnabled: true,
+				PrivatePresharedKeys: []unifi.WLANPrivatePresharedKeys{
+					{NetworkID: "net-a", Password: "secretpass1"},
+					{NetworkID: "net-b", Password: "secretpass2"},
+				},
+			},
+			prior: prior,
+			want: list(
+				wlanPrivatePresharedKeyModel{
+					NetworkID: types.StringValue("net-a"),
+					Password:  types.StringValue("secretpass1"),
+				},
+				wlanPrivatePresharedKeyModel{
+					NetworkID: types.StringValue("net-b"),
+					Password:  types.StringValue("secretpass2"),
+				},
+			),
+		},
+		{
+			name: "binding changed",
+			wlan: &unifi.WLAN{
+				PrivatePresharedKeysEnabled: true,
+				PrivatePresharedKeys: []unifi.WLANPrivatePresharedKeys{
+					{NetworkID: "net-b", Password: "secretpass1"},
+				},
+			},
+			prior: prior,
+			want: list(wlanPrivatePresharedKeyModel{
+				NetworkID: types.StringValue("net-b"),
+				Password:  types.StringValue("secretpass1"),
+			}),
+		},
+		{
+			name: "binding changed without password",
+			wlan: &unifi.WLAN{
+				PrivatePresharedKeysEnabled: true,
+				PrivatePresharedKeys: []unifi.WLANPrivatePresharedKeys{
+					{NetworkID: "net-b"},
+				},
+			},
+			prior: prior,
+			want: list(wlanPrivatePresharedKeyModel{
+				NetworkID: types.StringValue("net-b"),
+				Password:  types.StringValue(""),
+			}),
+		},
+		{
+			name: "password changed",
+			wlan: &unifi.WLAN{
+				PrivatePresharedKeysEnabled: true,
+				PrivatePresharedKeys: []unifi.WLANPrivatePresharedKeys{
+					{NetworkID: "net-a", Password: "changedpass1"},
+				},
+			},
+			prior: prior,
+			want: list(wlanPrivatePresharedKeyModel{
+				NetworkID: types.StringValue("net-a"),
+				Password:  types.StringValue("changedpass1"),
+			}),
+		},
+		{
+			name: "matching response",
+			wlan: &unifi.WLAN{
+				PrivatePresharedKeysEnabled: true,
+				PrivatePresharedKeys: []unifi.WLANPrivatePresharedKeys{
+					{NetworkID: "net-a", Password: "secretpass1"},
+				},
+			},
+			prior: prior,
+			want:  prior,
+		},
+		{
+			name: "duplicate bindings match once",
+			wlan: &unifi.WLAN{
+				PrivatePresharedKeysEnabled: true,
+				PrivatePresharedKeys: []unifi.WLANPrivatePresharedKeys{
+					{NetworkID: "net-a"},
+					{NetworkID: "net-a", Password: "secretpass1"},
+				},
+			},
+			prior: duplicateBindings,
+			want:  duplicateBindings,
+		},
+		{
+			name: "duplicate binding replaced",
+			wlan: &unifi.WLAN{
+				PrivatePresharedKeysEnabled: true,
+				PrivatePresharedKeys: []unifi.WLANPrivatePresharedKeys{
+					{NetworkID: "net-a"},
+					{NetworkID: "net-a", Password: "changedpass1"},
+				},
+			},
+			prior: duplicateBindings,
+			want: list(
+				wlanPrivatePresharedKeyModel{
+					NetworkID: types.StringValue("net-a"),
+					Password:  types.StringValue(""),
+				},
+				wlanPrivatePresharedKeyModel{
+					NetworkID: types.StringValue("net-a"),
+					Password:  types.StringValue("changedpass1"),
+				},
+			),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, diags := privatePresharedKeysState(ctx, test.wlan, test.prior)
+			if diags.HasError() {
+				t.Fatalf("privatePresharedKeysState: %v", diags)
+			}
+			if !got.Equal(test.want) {
+				t.Fatalf("privatePresharedKeysState = %v, want %v", got, test.want)
+			}
+		})
+	}
+}
+
+func TestWLANPrivatePresharedKeys_rejectsInvalidPriorState(t *testing.T) {
+	_, diags := privatePresharedKeysState(
+		context.Background(),
+		&unifi.WLAN{
+			PrivatePresharedKeysEnabled: true,
+			PrivatePresharedKeys: []unifi.WLANPrivatePresharedKeys{
+				{NetworkID: "net-a", Password: "secretpass1"},
+			},
+		},
+		types.ListValueMust(types.StringType, []attr.Value{types.StringValue("invalid")}),
+	)
+	if !diags.HasError() {
+		t.Fatal("privatePresharedKeysState accepted invalid prior state")
+	}
+}
+
 // TestApplyEnhancedIotOverrides guards #283: when enhanced_iot is enabled the
 // controller forces iapp_enabled, wpa3_support, wpa3_transition, pmf_mode and
 // dtim_ng, so the provider pins them in the plan to avoid an inconsistent-result


### PR DESCRIPTION
## Context

The PPSK implementation in [PR #212](https://github.com/ubiquiti-community/terraform-provider-unifi/pull/212) preserves planned PPSK values after create and update so an API echo does not replace configured secrets. The accepted read-path comment also records that a PPSK password is [not always echoed by the controller](https://github.com/ubiquiti-community/terraform-provider-unifi/blob/07c5b2cab4ea55a5c5d32d48877e5abb2a315ef5/unifi/wlan_resource.go#L1627-L1630).

Refresh does not have a plan to restore after `wlanToModel`. If UniFi returns the same PPSK entries in another order or without password values, the provider replaces the configured list and produces drift. A missing password is not a valid changed password: the schema requires [8 to 255 characters](https://github.com/ubiquiti-community/terraform-provider-unifi/blob/07c5b2cab4ea55a5c5d32d48877e5abb2a315ef5/unifi/wlan_resource.go#L406-L412). The returned entry and its `network_id` identify the key that still exists.

When UniFi returns a visible changed password, this change uses that value and Terraform detects drift. When UniFi omits a password for an otherwise matching entry, the API provides no value or version that can distinguish redaction from an out-of-band password change. In that case the provider keeps the configured state and cannot detect an out-of-band password change.

The controller used for local verification currently returns the complete field and both password properties, so password omission was not reproduced locally.

## Changes

- Keep prior PPSK state only when every returned entry matches one prior network binding and any visible password matches.
- Match each entry once, with visible passwords first, so duplicate network bindings remain unambiguous.
- Ignore response ordering after all entries match.
- Use the controller response for a disabled or absent list, an explicit empty list, a changed count, an unmatched binding, or a changed visible password.

This does not change the WLAN `passphrase` behavior or add secrets to state. PPSK passwords are already required sensitive state attributes.

## Tests

- `go test ./...`
- `go vet ./...`
- `go build ./...`
- `git diff --check`
- `privatePresharedKeysState`: 100% statement coverage