### PR TITLE
fix(network_resource): add support for firewall_zone_id parameter

### DIFF
--- a/docs/resources/network.md
+++ b/docs/resources/network.md
@@ -99,6 +99,7 @@ resource "unifi_network" "third_party" {
 - `dhcp_v6_server` (Attributes) DHCPv6 server configuration. (see [below for nested schema](#nestedatt--dhcp_v6_server))
 - `domain_name` (String) The domain name for the network.
 - `enabled` (Boolean) Specifies whether the network is enabled.
+- `firewall_zone_id` (String) The firewall zone ID assigned to this network. Note: This field is dual-managed and can compete with `unifi_firewall_zone.network_ids`. To prevent state drift loops, ensure you manage zone membership from exactly one side. On Zone-Based Firewall (ZBF) controllers, this field is tightly coupled to the network's `purpose` field.
 - `gateway_type` (String) The gateway type. Must be one of `default` or `switch`.
 - `igmp_snooping` (Boolean) Specifies whether IGMP snooping is enabled.
 - `internet_access` (Boolean) Specifies whether internet access is enabled.

--- a/unifi/network_resource.go
+++ b/unifi/network_resource.go
@@ -252,6 +252,7 @@ type networkResourceModel struct {
 	DhcpServer                  types.Object         `tfsdk:"dhcp_server"`
 	DhcpV6Server                types.Object         `tfsdk:"dhcp_v6_server"`
 	DhcpRelay                   types.Object         `tfsdk:"dhcp_relay"`
+	FirewallZoneID              types.String         `tfsdk:"firewall_zone_id"`
 	Timeouts                    timeouts.Value       `tfsdk:"timeouts"`
 }
 
@@ -810,6 +811,14 @@ func (r *networkResource) Schema(
 							listvalidator.SizeAtMost(4),
 						},
 					},
+				},
+			},
+			"firewall_zone_id": schema.StringAttribute{
+				MarkdownDescription: "The firewall zone ID assigned to this network.",
+				Optional:            true,
+				Computed:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
 				},
 			},
 			"timeouts": timeouts.Attributes(
@@ -1578,6 +1587,11 @@ func (r *networkResource) modelToNetwork(
 		network.DHCPRelayEnabled = false
 	}
 
+	if !model.FirewallZoneID.IsNull() && !model.FirewallZoneID.IsUnknown() {
+		zoneID := model.FirewallZoneID.ValueString()
+		network.FirewallZoneID = &zoneID
+	}
+
 	return network, diags
 }
 
@@ -1987,6 +2001,12 @@ func (r *networkResource) networkToModel(
 	} else {
 		// Keep dhcp_relay null if it wasn't in the plan/state
 		model.DhcpRelay = types.ObjectNull(dhcpRelayModel{}.AttributeTypes())
+	}
+
+	if network.FirewallZoneID != nil {
+		model.FirewallZoneID = types.StringValue(*network.FirewallZoneID)
+	} else {
+		model.FirewallZoneID = types.StringNull()
 	}
 
 	return diags

--- a/unifi/network_resource.go
+++ b/unifi/network_resource.go
@@ -254,6 +254,7 @@ type networkResourceModel struct {
 	DhcpServer                  types.Object         `tfsdk:"dhcp_server"`
 	DhcpV6Server                types.Object         `tfsdk:"dhcp_v6_server"`
 	DhcpRelay                   types.Object         `tfsdk:"dhcp_relay"`
+	FirewallZoneID              types.String         `tfsdk:"firewall_zone_id"`
 	Timeouts                    timeouts.Value       `tfsdk:"timeouts"`
 }
 
@@ -827,6 +828,14 @@ func (r *networkResource) Schema(
 						},
 					},
 				},
+			},
+			"firewall_zone_id": schema.StringAttribute{
+				MarkdownDescription: "The firewall zone ID assigned to this network. " +
+					"Note: This field is dual-managed and can compete with `unifi_firewall_zone.network_ids`. " +
+					"To prevent state drift loops, ensure you manage zone membership from exactly one side. " +
+					"On Zone-Based Firewall (ZBF) controllers, this field is tightly coupled to the network's `purpose` field.",
+				Optional: true,
+				Computed: true,
 			},
 			"timeouts": timeouts.Attributes(
 				ctx,
@@ -1630,6 +1639,12 @@ func (r *networkResource) modelToNetwork(
 		network.DHCPRelayEnabled = false
 	}
 
+	if !model.FirewallZoneID.IsNull() && !model.FirewallZoneID.IsUnknown() &&
+		model.FirewallZoneID.ValueString() != "" {
+		zoneID := model.FirewallZoneID.ValueString()
+		network.FirewallZoneID = &zoneID
+	}
+
 	return network, diags
 }
 
@@ -2057,6 +2072,12 @@ func (r *networkResource) networkToModel(
 	} else {
 		// Keep dhcp_relay null if it wasn't in the plan/state
 		model.DhcpRelay = types.ObjectNull(dhcpRelayModel{}.AttributeTypes())
+	}
+
+	if network.FirewallZoneID != nil {
+		model.FirewallZoneID = types.StringPointerValue(network.FirewallZoneID)
+	} else {
+		model.FirewallZoneID = types.StringNull()
 	}
 
 	return diags

--- a/unifi/network_resource.go
+++ b/unifi/network_resource.go
@@ -814,12 +814,12 @@ func (r *networkResource) Schema(
 				},
 			},
 			"firewall_zone_id": schema.StringAttribute{
-				MarkdownDescription: "The firewall zone ID assigned to this network.",
+				MarkdownDescription: "The firewall zone ID assigned to this network. " +
+					"Note: This field is dual-managed and can compete with `unifi_firewall_zone.network_ids`. " +
+					"To prevent state drift loops, ensure you manage zone membership from exactly one side. " +
+					"On Zone-Based Firewall (ZBF) controllers, this field is tightly coupled to the network's `purpose` field.",
 				Optional:            true,
 				Computed:            true,
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.UseStateForUnknown(),
-				},
 			},
 			"timeouts": timeouts.Attributes(
 				ctx,
@@ -1587,7 +1587,8 @@ func (r *networkResource) modelToNetwork(
 		network.DHCPRelayEnabled = false
 	}
 
-	if !model.FirewallZoneID.IsNull() && !model.FirewallZoneID.IsUnknown() {
+	if !model.FirewallZoneID.IsNull() && !model.FirewallZoneID.IsUnknown() &&
+		model.FirewallZoneID.ValueString() != "" {
 		zoneID := model.FirewallZoneID.ValueString()
 		network.FirewallZoneID = &zoneID
 	}
@@ -2004,7 +2005,7 @@ func (r *networkResource) networkToModel(
 	}
 
 	if network.FirewallZoneID != nil {
-		model.FirewallZoneID = types.StringValue(*network.FirewallZoneID)
+		model.FirewallZoneID = types.StringPointerValue(network.FirewallZoneID)
 	} else {
 		model.FirewallZoneID = types.StringNull()
 	}

--- a/unifi/network_resource_test.go
+++ b/unifi/network_resource_test.go
@@ -1199,8 +1199,8 @@ func TestAccNetworkList_basic(t *testing.T) {
 							filter {
 								name  = "name"
 								value = "Test VLAN"
-						  }
-					  }
+							}
+						}
 					}
 				`,
 				QueryResultChecks: []querycheck.QueryResultCheck{
@@ -1349,4 +1349,57 @@ func Test_networkResource_purpose(t *testing.T) {
 			t.Errorf("Purpose = %q, want %q", model.Purpose.ValueString(), unifi.PurposeGuest)
 		}
 	})
+}
+
+// TestNetworkFirewallZoneIDModelRoundTrip validates the model <-> go-unifi struct
+// conversion for the firewall_zone_id attribute on the unifi_network resource.
+// It is a unit test rather than an acceptance test because zone-based firewall
+// is not available in the dockerized acceptance controller.
+func TestNetworkFirewallZoneIDModelRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	r := &networkResource{}
+
+	// 1. Test modelToNetwork (Config presence / write path)
+	model := &networkResourceModel{
+		Name:           types.StringValue("Test Zone Network"),
+		FirewallZoneID: types.StringValue("60b7c25e0cf2732bbdf1e102"),
+	}
+
+	// Call modelToNetwork with exactly two arguments as required by the schema
+	network, diags := r.modelToNetwork(ctx, model)
+	if diags.HasError() {
+		t.Fatalf("modelToNetwork failed: %v", diags)
+	}
+
+	if network.FirewallZoneID == nil {
+		t.Fatalf("modelToNetwork: FirewallZoneID pointer is nil, want a value")
+	}
+	if *network.FirewallZoneID != "60b7c25e0cf2732bbdf1e102" {
+		t.Errorf("modelToNetwork: FirewallZoneID = %q, want 60b7c25e0cf2732bbdf1e102", *network.FirewallZoneID)
+	}
+
+	// 2. Test networkToModel (Read path drift detection)
+	apiNetwork := &unifi.Network{
+		ID:             "net-123",
+		Name:           stringPtr("Test Zone Network"), // Wrapped in helper to create a *string
+		FirewallZoneID: stringPtr("60b7c25e0cf2732bbdf1e102"),
+	}
+
+	var out networkResourceModel
+	var planData networkResourceModel
+	
+	// Ensure the arguments match your exact networkToModel signature (e.g. site, plan)
+	readDiags := r.networkToModel(ctx, apiNetwork, &out, "default", &planData)
+	if readDiags.HasError() {
+		t.Fatalf("networkToModel failed: %v", readDiags)
+	}
+
+	if out.FirewallZoneID.ValueString() != "60b7c25e0cf2732bbdf1e102" {
+		t.Errorf("networkToModel: FirewallZoneID = %q, want 60b7c25e0cf2732bbdf1e102", out.FirewallZoneID.ValueString())
+	}
+}
+
+// Helper utility to safely yield string pointers for the API structs
+func stringPtr(s string) *string {
+	return &s
 }

--- a/unifi/network_resource_test.go
+++ b/unifi/network_resource_test.go
@@ -1200,8 +1200,8 @@ func TestAccNetworkList_basic(t *testing.T) {
 							filter {
 								name  = "name"
 								value = "Test VLAN"
-						  }
-					  }
+							}
+						}
 					}
 				`,
 				QueryResultChecks: []querycheck.QueryResultCheck{
@@ -1350,4 +1350,61 @@ func Test_networkResource_purpose(t *testing.T) {
 			t.Errorf("Purpose = %q, want %q", model.Purpose.ValueString(), unifi.PurposeGuest)
 		}
 	})
+}
+
+// TestNetworkFirewallZoneIDModelRoundTrip validates the model <-> go-unifi struct
+// conversion for the firewall_zone_id attribute on the unifi_network resource.
+// It is a unit test rather than an acceptance test because zone-based firewall
+// is not available in the dockerized acceptance controller.
+func TestNetworkFirewallZoneIDModelRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	r := &networkResource{}
+
+	// Write path: a configured firewall_zone_id must reach the API struct.
+	model := &networkResourceModel{
+		Name:           types.StringValue("Test Zone Network"),
+		FirewallZoneID: types.StringValue("60b7c25e0cf2732bbdf1e102"),
+	}
+
+	network, diags := r.modelToNetwork(ctx, model)
+	if diags.HasError() {
+		t.Fatalf("modelToNetwork failed: %v", diags)
+	}
+
+	if network.FirewallZoneID == nil {
+		t.Fatalf("modelToNetwork: FirewallZoneID pointer is nil, want a value")
+	}
+	if *network.FirewallZoneID != "60b7c25e0cf2732bbdf1e102" {
+		t.Errorf(
+			"modelToNetwork: FirewallZoneID = %q, want 60b7c25e0cf2732bbdf1e102",
+			*network.FirewallZoneID,
+		)
+	}
+
+	// Read path: the controller-side value must land in the model for drift
+	// detection.
+	apiNetwork := &unifi.Network{
+		ID:             "net-123",
+		Name:           stringPtr("Test Zone Network"),
+		FirewallZoneID: stringPtr("60b7c25e0cf2732bbdf1e102"),
+	}
+
+	var out networkResourceModel
+	var planData networkResourceModel
+
+	readDiags := r.networkToModel(ctx, apiNetwork, &out, "default", &planData)
+	if readDiags.HasError() {
+		t.Fatalf("networkToModel failed: %v", readDiags)
+	}
+
+	if out.FirewallZoneID.ValueString() != "60b7c25e0cf2732bbdf1e102" {
+		t.Errorf(
+			"networkToModel: FirewallZoneID = %q, want 60b7c25e0cf2732bbdf1e102",
+			out.FirewallZoneID.ValueString(),
+		)
+	}
+}
+
+func stringPtr(s string) *string {
+	return &s
 }


### PR DESCRIPTION
This PR adds support for managing the `firewall_zone_id` attribute directly within the unifi_network resource.

While the underlying go-unifi SDK already exposes `FirewallZoneId` on the generated network types, the Terraform provider currently lacks schema mapping for it, forcing users to configure network-to-zone mappings solely from the **unifi_firewall_zone** resource side.

This change bridges that functional gap.