### PR TITLE
fix(network): normalize omitted import defaults

### DIFF
--- a/unifi/network_resource.go
+++ b/unifi/network_resource.go
@@ -1719,8 +1719,19 @@ func (r *networkResource) networkToModel(
 		} else {
 			model.MulticastDNS = types.BoolValue(network.MdnsEnabled)
 		}
-		model.GatewayType = types.StringPointerValue(network.GatewayType)
-		model.IPv6InterfaceType = types.StringPointerValue(network.IPV6InterfaceType)
+		// UniFi omits these fields when they have their implicit controller defaults.
+		// Normalize the omitted values to the provider schema defaults so an imported
+		// network does not perpetually plan null -> default/none changes (#414).
+		if network.GatewayType == nil || *network.GatewayType == "" {
+			model.GatewayType = types.StringValue("default")
+		} else {
+			model.GatewayType = types.StringPointerValue(network.GatewayType)
+		}
+		if network.IPV6InterfaceType == nil || *network.IPV6InterfaceType == "" {
+			model.IPv6InterfaceType = types.StringValue("none")
+		} else {
+			model.IPv6InterfaceType = types.StringPointerValue(network.IPV6InterfaceType)
+		}
 		model.IPv6ClientAddressAssignment = types.StringPointerValue(
 			network.IPV6ClientAddressAssignment,
 		)

--- a/unifi/network_resource.go
+++ b/unifi/network_resource.go
@@ -1698,8 +1698,23 @@ func (r *networkResource) networkToModel(
 		} else {
 			model.MulticastDNS = previousModel.MulticastDNS
 		}
-		model.GatewayType = previousModel.GatewayType
-		model.IPv6InterfaceType = previousModel.IPv6InterfaceType
+		// Preserve configured values, but normalize import/read values that are
+		// absent because the controller omits fields irrelevant to vlan-only
+		// networks. Leaving these null/unknown would perpetually plan the schema
+		// defaults (gateway_type="default", ipv6_interface_type="none") (#414).
+		if previousModel.GatewayType.IsNull() || previousModel.GatewayType.IsUnknown() ||
+			previousModel.GatewayType.ValueString() == "" {
+			model.GatewayType = types.StringValue("default")
+		} else {
+			model.GatewayType = previousModel.GatewayType
+		}
+		if previousModel.IPv6InterfaceType.IsNull() ||
+			previousModel.IPv6InterfaceType.IsUnknown() ||
+			previousModel.IPv6InterfaceType.ValueString() == "" {
+			model.IPv6InterfaceType = types.StringValue("none")
+		} else {
+			model.IPv6InterfaceType = previousModel.IPv6InterfaceType
+		}
 		model.IPv6StaticSubnet = previousModel.IPv6StaticSubnet
 		model.IPv6PDInterface = previousModel.IPv6PDInterface
 		model.IPv6PDPrefixID = previousModel.IPv6PDPrefixID

--- a/unifi/network_resource.go
+++ b/unifi/network_resource.go
@@ -1631,8 +1631,23 @@ func (r *networkResource) networkToModel(
 		} else {
 			model.MulticastDNS = previousModel.MulticastDNS
 		}
-		model.GatewayType = previousModel.GatewayType
-		model.IPv6InterfaceType = previousModel.IPv6InterfaceType
+		// Preserve configured values, but normalize import/read values that are
+		// absent because the controller omits fields irrelevant to vlan-only
+		// networks. Leaving these null/unknown would perpetually plan the schema
+		// defaults (gateway_type="default", ipv6_interface_type="none") (#414).
+		if previousModel.GatewayType.IsNull() || previousModel.GatewayType.IsUnknown() ||
+			previousModel.GatewayType.ValueString() == "" {
+			model.GatewayType = types.StringValue("default")
+		} else {
+			model.GatewayType = previousModel.GatewayType
+		}
+		if previousModel.IPv6InterfaceType.IsNull() ||
+			previousModel.IPv6InterfaceType.IsUnknown() ||
+			previousModel.IPv6InterfaceType.ValueString() == "" {
+			model.IPv6InterfaceType = types.StringValue("none")
+		} else {
+			model.IPv6InterfaceType = previousModel.IPv6InterfaceType
+		}
 		model.IPv6StaticSubnet = previousModel.IPv6StaticSubnet
 		model.IPv6PDInterface = previousModel.IPv6PDInterface
 		model.IPv6PDPrefixID = previousModel.IPv6PDPrefixID

--- a/unifi/network_resource.go
+++ b/unifi/network_resource.go
@@ -1786,8 +1786,19 @@ func (r *networkResource) networkToModel(
 		} else {
 			model.MulticastDNS = types.BoolValue(network.MdnsEnabled)
 		}
-		model.GatewayType = types.StringPointerValue(network.GatewayType)
-		model.IPv6InterfaceType = types.StringPointerValue(network.IPV6InterfaceType)
+		// UniFi omits these fields when they have their implicit controller defaults.
+		// Normalize the omitted values to the provider schema defaults so an imported
+		// network does not perpetually plan null -> default/none changes (#414).
+		if network.GatewayType == nil || *network.GatewayType == "" {
+			model.GatewayType = types.StringValue("default")
+		} else {
+			model.GatewayType = types.StringPointerValue(network.GatewayType)
+		}
+		if network.IPV6InterfaceType == nil || *network.IPV6InterfaceType == "" {
+			model.IPv6InterfaceType = types.StringValue("none")
+		} else {
+			model.IPv6InterfaceType = types.StringPointerValue(network.IPV6InterfaceType)
+		}
 		model.IPv6ClientAddressAssignment = types.StringPointerValue(
 			network.IPV6ClientAddressAssignment,
 		)

--- a/unifi/network_resource_test.go
+++ b/unifi/network_resource_test.go
@@ -1354,6 +1354,97 @@ func Test_networkResource_networkToModel_normalizesControllerDefaults(t *testing
 	}
 }
 
+func Test_networkResource_networkToModel_normalizesVLANOnlyDefaults(t *testing.T) {
+	r := &networkResource{}
+	base := func() *networkResourceModel {
+		return &networkResourceModel{
+			// Import seeds identity only, leaving computed attributes null.
+			NetworkIsolation: types.BoolNull(),
+			DhcpServer:       types.ObjectNull(dhcpServerModel{}.AttributeTypes()),
+			DhcpRelay:        types.ObjectNull(dhcpRelayModel{}.AttributeTypes()),
+			DhcpV6Server:     types.ObjectNull(dhcpV6ServerModel{}.AttributeTypes()),
+			DhcpGuarding:     types.ObjectNull(dhcpGuardingModel{}.AttributeTypes()),
+			NatOutboundIPAddresses: types.ListNull(
+				types.ObjectType{AttrTypes: natOutboundIPAddresses()},
+			),
+			IPAliases:   types.ListNull(types.StringType),
+			IPv6Aliases: types.ListNull(types.StringType),
+		}
+	}
+
+	tests := []struct {
+		name                  string
+		previousGatewayType   types.String
+		previousIPv6Type      types.String
+		wantGatewayType       string
+		wantIPv6InterfaceType string
+	}{
+		{
+			name:                  "import nulls use schema defaults",
+			previousGatewayType:   types.StringNull(),
+			previousIPv6Type:      types.StringNull(),
+			wantGatewayType:       "default",
+			wantIPv6InterfaceType: "none",
+		},
+		{
+			name:                  "unknown plan values use schema defaults",
+			previousGatewayType:   types.StringUnknown(),
+			previousIPv6Type:      types.StringUnknown(),
+			wantGatewayType:       "default",
+			wantIPv6InterfaceType: "none",
+		},
+		{
+			name:                  "empty prior values use schema defaults",
+			previousGatewayType:   types.StringValue(""),
+			previousIPv6Type:      types.StringValue(""),
+			wantGatewayType:       "default",
+			wantIPv6InterfaceType: "none",
+		},
+		{
+			name:                  "explicit prior values are preserved",
+			previousGatewayType:   types.StringValue("switch"),
+			previousIPv6Type:      types.StringValue("static"),
+			wantGatewayType:       "switch",
+			wantIPv6InterfaceType: "static",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			previous := base()
+			previous.GatewayType = tt.previousGatewayType
+			previous.IPv6InterfaceType = tt.previousIPv6Type
+			network := &unifi.Network{
+				ID:      "net-vlan-only-imported",
+				Name:    strPtr("Imported VLAN Only"),
+				Purpose: unifi.PurposeVLANOnly,
+				Enabled: true,
+			}
+			var model networkResourceModel
+			d := r.networkToModel(context.Background(), network, &model, "default", previous)
+			if d.HasError() {
+				t.Fatalf("networkToModel: %v", d)
+			}
+			if model.GatewayType.IsNull() || model.GatewayType.IsUnknown() {
+				t.Fatalf("gateway_type should be known, got %v", model.GatewayType)
+			}
+			if got := model.GatewayType.ValueString(); got != tt.wantGatewayType {
+				t.Errorf("gateway_type = %q, want %q", got, tt.wantGatewayType)
+			}
+			if model.IPv6InterfaceType.IsNull() || model.IPv6InterfaceType.IsUnknown() {
+				t.Fatalf("ipv6_interface_type should be known, got %v", model.IPv6InterfaceType)
+			}
+			if got := model.IPv6InterfaceType.ValueString(); got != tt.wantIPv6InterfaceType {
+				t.Errorf(
+					"ipv6_interface_type = %q, want %q",
+					got,
+					tt.wantIPv6InterfaceType,
+				)
+			}
+		})
+	}
+}
+
 // Test_networkResource_purpose covers #276: purpose must be author-settable
 // (guest/vlan-only/corporate) on write and reflected from the controller on read.
 func Test_networkResource_purpose(t *testing.T) {

--- a/unifi/network_resource_test.go
+++ b/unifi/network_resource_test.go
@@ -1268,6 +1268,92 @@ func Test_networkResource_networkToModel_multicastDNS(t *testing.T) {
 	})
 }
 
+// Test_networkResource_networkToModel_normalizesControllerDefaults guards #414:
+// UniFi may omit gateway_type and ipv6_interface_type when they have their
+// implicit defaults. Import must write the provider defaults into state instead
+// of null, otherwise every subsequent plan proposes null -> default/none.
+func Test_networkResource_networkToModel_normalizesControllerDefaults(t *testing.T) {
+	r := &networkResource{}
+	base := func() *networkResourceModel {
+		return &networkResourceModel{
+			// Import seeds identity only, leaving computed attributes null.
+			NetworkIsolation: types.BoolNull(),
+			DhcpServer:       types.ObjectNull(dhcpServerModel{}.AttributeTypes()),
+			DhcpRelay:        types.ObjectNull(dhcpRelayModel{}.AttributeTypes()),
+			DhcpV6Server:     types.ObjectNull(dhcpV6ServerModel{}.AttributeTypes()),
+			DhcpGuarding:     types.ObjectNull(dhcpGuardingModel{}.AttributeTypes()),
+			NatOutboundIPAddresses: types.ListNull(
+				types.ObjectType{AttrTypes: natOutboundIPAddresses()},
+			),
+			IPAliases:   types.ListNull(types.StringType),
+			IPv6Aliases: types.ListNull(types.StringType),
+		}
+	}
+
+	tests := []struct {
+		name                  string
+		gatewayType           *string
+		ipv6InterfaceType     *string
+		wantGatewayType       string
+		wantIPv6InterfaceType string
+	}{
+		{
+			name:                  "nil API values use schema defaults",
+			wantGatewayType:       "default",
+			wantIPv6InterfaceType: "none",
+		},
+		{
+			name:                  "empty API values use schema defaults",
+			gatewayType:           strPtr(""),
+			ipv6InterfaceType:     strPtr(""),
+			wantGatewayType:       "default",
+			wantIPv6InterfaceType: "none",
+		},
+		{
+			name:                  "explicit API values are preserved",
+			gatewayType:           strPtr("switch"),
+			ipv6InterfaceType:     strPtr("static"),
+			wantGatewayType:       "switch",
+			wantIPv6InterfaceType: "static",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			network := &unifi.Network{
+				ID:                "net-imported",
+				Name:              strPtr("Imported Network"),
+				Purpose:           unifi.PurposeCorporate,
+				Enabled:           true,
+				IPSubnet:          strPtr("10.25.0.1/24"),
+				GatewayType:       tt.gatewayType,
+				IPV6InterfaceType: tt.ipv6InterfaceType,
+			}
+			var model networkResourceModel
+			d := r.networkToModel(context.Background(), network, &model, "default", base())
+			if d.HasError() {
+				t.Fatalf("networkToModel: %v", d)
+			}
+			if model.GatewayType.IsNull() || model.GatewayType.IsUnknown() {
+				t.Fatalf("gateway_type should be known, got %v", model.GatewayType)
+			}
+			if got := model.GatewayType.ValueString(); got != tt.wantGatewayType {
+				t.Errorf("gateway_type = %q, want %q", got, tt.wantGatewayType)
+			}
+			if model.IPv6InterfaceType.IsNull() || model.IPv6InterfaceType.IsUnknown() {
+				t.Fatalf("ipv6_interface_type should be known, got %v", model.IPv6InterfaceType)
+			}
+			if got := model.IPv6InterfaceType.ValueString(); got != tt.wantIPv6InterfaceType {
+				t.Errorf(
+					"ipv6_interface_type = %q, want %q",
+					got,
+					tt.wantIPv6InterfaceType,
+				)
+			}
+		})
+	}
+}
+
 // Test_networkResource_purpose covers #276: purpose must be author-settable
 // (guest/vlan-only/corporate) on write and reflected from the controller on read.
 func Test_networkResource_purpose(t *testing.T) {

--- a/unifi/network_resource_test.go
+++ b/unifi/network_resource_test.go
@@ -1355,6 +1355,97 @@ func Test_networkResource_networkToModel_normalizesControllerDefaults(t *testing
 	}
 }
 
+func Test_networkResource_networkToModel_normalizesVLANOnlyDefaults(t *testing.T) {
+	r := &networkResource{}
+	base := func() *networkResourceModel {
+		return &networkResourceModel{
+			// Import seeds identity only, leaving computed attributes null.
+			NetworkIsolation: types.BoolNull(),
+			DhcpServer:       types.ObjectNull(dhcpServerModel{}.AttributeTypes()),
+			DhcpRelay:        types.ObjectNull(dhcpRelayModel{}.AttributeTypes()),
+			DhcpV6Server:     types.ObjectNull(dhcpV6ServerModel{}.AttributeTypes()),
+			DhcpGuarding:     types.ObjectNull(dhcpGuardingModel{}.AttributeTypes()),
+			NatOutboundIPAddresses: types.ListNull(
+				types.ObjectType{AttrTypes: natOutboundIPAddresses()},
+			),
+			IPAliases:   types.ListNull(types.StringType),
+			IPv6Aliases: types.ListNull(types.StringType),
+		}
+	}
+
+	tests := []struct {
+		name                  string
+		previousGatewayType   types.String
+		previousIPv6Type      types.String
+		wantGatewayType       string
+		wantIPv6InterfaceType string
+	}{
+		{
+			name:                  "import nulls use schema defaults",
+			previousGatewayType:   types.StringNull(),
+			previousIPv6Type:      types.StringNull(),
+			wantGatewayType:       "default",
+			wantIPv6InterfaceType: "none",
+		},
+		{
+			name:                  "unknown plan values use schema defaults",
+			previousGatewayType:   types.StringUnknown(),
+			previousIPv6Type:      types.StringUnknown(),
+			wantGatewayType:       "default",
+			wantIPv6InterfaceType: "none",
+		},
+		{
+			name:                  "empty prior values use schema defaults",
+			previousGatewayType:   types.StringValue(""),
+			previousIPv6Type:      types.StringValue(""),
+			wantGatewayType:       "default",
+			wantIPv6InterfaceType: "none",
+		},
+		{
+			name:                  "explicit prior values are preserved",
+			previousGatewayType:   types.StringValue("switch"),
+			previousIPv6Type:      types.StringValue("static"),
+			wantGatewayType:       "switch",
+			wantIPv6InterfaceType: "static",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			previous := base()
+			previous.GatewayType = tt.previousGatewayType
+			previous.IPv6InterfaceType = tt.previousIPv6Type
+			network := &unifi.Network{
+				ID:      "net-vlan-only-imported",
+				Name:    strPtr("Imported VLAN Only"),
+				Purpose: unifi.PurposeVLANOnly,
+				Enabled: true,
+			}
+			var model networkResourceModel
+			d := r.networkToModel(context.Background(), network, &model, "default", previous)
+			if d.HasError() {
+				t.Fatalf("networkToModel: %v", d)
+			}
+			if model.GatewayType.IsNull() || model.GatewayType.IsUnknown() {
+				t.Fatalf("gateway_type should be known, got %v", model.GatewayType)
+			}
+			if got := model.GatewayType.ValueString(); got != tt.wantGatewayType {
+				t.Errorf("gateway_type = %q, want %q", got, tt.wantGatewayType)
+			}
+			if model.IPv6InterfaceType.IsNull() || model.IPv6InterfaceType.IsUnknown() {
+				t.Fatalf("ipv6_interface_type should be known, got %v", model.IPv6InterfaceType)
+			}
+			if got := model.IPv6InterfaceType.ValueString(); got != tt.wantIPv6InterfaceType {
+				t.Errorf(
+					"ipv6_interface_type = %q, want %q",
+					got,
+					tt.wantIPv6InterfaceType,
+				)
+			}
+		})
+	}
+}
+
 // Test_networkResource_purpose covers #276: purpose must be author-settable
 // (guest/vlan-only/corporate) on write and reflected from the controller on read.
 func Test_networkResource_purpose(t *testing.T) {

--- a/unifi/network_resource_test.go
+++ b/unifi/network_resource_test.go
@@ -1269,6 +1269,92 @@ func Test_networkResource_networkToModel_multicastDNS(t *testing.T) {
 	})
 }
 
+// Test_networkResource_networkToModel_normalizesControllerDefaults guards #414:
+// UniFi may omit gateway_type and ipv6_interface_type when they have their
+// implicit defaults. Import must write the provider defaults into state instead
+// of null, otherwise every subsequent plan proposes null -> default/none.
+func Test_networkResource_networkToModel_normalizesControllerDefaults(t *testing.T) {
+	r := &networkResource{}
+	base := func() *networkResourceModel {
+		return &networkResourceModel{
+			// Import seeds identity only, leaving computed attributes null.
+			NetworkIsolation: types.BoolNull(),
+			DhcpServer:       types.ObjectNull(dhcpServerModel{}.AttributeTypes()),
+			DhcpRelay:        types.ObjectNull(dhcpRelayModel{}.AttributeTypes()),
+			DhcpV6Server:     types.ObjectNull(dhcpV6ServerModel{}.AttributeTypes()),
+			DhcpGuarding:     types.ObjectNull(dhcpGuardingModel{}.AttributeTypes()),
+			NatOutboundIPAddresses: types.ListNull(
+				types.ObjectType{AttrTypes: natOutboundIPAddresses()},
+			),
+			IPAliases:   types.ListNull(types.StringType),
+			IPv6Aliases: types.ListNull(types.StringType),
+		}
+	}
+
+	tests := []struct {
+		name                  string
+		gatewayType           *string
+		ipv6InterfaceType     *string
+		wantGatewayType       string
+		wantIPv6InterfaceType string
+	}{
+		{
+			name:                  "nil API values use schema defaults",
+			wantGatewayType:       "default",
+			wantIPv6InterfaceType: "none",
+		},
+		{
+			name:                  "empty API values use schema defaults",
+			gatewayType:           strPtr(""),
+			ipv6InterfaceType:     strPtr(""),
+			wantGatewayType:       "default",
+			wantIPv6InterfaceType: "none",
+		},
+		{
+			name:                  "explicit API values are preserved",
+			gatewayType:           strPtr("switch"),
+			ipv6InterfaceType:     strPtr("static"),
+			wantGatewayType:       "switch",
+			wantIPv6InterfaceType: "static",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			network := &unifi.Network{
+				ID:                "net-imported",
+				Name:              strPtr("Imported Network"),
+				Purpose:           unifi.PurposeCorporate,
+				Enabled:           true,
+				IPSubnet:          strPtr("10.25.0.1/24"),
+				GatewayType:       tt.gatewayType,
+				IPV6InterfaceType: tt.ipv6InterfaceType,
+			}
+			var model networkResourceModel
+			d := r.networkToModel(context.Background(), network, &model, "default", base())
+			if d.HasError() {
+				t.Fatalf("networkToModel: %v", d)
+			}
+			if model.GatewayType.IsNull() || model.GatewayType.IsUnknown() {
+				t.Fatalf("gateway_type should be known, got %v", model.GatewayType)
+			}
+			if got := model.GatewayType.ValueString(); got != tt.wantGatewayType {
+				t.Errorf("gateway_type = %q, want %q", got, tt.wantGatewayType)
+			}
+			if model.IPv6InterfaceType.IsNull() || model.IPv6InterfaceType.IsUnknown() {
+				t.Fatalf("ipv6_interface_type should be known, got %v", model.IPv6InterfaceType)
+			}
+			if got := model.IPv6InterfaceType.ValueString(); got != tt.wantIPv6InterfaceType {
+				t.Errorf(
+					"ipv6_interface_type = %q, want %q",
+					got,
+					tt.wantIPv6InterfaceType,
+				)
+			}
+		})
+	}
+}
+
 // Test_networkResource_purpose covers #276: purpose must be author-settable
 // (guest/vlan-only/corporate) on write and reflected from the controller on read.
 func Test_networkResource_purpose(t *testing.T) {


### PR DESCRIPTION
## What changed

- Normalize an omitted `gateway_type` API value to the schema default, `default`.
- Normalize an omitted `ipv6_interface_type` API value to the schema default, `none`.
- Apply the same normalization to VLAN-only import/read state while preserving explicit prior values.
- Add focused regression coverage for routed and VLAN-only networks, including nil, unknown, empty, and explicit non-default values.

## Why

Some UniFi controllers omit these fields when they use their implicit defaults. VLAN-only reads also intentionally preserve prior state because the controller omits fields irrelevant to those networks. During import that prior state is null, so the provider previously kept `null` while the resource schema planned `default` and `none`, causing a perpetual no-op diff.

The change is read-side normalization only; it does not add or alter controller writes.

Fixes #414.

## Validation

- `go test ./... -count=1`
- `go test -race -count=1 -timeout 120m ./...`
- `go vet ./...`
- `go generate ./...` followed by a clean generated-file diff
- `golangci-lint run --new-from-rev=origin/main` (`0 issues`)
- `go build -trimpath .`
