### PR TITLE
fix(device): send port_overrides as [] not null for devices with none

### DIFF
--- a/unifi/device_resource.go
+++ b/unifi/device_resource.go
@@ -1654,6 +1654,13 @@ func buildMinimalUpdateDevice(
 	deviceReq, currentDevice *unifi.Device,
 	portOverrides []unifi.DevicePortOverrides,
 ) *unifi.Device {
+	// A nil slice marshals to `port_overrides: null`, which UDM/Dream Machine
+	// gateways reject with api.err.InvalidPayload (400). Force a non-nil empty
+	// slice so a device with no overrides at all (an access point, a gateway)
+	// sends `port_overrides: []` instead.
+	if portOverrides == nil {
+		portOverrides = []unifi.DevicePortOverrides{}
+	}
 	minimalDevice := &unifi.Device{
 		ID:                         deviceReq.ID,
 		Type:                       deviceReq.Type,

--- a/unifi/udm_update_fix_test.go
+++ b/unifi/udm_update_fix_test.go
@@ -1,6 +1,7 @@
 package unifi
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 
@@ -222,5 +223,32 @@ func TestBuildMinimalUpdateDevice_UsesProvidedPortOverrides(t *testing.T) {
 	}
 	if len(out.PortOverrides) != 1 {
 		t.Fatalf("expected 1 preserved override, got %d", len(out.PortOverrides))
+	}
+}
+
+// TestBuildMinimalUpdateDevice_EmptyOverridesMarshalAsArrayNotNull: a device
+// with no port overrides at all (an access point, a gateway) must send
+// `port_overrides: []`, never `null`, which UDM/Dream Machine gateways reject
+// with api.err.InvalidPayload (400).
+func TestBuildMinimalUpdateDevice_EmptyOverridesMarshalAsArrayNotNull(t *testing.T) {
+	req := &unifi.Device{ID: "x", MAC: "aa", MgmtNetworkID: "net99"}
+	current := &unifi.Device{} // no overrides, e.g. an access point
+
+	// No declared overrides and none on the device: updateDevice's fallback
+	// passes currentDevice.PortOverrides through, which is nil here.
+	out := buildMinimalUpdateDevice(req, current, current.PortOverrides)
+	if out.PortOverrides == nil {
+		t.Fatalf("port_overrides must be non-nil so it marshals to [] not null")
+	}
+
+	body, err := json.Marshal(out)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(body), `"port_overrides":null`) {
+		t.Fatalf("body must not contain port_overrides:null, got: %s", body)
+	}
+	if !strings.Contains(string(body), `"port_overrides":[]`) {
+		t.Fatalf("body must contain port_overrides:[], got: %s", body)
 	}
 }


### PR DESCRIPTION
 ## Problem
Updating a device that has no port overrides at all (an access point, a gateway) sends `port_overrides: null`. UDM/Dream Machine gateways reject it with `api.err.InvalidPayload (400)`.

This is the same failure class as #150/#177. PR #378 fixed it for devices that had overrides to echo back, but a device with none still produced a nil slice → `null`.

## Fix
Force a non-nil empty slice in `buildMinimalUpdateDevice`, so the body carries `port_overrides: []`, which the controller accepts.

## Why
An access point's `mgmt_network_id` (management VLAN) can't be set otherwise: an AP rejects a real port override (`api.err.Invalid`), so the only viable payload is `mgmt_network_id` + `port_overrides: []`.

## Verification
- New unit test asserting the body carries `port_overrides:[]`, never `null`.
- Existing #150/#177 tests still pass.
- End-to-end on a live UDR: raw `PUT` with `[]` to a U7 Pro → `rc:ok`; `tofu apply` then created the AP (mgmt VLAN 99) with no error.