### PR TITLE
fix(network_resource) add ntp_servers to make ntp_enabled usable

### DIFF
--- a/docs/data-sources/network.md
+++ b/docs/data-sources/network.md
@@ -120,6 +120,7 @@ Read-Only:
 - `gateway_enabled` (Boolean) Specifies whether DHCP gateway is enabled.
 - `leasetime` (String) Specifies the DHCP lease time, as a Go duration string.
 - `ntp_enabled` (Boolean) Specifies whether DHCP NTP is enabled.
+- `ntp_servers` (List of String) List of NTP server addresses for DHCP clients.
 - `start` (String) The IPv4 address where the DHCP range starts.
 - `stop` (String) The IPv4 address where the DHCP range stops.
 - `tftp_server` (String) TFTP server address.

--- a/docs/resources/network.md
+++ b/docs/resources/network.md
@@ -163,6 +163,7 @@ Optional:
 - `gateway_enabled` (Boolean) Specifies whether DHCP gateway is enabled.
 - `leasetime` (String) Specifies the DHCP lease time, as a Go duration string (e.g. `24h`, `86400s`). Defaults to `24h0m0s`.
 - `ntp_enabled` (Boolean) Specifies whether DHCP NTP is enabled.
+- `ntp_servers` (List of String) List of NTP server addresses for DHCP clients.
 - `start` (String) The IPv4 address where the DHCP range starts.
 - `stop` (String) The IPv4 address where the DHCP range stops.
 - `tftp_server` (String) TFTP server address.

--- a/unifi/network_data_source.go
+++ b/unifi/network_data_source.go
@@ -287,11 +287,11 @@ func (d *networkDataSource) Schema(
 						MarkdownDescription: "Specifies whether DHCP NTP is enabled.",
 						Computed:            true,
 					},
-                    "ntp_servers": schema.ListAttribute{
-                        MarkdownDescription: "List of NTP server addresses for DHCP clients.",
-                        Computed:            true,
-                        ElementType:         types.StringType,
-                    },
+					"ntp_servers": schema.ListAttribute{
+						MarkdownDescription: "List of NTP server addresses for DHCP clients.",
+						Computed:            true,
+						ElementType:         types.StringType,
+					},
 					"time_offset_enabled": schema.BoolAttribute{
 						MarkdownDescription: "Specifies whether DHCP time offset is enabled.",
 						Computed:            true,
@@ -706,13 +706,13 @@ func (d *networkDataSource) setDataSourceData(
 		diags.Append(d...)
 
 		ntpServers := collectNonEmptyStringPointers(network.DHCPDNtp1, network.DHCPDNtp2)
-        var ntpServersList types.List
-        if len(ntpServers) > 0 {
-        	ntpServersList, d = types.ListValueFrom(ctx, types.StringType, ntpServers)
-        	diags.Append(d...)
-        } else {
-        	ntpServersList = types.ListNull(types.StringType)
-        }
+		var ntpServersList types.List
+		if len(ntpServers) > 0 {
+			ntpServersList, d = types.ListValueFrom(ctx, types.StringType, ntpServers)
+			diags.Append(d...)
+		} else {
+			ntpServersList = types.ListNull(types.StringType)
+		}
 
 		dhcpServerValue := dhcpServerModel{
 			Boot:              dhcpBootObj,

--- a/unifi/network_data_source.go
+++ b/unifi/network_data_source.go
@@ -287,6 +287,11 @@ func (d *networkDataSource) Schema(
 						MarkdownDescription: "Specifies whether DHCP NTP is enabled.",
 						Computed:            true,
 					},
+                     "ntp_servers": schema.ListAttribute{
+                        MarkdownDescription: "List of NTP server addresses for DHCP clients.",
+                        Computed:            true,
+                        ElementType:         types.StringType,
+                    },
 					"time_offset_enabled": schema.BoolAttribute{
 						MarkdownDescription: "Specifies whether DHCP time offset is enabled.",
 						Computed:            true,
@@ -700,6 +705,15 @@ func (d *networkDataSource) setDataSourceData(
 		winsObj, d := types.ObjectValueFrom(ctx, winsValue.AttributeTypes(), winsValue)
 		diags.Append(d...)
 
+		ntpServers := collectNonEmptyStringPointers(network.DHCPDNtp1, network.DHCPDNtp2)
+        var ntpServersList types.List
+        if len(ntpServers) > 0 {
+        	ntpServersList, d = types.ListValueFrom(ctx, types.StringType, ntpServers)
+        	diags.Append(d...)
+        } else {
+        	ntpServersList = types.ListNull(types.StringType)
+        }
+
 		dhcpServerValue := dhcpServerModel{
 			Boot:              dhcpBootObj,
 			Enabled:           types.BoolValue(network.DHCPDEnabled),
@@ -708,6 +722,7 @@ func (d *networkDataSource) setDataSourceData(
 			GatewayEnabled:    types.BoolValue(network.DHCPDGatewayEnabled),
 			ConflictChecking:  types.BoolValue(network.DHCPDConflictChecking),
 			NtpEnabled:        types.BoolValue(network.DHCPDNtpEnabled),
+			NtpServers:        ntpServersList,
 			TimeOffsetEnabled: types.BoolValue(network.DHCPDTimeOffsetEnabled),
 			DnsEnabled:        types.BoolValue(network.DHCPDDNSEnabled),
 			Leasetime:         util.DurationPtrValue(network.DHCPDLeaseTime, time.Second),

--- a/unifi/network_data_source.go
+++ b/unifi/network_data_source.go
@@ -287,7 +287,7 @@ func (d *networkDataSource) Schema(
 						MarkdownDescription: "Specifies whether DHCP NTP is enabled.",
 						Computed:            true,
 					},
-                     "ntp_servers": schema.ListAttribute{
+                    "ntp_servers": schema.ListAttribute{
                         MarkdownDescription: "List of NTP server addresses for DHCP clients.",
                         Computed:            true,
                         ElementType:         types.StringType,

--- a/unifi/network_resource.go
+++ b/unifi/network_resource.go
@@ -689,7 +689,6 @@ func (r *networkResource) Schema(
                     		listvalidator.SizeAtMost(2),
                     		listvalidator.ValueStringsAre(
                     			stringvalidator.Any(
-                    				stringvalidator.OneOf(""),
                     				validators.IPv4Validator(),
                     				validators.IPv6Validator(),
                     			),

--- a/unifi/network_resource.go
+++ b/unifi/network_resource.go
@@ -117,6 +117,7 @@ type dhcpServerModel struct {
 	GatewayEnabled    types.Bool           `tfsdk:"gateway_enabled"`
 	ConflictChecking  types.Bool           `tfsdk:"conflict_checking"`
 	NtpEnabled        types.Bool           `tfsdk:"ntp_enabled"`
+	NtpServers        types.List           `tfsdk:"ntp_servers"`
 	TimeOffsetEnabled types.Bool           `tfsdk:"time_offset_enabled"`
 	DnsEnabled        types.Bool           `tfsdk:"dns_enabled"`
 	Leasetime         timetypes.GoDuration `tfsdk:"leasetime"`
@@ -136,6 +137,7 @@ func (m dhcpServerModel) AttributeTypes() map[string]attr.Type {
 		"gateway_enabled":     types.BoolType,
 		"conflict_checking":   types.BoolType,
 		"ntp_enabled":         types.BoolType,
+		"ntp_servers":         types.ListType{ElemType: types.StringType},
 		"time_offset_enabled": types.BoolType,
 		"dns_enabled":         types.BoolType,
 		"leasetime":           timetypes.GoDurationType{},
@@ -679,6 +681,21 @@ func (r *networkResource) Schema(
 						Computed:            true,
 						Default:             booldefault.StaticBool(false),
 					},
+                	"ntp_servers": schema.ListAttribute{
+                        MarkdownDescription: "List of NTP server addresses for DHCP clients.",
+                        Optional:            true,
+                        ElementType:         types.StringType,
+                        Validators: []validator.List{
+                    		listvalidator.SizeAtMost(2),
+                    		listvalidator.ValueStringsAre(
+                    			stringvalidator.Any(
+                    				stringvalidator.OneOf(""),
+                    				validators.IPv4Validator(),
+                    				validators.IPv6Validator(),
+                    			),
+                    		),
+                    	},
+                     },
 					"time_offset_enabled": schema.BoolAttribute{
 						MarkdownDescription: "Specifies whether DHCP time offset is enabled.",
 						Optional:            true,
@@ -1365,6 +1382,42 @@ func (r *networkResource) modelToNetwork(
 			network.DHCPDGatewayEnabled = dhcpServer.GatewayEnabled.ValueBool()
 			network.DHCPDConflictChecking = dhcpServer.ConflictChecking.ValueBool()
 			network.DHCPDNtpEnabled = dhcpServer.NtpEnabled.ValueBool()
+
+			// Handle NTP servers
+            if !dhcpServer.NtpServers.IsNull() && !dhcpServer.NtpServers.IsUnknown() {
+            	var ntpServers []string
+            	d := dhcpServer.NtpServers.ElementsAs(ctx, &ntpServers, false)
+            	diags.Append(d...)
+            	if !diags.HasError() {
+            		for i, ntp := range ntpServers {
+            			if i >= 2 {
+            				break
+            			}
+            			switch i {
+            			case 0:
+            				network.DHCPDNtp1 = util.Ptr(ntp)
+            			case 1:
+            				network.DHCPDNtp2 = util.Ptr(ntp)
+            			}
+            		}
+            		// Set remaining NTP servers to empty
+            		for i := len(ntpServers); i < 2; i++ {
+            			switch i {
+            			case 0:
+            				network.DHCPDNtp1 = util.Ptr("")
+            			case 1:
+            				network.DHCPDNtp2 = util.Ptr("")
+            			}
+            		}
+            	}
+            } else {
+            	// Set all NTP servers to empty string when not configured
+            	network.DHCPDNtp1 = util.Ptr("")
+            	network.DHCPDNtp2 = util.Ptr("")
+            }
+
+
+
 			network.DHCPDTimeOffsetEnabled = dhcpServer.TimeOffsetEnabled.ValueBool()
 			network.DHCPDDNSEnabled = dhcpServer.DnsEnabled.ValueBool()
 			network.DHCPDLeaseTime = util.DurationUnitsPtr(dhcpServer.Leasetime, time.Second)
@@ -1483,6 +1536,8 @@ func (r *networkResource) modelToNetwork(
 		network.DHCPDGatewayEnabled = false
 		network.DHCPDConflictChecking = true
 		network.DHCPDNtpEnabled = false
+		network.DHCPDNtp1 = util.Ptr("")
+        network.DHCPDNtp2 = util.Ptr("")
 		network.DHCPDTimeOffsetEnabled = false
 		network.DHCPDDNSEnabled = false
 		network.DHCPDLeaseTime = util.Ptr(int64(86400))
@@ -1853,6 +1908,23 @@ func (r *networkResource) networkToModel(
 			dnsServersList = types.ListNull(types.StringType)
 		}
 
+        // Build NTP servers list from DHCPDNtp1-2
+        var ntpServers []string
+        if network.DHCPDNtp1 != nil && *network.DHCPDNtp1 != "" {
+        	ntpServers = append(ntpServers, *network.DHCPDNtp1)
+        }
+        if network.DHCPDNtp2 != nil && *network.DHCPDNtp2 != "" {
+        	ntpServers = append(ntpServers, *network.DHCPDNtp2)
+        }
+
+        var ntpServersList types.List
+        if len(ntpServers) > 0 {
+        	ntpServersList, d = types.ListValueFrom(ctx, types.StringType, ntpServers)
+        	diags.Append(d...)
+        } else {
+        	ntpServersList = types.ListNull(types.StringType)
+        }
+
 		// Build WINS addresses list from DHCPDWins1-2
 		var winsAddresses []string
 		if network.DHCPDWins1 != nil && *network.DHCPDWins1 != "" {
@@ -1884,6 +1956,7 @@ func (r *networkResource) networkToModel(
 			GatewayEnabled:    types.BoolValue(network.DHCPDGatewayEnabled),
 			ConflictChecking:  types.BoolValue(network.DHCPDConflictChecking),
 			NtpEnabled:        types.BoolValue(network.DHCPDNtpEnabled),
+			NtpServers:        ntpServersList,
 			TimeOffsetEnabled: types.BoolValue(network.DHCPDTimeOffsetEnabled),
 			DnsEnabled:        types.BoolValue(network.DHCPDDNSEnabled),
 			Leasetime:         util.DurationPtrValue(network.DHCPDLeaseTime, time.Second),

--- a/unifi/network_resource.go
+++ b/unifi/network_resource.go
@@ -681,20 +681,20 @@ func (r *networkResource) Schema(
 						Computed:            true,
 						Default:             booldefault.StaticBool(false),
 					},
-                	"ntp_servers": schema.ListAttribute{
-                        MarkdownDescription: "List of NTP server addresses for DHCP clients.",
-                        Optional:            true,
-                        ElementType:         types.StringType,
-                        Validators: []validator.List{
-                    		listvalidator.SizeAtMost(2),
-                    		listvalidator.ValueStringsAre(
-                    			stringvalidator.Any(
-                    				validators.IPv4Validator(),
-                    				validators.IPv6Validator(),
-                    			),
-                    		),
-                    	},
-                     },
+					"ntp_servers": schema.ListAttribute{
+						MarkdownDescription: "List of NTP server addresses for DHCP clients.",
+						Optional:            true,
+						ElementType:         types.StringType,
+						Validators: []validator.List{
+							listvalidator.SizeAtMost(2),
+							listvalidator.ValueStringsAre(
+								stringvalidator.Any(
+									validators.IPv4Validator(),
+									validators.IPv6Validator(),
+								),
+							),
+						},
+					},
 					"time_offset_enabled": schema.BoolAttribute{
 						MarkdownDescription: "Specifies whether DHCP time offset is enabled.",
 						Optional:            true,
@@ -1383,39 +1383,37 @@ func (r *networkResource) modelToNetwork(
 			network.DHCPDNtpEnabled = dhcpServer.NtpEnabled.ValueBool()
 
 			// Handle NTP servers
-            if !dhcpServer.NtpServers.IsNull() && !dhcpServer.NtpServers.IsUnknown() {
-            	var ntpServers []string
-            	d := dhcpServer.NtpServers.ElementsAs(ctx, &ntpServers, false)
-            	diags.Append(d...)
-            	if !diags.HasError() {
-            		for i, ntp := range ntpServers {
-            			if i >= 2 {
-            				break
-            			}
-            			switch i {
-            			case 0:
-            				network.DHCPDNtp1 = util.Ptr(ntp)
-            			case 1:
-            				network.DHCPDNtp2 = util.Ptr(ntp)
-            			}
-            		}
-            		// Set remaining NTP servers to empty
-            		for i := len(ntpServers); i < 2; i++ {
-            			switch i {
-            			case 0:
-            				network.DHCPDNtp1 = util.Ptr("")
-            			case 1:
-            				network.DHCPDNtp2 = util.Ptr("")
-            			}
-            		}
-            	}
-            } else {
-            	// Set all NTP servers to empty string when not configured
-            	network.DHCPDNtp1 = util.Ptr("")
-            	network.DHCPDNtp2 = util.Ptr("")
-            }
-
-
+			if !dhcpServer.NtpServers.IsNull() && !dhcpServer.NtpServers.IsUnknown() {
+				var ntpServers []string
+				d := dhcpServer.NtpServers.ElementsAs(ctx, &ntpServers, false)
+				diags.Append(d...)
+				if !diags.HasError() {
+					for i, ntp := range ntpServers {
+						if i >= 2 {
+							break
+						}
+						switch i {
+						case 0:
+							network.DHCPDNtp1 = util.Ptr(ntp)
+						case 1:
+							network.DHCPDNtp2 = util.Ptr(ntp)
+						}
+					}
+					// Set remaining NTP servers to empty
+					for i := len(ntpServers); i < 2; i++ {
+						switch i {
+						case 0:
+							network.DHCPDNtp1 = util.Ptr("")
+						case 1:
+							network.DHCPDNtp2 = util.Ptr("")
+						}
+					}
+				}
+			} else {
+				// Set all NTP servers to empty string when not configured
+				network.DHCPDNtp1 = util.Ptr("")
+				network.DHCPDNtp2 = util.Ptr("")
+			}
 
 			network.DHCPDTimeOffsetEnabled = dhcpServer.TimeOffsetEnabled.ValueBool()
 			network.DHCPDDNSEnabled = dhcpServer.DnsEnabled.ValueBool()
@@ -1536,7 +1534,7 @@ func (r *networkResource) modelToNetwork(
 		network.DHCPDConflictChecking = true
 		network.DHCPDNtpEnabled = false
 		network.DHCPDNtp1 = util.Ptr("")
-        network.DHCPDNtp2 = util.Ptr("")
+		network.DHCPDNtp2 = util.Ptr("")
 		network.DHCPDTimeOffsetEnabled = false
 		network.DHCPDDNSEnabled = false
 		network.DHCPDLeaseTime = util.Ptr(int64(86400))
@@ -1907,22 +1905,22 @@ func (r *networkResource) networkToModel(
 			dnsServersList = types.ListNull(types.StringType)
 		}
 
-        // Build NTP servers list from DHCPDNtp1-2
-        var ntpServers []string
-        if network.DHCPDNtp1 != nil && *network.DHCPDNtp1 != "" {
-        	ntpServers = append(ntpServers, *network.DHCPDNtp1)
-        }
-        if network.DHCPDNtp2 != nil && *network.DHCPDNtp2 != "" {
-        	ntpServers = append(ntpServers, *network.DHCPDNtp2)
-        }
+		// Build NTP servers list from DHCPDNtp1-2
+		var ntpServers []string
+		if network.DHCPDNtp1 != nil && *network.DHCPDNtp1 != "" {
+			ntpServers = append(ntpServers, *network.DHCPDNtp1)
+		}
+		if network.DHCPDNtp2 != nil && *network.DHCPDNtp2 != "" {
+			ntpServers = append(ntpServers, *network.DHCPDNtp2)
+		}
 
-        var ntpServersList types.List
-        if len(ntpServers) > 0 {
-        	ntpServersList, d = types.ListValueFrom(ctx, types.StringType, ntpServers)
-        	diags.Append(d...)
-        } else {
-        	ntpServersList = types.ListNull(types.StringType)
-        }
+		var ntpServersList types.List
+		if len(ntpServers) > 0 {
+			ntpServersList, d = types.ListValueFrom(ctx, types.StringType, ntpServers)
+			diags.Append(d...)
+		} else {
+			ntpServersList = types.ListNull(types.StringType)
+		}
 
 		// Build WINS addresses list from DHCPDWins1-2
 		var winsAddresses []string

--- a/unifi/network_resource_test.go
+++ b/unifi/network_resource_test.go
@@ -11,11 +11,14 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	fwlist "github.com/hashicorp/terraform-plugin-framework/list"
 	fwresource "github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/querycheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 	"github.com/ubiquiti-community/go-unifi/unifi"
+	"github.com/ubiquiti-community/terraform-provider-unifi/unifi/validators"
 )
 
 func strPtr(s string) *string { return &s }
@@ -654,6 +657,7 @@ func Test_dhcpServerModel_AttributeTypes(t *testing.T) {
 				"gateway_enabled":     types.BoolType,
 				"conflict_checking":   types.BoolType,
 				"ntp_enabled":         types.BoolType,
+				"ntp_servers":         types.ListType{ElemType: types.StringType},
 				"time_offset_enabled": types.BoolType,
 				"dns_enabled":         types.BoolType,
 				"leasetime":           timetypes.GoDurationType{},

--- a/unifi/network_resource_test.go
+++ b/unifi/network_resource_test.go
@@ -11,14 +11,11 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	fwlist "github.com/hashicorp/terraform-plugin-framework/list"
 	fwresource "github.com/hashicorp/terraform-plugin-framework/resource"
-	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
-	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/querycheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 	"github.com/ubiquiti-community/go-unifi/unifi"
-	"github.com/ubiquiti-community/terraform-provider-unifi/unifi/validators"
 )
 
 func strPtr(s string) *string { return &s }


### PR DESCRIPTION
I added ntp_servers because without ntp_enabled was unusable. 

I'm not a go developer, therefore supported by Copilot with Claude Haike 4.5. 

I thought about creating an ACC test but I ended up for this simple field this would be overkill. 

Locally on my device not all ACC tests pass if I try to run them together but single executed all pass.   