### PR TITLE
feat(wlan): add bandsteering_mode for per-SSID band steering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### ✨ Features
+
+- **`unifi_wlan`: per-SSID band steering via the new `bandsteering_mode` attribute** (`off` | `equal` | `prefer_5g`). Modern controllers expose band steering on the wlanconf record, and on WiFi 6/7 access points this per-SSID control has replaced the legacy device-level one (still available as `unifi_device.bandsteering_mode`), so band steering was previously unmanageable on that hardware. Optional+Computed with value validation; the value is echoed from the controller on read, stays entirely off the wire when unset, and on controllers without per-SSID band steering (which accept and ignore the key) the declared value is kept in state instead of failing the apply with an inconsistent-result error. Requires go-unifi with `WLAN.BandsteeringMode` (go-unifi#72) (#388)
+
 ### 🐛 Bug Fixes
 
 - **`unifi_wlan`: creating a WLAN with `"6g"` in `wlan_bands` no longer fails with `Provider produced inconsistent result after apply`.** The provider marshals the full declared band list — `6g` included — on both create and update, but some controllers (observed on Network 10.4.x) silently drop `6g` from the initial create response while accepting the identical payload on a subsequent update; the reporter's manual workaround (create without `6g`, then add it) confirmed the asymmetry. `Create` now compares the controller's response against the requested band list and, when a band was dropped, immediately re-asserts the intended configuration with a single follow-up update — the created WLAN carries all declared bands in one `terraform apply`. If the controller refuses the band even then, the apply now fails with an actionable diagnostic (6GHz gating: WPA3/SAE with PMF, 6GHz-capable APs) instead of the cryptic consistency error, and the created WLAN is tracked in state as tainted rather than orphaned on the controller (#406)

--- a/docs/resources/wlan.md
+++ b/docs/resources/wlan.md
@@ -77,6 +77,7 @@ resource "unifi_wlan" "wifi" {
 
 - `ap_group_ids` (Set of String) List of AP group IDs to apply this WLAN to.
 - `ap_group_mode` (String) Access point group mode.
+- `bandsteering_mode` (String) Per-SSID band steering mode. Steers dual-band capable clients toward the less congested / higher-throughput band. Valid values are `off`, `equal` and `prefer_5g`. Requires a controller that exposes per-SSID band steering on the WLAN (Network 9/10.x; on WiFi 6/7 access points this replaces the legacy device-level control). Left unset, the controller default applies.
 - `bc_filter_list` (Set of String) List of MAC addresses for the broadcast filter. The controller may populate this on its own, so it is computed when unset.
 - `bss_transition` (Boolean) Improves client roaming by providing connection details of nearby APs.
 - `dtim_6e` (Number) DTIM period for the 6 GHz band (1-255). Only used when `dtim_mode` is `custom`. Computed from the controller when not set.

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/hashicorp/terraform-plugin-testing v1.16.0
 	github.com/testcontainers/testcontainers-go v0.44.0
 	github.com/testcontainers/testcontainers-go/modules/compose v0.44.0
-	github.com/ubiquiti-community/go-unifi v1.33.43-0.20260824040234-bbd37dd24ec5
+	github.com/ubiquiti-community/go-unifi v1.33.43-0.20260824085003-2a9f91a7ddf0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -535,8 +535,8 @@ github.com/transparency-dev/formats v0.1.1 h1:4bVHJc+KdBgpA1OJD1yjI+g0i5Z1graCpp
 github.com/transparency-dev/formats v0.1.1/go.mod h1:qtZ8goRuJ8FTBG9c9+Bj0rn2rUG7eG/AUTkr+Aw3jFw=
 github.com/transparency-dev/merkle v0.0.2 h1:Q9nBoQcZcgPamMkGn7ghV8XiTZ/kRxn1yCG81+twTK4=
 github.com/transparency-dev/merkle v0.0.2/go.mod h1:pqSy+OXefQ1EDUVmAJ8MUhHB9TXGuzVAT58PqBoHz1A=
-github.com/ubiquiti-community/go-unifi v1.33.43-0.20260824040234-bbd37dd24ec5 h1:ZrphydKXKinYBkIYqETfQW3JtWvEhw4L2M81DewcjKk=
-github.com/ubiquiti-community/go-unifi v1.33.43-0.20260824040234-bbd37dd24ec5/go.mod h1:Nnp+DsBAf+80/5BZnN7Id0t5HUuigZ+rwGlXRGrYkTM=
+github.com/ubiquiti-community/go-unifi v1.33.43-0.20260824085003-2a9f91a7ddf0 h1:JByzJ3dya0K3G1SqIhWdKqYRJ1dmRVu5MpK/09gKUrM=
+github.com/ubiquiti-community/go-unifi v1.33.43-0.20260824085003-2a9f91a7ddf0/go.mod h1:Nnp+DsBAf+80/5BZnN7Id0t5HUuigZ+rwGlXRGrYkTM=
 github.com/vbatts/tar-split v0.12.3 h1:Cd46rkGXI3Td4yrVNwU8ripbxFaQbmesqhjBUUYAJSw=
 github.com/vbatts/tar-split v0.12.3/go.mod h1:sQOc6OlqGCr7HkGx/IDBeKiTIvqhmj8KffNhEXG4Nq0=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=

--- a/unifi/wlan_resource.go
+++ b/unifi/wlan_resource.go
@@ -120,6 +120,7 @@ type wlanFrameworkResourceModel struct {
 	VLAN                        types.Int64  `tfsdk:"vlan"`
 	WLANBand                    types.String `tfsdk:"wlan_band"`
 	WLANBands                   types.Set    `tfsdk:"wlan_bands"`
+	BandsteeringMode            types.String `tfsdk:"bandsteering_mode"`
 	MulticastEnhance            types.Bool   `tfsdk:"multicast_enhance"`
 	MacFilter                   types.Object `tfsdk:"mac_filter"`
 	PrivatePresharedKeysEnabled types.Bool   `tfsdk:"private_preshared_keys_enabled"`
@@ -354,6 +355,19 @@ func (r *wlanFrameworkResource) Schema(
 				ElementType: types.StringType,
 				Validators: []validator.Set{
 					setvalidator.ValueStringsAre(stringvalidator.OneOf("2g", "5g", "6g")),
+				},
+			},
+			"bandsteering_mode": schema.StringAttribute{
+				MarkdownDescription: "Per-SSID band steering mode. Steers dual-band capable " +
+					"clients toward the less congested / higher-throughput band. Valid values " +
+					"are `off`, `equal` and `prefer_5g`. Requires a controller that exposes " +
+					"per-SSID band steering on the WLAN (Network 9/10.x; on WiFi 6/7 access " +
+					"points this replaces the legacy device-level control). Left unset, the " +
+					"controller default applies.",
+				Optional: true,
+				Computed: true,
+				Validators: []validator.String{
+					stringvalidator.OneOf("off", "equal", "prefer_5g"),
 				},
 			},
 			"multicast_enhance": schema.BoolAttribute{
@@ -1320,6 +1334,9 @@ func (r *wlanFrameworkResource) applyPlanToState(
 	if !plan.WLANBands.IsNull() && !plan.WLANBands.IsUnknown() {
 		state.WLANBands = plan.WLANBands
 	}
+	if !plan.BandsteeringMode.IsNull() && !plan.BandsteeringMode.IsUnknown() {
+		state.BandsteeringMode = plan.BandsteeringMode
+	}
 	if !plan.MulticastEnhance.IsNull() && !plan.MulticastEnhance.IsUnknown() {
 		state.MulticastEnhance = plan.MulticastEnhance
 	}
@@ -1526,30 +1543,33 @@ func (r *wlanFrameworkResource) planToWLAN(
 	var diags diag.Diagnostics
 
 	wlan := &unifi.WLAN{
-		ID:                       plan.ID.ValueString(),
-		Name:                     plan.Name.ValueString(),
-		NetworkID:                plan.NetworkID.ValueString(),
-		UserGroupID:              plan.UserGroupID.ValueString(),
-		Security:                 plan.Security.ValueString(),
-		WPA3Support:              plan.WPA3Support.ValueBool(),
-		WPA3Transition:           plan.WPA3Transition.ValueBool(),
-		PMFMode:                  plan.PMFMode.ValueString(),
-		Passphrase:               plan.Passphrase.ValueString(),
-		HideSSID:                 plan.HideSSID.ValueBool(),
-		IsGuest:                  plan.IsGuest.ValueBool(),
-		Enabled:                  plan.Enabled.ValueBool(),
-		ApGroupMode:              plan.ApGroupMode.ValueString(),
-		VLANEnabled:              plan.VLANEnabled.ValueBool(),
-		VLAN:                     plan.VLAN.ValueInt64Pointer(),
-		MulticastEnhanceEnabled:  plan.MulticastEnhance.ValueBool(),
-		RADIUSProfileID:          plan.RadiusProfileID.ValueString(),
-		NasIDentifierType:        plan.NasIDentifierType.ValueString(),
-		No2GhzOui:                plan.No2GhzOui.ValueBool(),
-		L2Isolation:              plan.L2Isolation.ValueBool(),
-		ProxyArp:                 plan.ProxyArp.ValueBool(),
-		BssTransition:            plan.BssTransition.ValueBool(),
-		UapsdEnabled:             plan.Uapsd.ValueBool(),
-		FastRoamingEnabled:       plan.FastRoamingEnabled.ValueBool(),
+		ID:                      plan.ID.ValueString(),
+		Name:                    plan.Name.ValueString(),
+		NetworkID:               plan.NetworkID.ValueString(),
+		UserGroupID:             plan.UserGroupID.ValueString(),
+		Security:                plan.Security.ValueString(),
+		WPA3Support:             plan.WPA3Support.ValueBool(),
+		WPA3Transition:          plan.WPA3Transition.ValueBool(),
+		PMFMode:                 plan.PMFMode.ValueString(),
+		Passphrase:              plan.Passphrase.ValueString(),
+		HideSSID:                plan.HideSSID.ValueBool(),
+		IsGuest:                 plan.IsGuest.ValueBool(),
+		Enabled:                 plan.Enabled.ValueBool(),
+		ApGroupMode:             plan.ApGroupMode.ValueString(),
+		VLANEnabled:             plan.VLANEnabled.ValueBool(),
+		VLAN:                    plan.VLAN.ValueInt64Pointer(),
+		MulticastEnhanceEnabled: plan.MulticastEnhance.ValueBool(),
+		RADIUSProfileID:         plan.RadiusProfileID.ValueString(),
+		NasIDentifierType:       plan.NasIDentifierType.ValueString(),
+		No2GhzOui:               plan.No2GhzOui.ValueBool(),
+		L2Isolation:             plan.L2Isolation.ValueBool(),
+		ProxyArp:                plan.ProxyArp.ValueBool(),
+		BssTransition:           plan.BssTransition.ValueBool(),
+		UapsdEnabled:            plan.Uapsd.ValueBool(),
+		FastRoamingEnabled:      plan.FastRoamingEnabled.ValueBool(),
+		// Unknown/null → "" → omitempty keeps it off the wire, so controllers
+		// without per-SSID band steering are never sent the key (#388).
+		BandsteeringMode:         plan.BandsteeringMode.ValueString(),
 		MinrateSettingPreference: plan.MinrateSettingPreference.ValueString(),
 		MinrateNgEnabled:         plan.MinimumDataRate2GKbps.ValueInt64() > 0,
 		MinrateNgDataRateKbps:    plan.MinimumDataRate2GKbps.ValueInt64Pointer(),
@@ -1831,6 +1851,18 @@ func (r *wlanFrameworkResource) wlanToModel(
 		model.WLANBand = types.StringValue(wlan.WLANBand)
 	} else {
 		model.WLANBand = types.StringValue("both")
+	}
+
+	// Per-SSID band steering (#388). Controllers without the feature never
+	// echo the key: keep the model's existing value in that case — the
+	// declared value on create/update, the prior state on read — so a config
+	// on an unsupporting controller doesn't fail the apply with an
+	// inconsistent-result error or produce perpetual drift. An Unknown value
+	// (never configured, nothing stored) resolves to null.
+	if wlan.BandsteeringMode != "" {
+		model.BandsteeringMode = types.StringValue(wlan.BandsteeringMode)
+	} else if model.BandsteeringMode.IsUnknown() {
+		model.BandsteeringMode = types.StringNull()
 	}
 
 	model.MulticastEnhance = types.BoolValue(wlan.MulticastEnhanceEnabled)

--- a/unifi/wlan_resource_test.go
+++ b/unifi/wlan_resource_test.go
@@ -11,6 +11,7 @@ import (
 	"net/http/cookiejar"
 	"os"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
@@ -1198,4 +1199,163 @@ func Test_reassertWLANBands(t *testing.T) {
 			t.Errorf("result = %+v, want the create response", got)
 		}
 	})
+}
+
+// ---------------------------------------------------------------------------
+// #388: per-SSID band steering (bandsteering_mode)
+// ---------------------------------------------------------------------------
+
+// Test_planToWLAN_bandsteeringMode verifies the write path for #388: a
+// declared value travels to the controller, and an unset (null or unknown)
+// value stays off the wire entirely — controllers without per-SSID band
+// steering must never be sent the key.
+func Test_planToWLAN_bandsteeringMode(t *testing.T) {
+	ctx := context.Background()
+	r := &wlanFrameworkResource{}
+
+	t.Run("declared value is sent", func(t *testing.T) {
+		plan := wlanFrameworkResourceModel{
+			Name:             types.StringValue("w"),
+			BandsteeringMode: types.StringValue("prefer_5g"),
+		}
+		wlan, diags := r.planToWLAN(ctx, plan)
+		if diags.HasError() {
+			t.Fatalf("planToWLAN: %v", diags)
+		}
+		if wlan.BandsteeringMode != "prefer_5g" {
+			t.Errorf("BandsteeringMode = %q, want prefer_5g", wlan.BandsteeringMode)
+		}
+		raw, err := json.Marshal(wlan)
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		if !strings.Contains(string(raw), `"bandsteering_mode":"prefer_5g"`) {
+			t.Errorf("payload missing bandsteering_mode: %s", raw)
+		}
+	})
+
+	for name, value := range map[string]types.String{
+		"null stays off the wire":    types.StringNull(),
+		"unknown stays off the wire": types.StringUnknown(),
+	} {
+		t.Run(name, func(t *testing.T) {
+			plan := wlanFrameworkResourceModel{
+				Name:             types.StringValue("w"),
+				BandsteeringMode: value,
+			}
+			wlan, diags := r.planToWLAN(ctx, plan)
+			if diags.HasError() {
+				t.Fatalf("planToWLAN: %v", diags)
+			}
+			raw, err := json.Marshal(wlan)
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			if strings.Contains(string(raw), "bandsteering_mode") {
+				t.Errorf("unset bandsteering_mode leaked into payload: %s", raw)
+			}
+		})
+	}
+}
+
+// Test_wlanToModel_bandsteeringMode verifies the read path for #388:
+// controller echo wins; a missing key keeps the model's existing value (the
+// declared value on create/update, prior state on read) so controllers
+// without per-SSID band steering neither fail the apply with an
+// inconsistent-result error nor produce perpetual drift; and Unknown resolves
+// to null when the controller has nothing stored.
+func Test_wlanToModel_bandsteeringMode(t *testing.T) {
+	ctx := context.Background()
+	r := &wlanFrameworkResource{}
+
+	t.Run("controller echo wins", func(t *testing.T) {
+		model := wlanFrameworkResourceModel{BandsteeringMode: types.StringValue("off")}
+		wlan := &unifi.WLAN{ID: "id", Name: "w", BandsteeringMode: "equal"}
+		if diags := r.wlanToModel(ctx, wlan, &model, "default"); diags.HasError() {
+			t.Fatalf("wlanToModel: %v", diags)
+		}
+		if model.BandsteeringMode.ValueString() != "equal" {
+			t.Errorf("BandsteeringMode = %v, want controller echo equal", model.BandsteeringMode)
+		}
+	})
+
+	t.Run("missing key keeps the declared value", func(t *testing.T) {
+		model := wlanFrameworkResourceModel{BandsteeringMode: types.StringValue("prefer_5g")}
+		wlan := &unifi.WLAN{ID: "id", Name: "w"}
+		if diags := r.wlanToModel(ctx, wlan, &model, "default"); diags.HasError() {
+			t.Fatalf("wlanToModel: %v", diags)
+		}
+		if model.BandsteeringMode.ValueString() != "prefer_5g" {
+			t.Errorf("BandsteeringMode = %v, want declared prefer_5g kept", model.BandsteeringMode)
+		}
+	})
+
+	t.Run("missing key resolves unknown to null", func(t *testing.T) {
+		model := wlanFrameworkResourceModel{BandsteeringMode: types.StringUnknown()}
+		wlan := &unifi.WLAN{ID: "id", Name: "w"}
+		if diags := r.wlanToModel(ctx, wlan, &model, "default"); diags.HasError() {
+			t.Fatalf("wlanToModel: %v", diags)
+		}
+		if !model.BandsteeringMode.IsNull() {
+			t.Errorf("BandsteeringMode = %v, want null", model.BandsteeringMode)
+		}
+	})
+}
+
+// TestAccWLANFramework_bandsteeringMode exercises #388 end to end against the
+// demo controller. This controller does not persist wlanconf
+// bandsteering_mode (it accepts and ignores the key — the same shape as any
+// controller without per-SSID band steering), so this test pins the graceful
+// path: the declared value applies cleanly, is kept in state, and can be
+// changed in place. The controller-echo path is covered by
+// Test_wlanToModel_bandsteeringMode.
+func TestAccWLANFramework_bandsteeringMode(t *testing.T) {
+	if os.Getenv("TF_ACC") == "" {
+		t.Skip("TF_ACC not set, skipping acceptance test")
+	}
+
+	userGroupID := testAccWLANDefaultUserGroupID(t)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { preCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccWLANFrameworkConfig_bandsteering(userGroupID, "prefer_5g"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"unifi_wlan.test_bs", "bandsteering_mode", "prefer_5g"),
+				),
+			},
+			{
+				Config: testAccWLANFrameworkConfig_bandsteering(userGroupID, "equal"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"unifi_wlan.test_bs", "bandsteering_mode", "equal"),
+				),
+			},
+		},
+	})
+}
+
+func testAccWLANFrameworkConfig_bandsteering(userGroupID, mode string) string {
+	return fmt.Sprintf(`
+data "unifi_ap_group" "default" {
+	name = "All APs"
+}
+
+data "unifi_network" "default" {
+	name = "Default"
+}
+
+resource "unifi_wlan" "test_bs" {
+	name              = "tfacc-wlan-bandsteer"
+	security          = "wpapsk"
+	passphrase        = "pwd12345678"
+	user_group_id     = %q
+	network_id        = data.unifi_network.default.id
+	ap_group_ids      = [data.unifi_ap_group.default.id]
+	bandsteering_mode = %q
+}
+`, userGroupID, mode)
 }


### PR DESCRIPTION
Fixes #388

## Background

Modern controllers (Network 9/10.x) expose band steering per SSID as `bandsteering_mode` on the wlanconf record (`off` | `equal` | `prefer_5g`). On WiFi 6/7 access points (the reporter's UDR7) this per-SSID control has **replaced** the legacy device-level control that `unifi_device.bandsteering_mode` maps to, so band steering was completely unmanageable through the provider on current hardware: the go-unifi `WLAN` model had no field for it, and the value silently round-tripped as null.

## Changes

- **go-unifi**: `WLAN.BandsteeringMode` (`json:"bandsteering_mode,omitempty"`) added upstream in ubiquiti-community/go-unifi#72 (merged as `2a9f91a`), mirroring the existing `Device.BandsteeringMode`; this repo's dependency bumped to `v1.33.43-0.20260824085003-2a9f91a7ddf0`.
- **Schema**: `bandsteering_mode` on `unifi_wlan` — Optional + Computed, `stringvalidator.OneOf("off", "equal", "prefer_5g")`, no default (left unset, nothing is sent and the controller default applies — no plan churn for existing states).
- **Write path** (`planToWLAN`): unset (null/unknown) marshals to `""` and `omitempty` keeps the key off the wire, so controllers without per-SSID band steering are never sent it.
- **Read path** (`wlanToModel`): controller echo wins; when the controller doesn't echo the key — controllers without the feature accept and ignore it, as verified empirically against the demo controller — the model's existing value is kept (declared value on create/update, prior state on read), so such controllers neither fail the apply with an inconsistent-result error nor produce perpetual drift. Unknown resolves to null.
- **Update path** (`applyPlanToState`): standard plan-onto-state passthrough, same as every other attribute in the file.
- **Docs**: regenerated with `go generate` (tfplugindocs); `docs/resources/wlan.md` picks up the attribute.

## Test evidence

- `TestAccWLANFramework_bandsteeringMode` (new): create with `prefer_5g`, in-place change to `equal` — PASS against the demo controller. Note: the demo controller accepts but does **not** persist wlanconf `bandsteering_mode` (verified by direct API probing), so this acceptance test pins the graceful accept-and-ignore path; the controller-echo path is pinned by `Test_wlanToModel_bandsteeringMode`.
- New unit tests: `Test_planToWLAN_bandsteeringMode` (declared value sent; null/unknown stay off the wire — payload-marshaling asserted) and `Test_wlanToModel_bandsteeringMode` (echo wins / missing key keeps declared value / unknown resolves to null).
- Full WLAN acceptance suite (`TestAccWLANFramework_*`, 5 tests) — PASS.
- Full unit suite green, `golangci-lint run ./unifi/...` → 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)