### PR TITLE
docs: fix leaked template artifact in generated import sections

### DIFF
--- a/docs/resources/ap_group.md
+++ b/docs/resources/ap_group.md
@@ -59,7 +59,7 @@ Optional:
 
 Import is supported using the following syntax:
 
-The [` + "`" + `terraform import` + "`" + ` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
 
 ```shell
 # AP groups can be imported using the group ID, or site:id for a non-default site.

--- a/docs/resources/client_qos_rate.md
+++ b/docs/resources/client_qos_rate.md
@@ -64,7 +64,7 @@ Optional:
 
 Import is supported using the following syntax:
 
-The [` + "`" + `terraform import` + "`" + ` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
 
 ```shell
 # import using the ID

--- a/docs/resources/firewall_policy.md
+++ b/docs/resources/firewall_policy.md
@@ -277,7 +277,7 @@ Optional:
 
 Import is supported using the following syntax:
 
-The [` + "`" + `terraform import` + "`" + ` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
 
 ```shell
 # Firewall policies can be imported using the policy ID, or site:id for a non-default site.

--- a/docs/resources/firewall_rule.md
+++ b/docs/resources/firewall_rule.md
@@ -170,7 +170,7 @@ Optional:
 
 Import is supported using the following syntax:
 
-The [` + "`" + `terraform import` + "`" + ` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
 
 ```shell
 # import using the ID from the controller API/UI

--- a/docs/resources/firewall_zone.md
+++ b/docs/resources/firewall_zone.md
@@ -90,7 +90,7 @@ Optional:
 
 Import is supported using the following syntax:
 
-The [` + "`" + `terraform import` + "`" + ` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
 
 ```shell
 # Firewall zones can be imported using the zone ID, or site:id for a non-default site.

--- a/docs/resources/network.md
+++ b/docs/resources/network.md
@@ -231,7 +231,7 @@ Optional:
 
 Import is supported using the following syntax:
 
-The [` + "`" + `terraform import` + "`" + ` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
 
 ```shell
 # import by ID from provider configured site

--- a/docs/resources/port_forward.md
+++ b/docs/resources/port_forward.md
@@ -179,7 +179,7 @@ Optional:
 
 Import is supported using the following syntax:
 
-The [` + "`" + `terraform import` + "`" + ` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
 
 ```shell
 # import from provider configured site

--- a/docs/resources/power_supervisor.md
+++ b/docs/resources/power_supervisor.md
@@ -72,7 +72,7 @@ Read-Only:
 
 Import is supported using the following syntax:
 
-The [` + "`" + `terraform import` + "`" + ` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
 
 ```shell
 # Power supervisors can be imported by the supervised device's MAC address,

--- a/docs/resources/radius_profile.md
+++ b/docs/resources/radius_profile.md
@@ -124,7 +124,7 @@ Optional:
 
 Import is supported using the following syntax:
 
-The [` + "`" + `terraform import` + "`" + ` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
 
 ```shell
 # RADIUS profiles can be imported using the ID, e.g.

--- a/docs/resources/radius_user.md
+++ b/docs/resources/radius_user.md
@@ -90,7 +90,7 @@ Optional:
 
 Import is supported using the following syntax:
 
-The [` + "`" + `terraform import` + "`" + ` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
 
 ```shell
 # RADIUS users can be imported using the ID, e.g.

--- a/docs/resources/site.md
+++ b/docs/resources/site.md
@@ -47,7 +47,7 @@ Optional:
 
 Import is supported using the following syntax:
 
-The [` + "`" + `terraform import` + "`" + ` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
 
 ```shell
 # Import using the site's 24-hex controller id (the `_id` from

--- a/docs/resources/site_to_site_vpn.md
+++ b/docs/resources/site_to_site_vpn.md
@@ -103,7 +103,7 @@ Optional:
 
 Import is supported using the following syntax:
 
-The [` + "`" + `terraform import` + "`" + ` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
 
 ```shell
 # Site-to-site VPN networks can be imported using the network ID (the pre-shared

--- a/docs/resources/traffic_route.md
+++ b/docs/resources/traffic_route.md
@@ -179,7 +179,7 @@ Optional:
 
 Import is supported using the following syntax:
 
-The [` + "`" + `terraform import` + "`" + ` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
 
 ```shell
 # import from provider configured site

--- a/docs/resources/vpn_client.md
+++ b/docs/resources/vpn_client.md
@@ -170,7 +170,7 @@ Optional:
 
 Import is supported using the following syntax:
 
-The [` + "`" + `terraform import` + "`" + ` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
 
 ```shell
 # Import a VPN client by ID

--- a/docs/resources/vpn_server.md
+++ b/docs/resources/vpn_server.md
@@ -192,7 +192,7 @@ Read-Only:
 
 Import is supported using the following syntax:
 
-The [` + "`" + `terraform import` + "`" + ` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
 
 ```shell
 # VPN servers can be imported by their 24-character hex network ID:

--- a/docs/resources/wan.md
+++ b/docs/resources/wan.md
@@ -250,7 +250,7 @@ Optional:
 
 Import is supported using the following syntax:
 
-The [` + "`" + `terraform import` + "`" + ` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
 
 ```shell
 # import from provider configured site

--- a/docs/resources/wireguard_peer.md
+++ b/docs/resources/wireguard_peer.md
@@ -63,7 +63,7 @@ Optional:
 
 Import is supported using the following syntax:
 
-The [` + "`" + `terraform import` + "`" + ` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
 
 ```shell
 # import by network ID and peer ID from provider configured site

--- a/docs/resources/wlan.md
+++ b/docs/resources/wlan.md
@@ -180,7 +180,7 @@ Optional:
 
 Import is supported using the following syntax:
 
-The [` + "`" + `terraform import` + "`" + ` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
 
 ```shell
 # import from provider configured site

--- a/templates/resources.md.tmpl
+++ b/templates/resources.md.tmpl
@@ -27,7 +27,7 @@ Import is supported using the following syntax:
 {{- end }}
 {{- if .HasImportIdentityConfig }}
 
-In Terraform v1.12.0 and later, the [` + "`" + `import` + "`" + ` block](https://developer.hashicorp.com/terraform/language/import) can be used with the ` + "`" + `identity` + "`" + ` attribute, for example:
+In Terraform v1.12.0 and later, the [`import` block](https://developer.hashicorp.com/terraform/language/import) can be used with the `identity` attribute, for example:
 
 {{tffile .ImportIdentityConfigFile }}
 
@@ -35,13 +35,13 @@ In Terraform v1.12.0 and later, the [` + "`" + `import` + "`" + ` block](https:/
 {{- end }}
 {{- if .HasImportIDConfig }}
 
-In Terraform v1.5.0 and later, the [` + "`" + `import` + "`" + ` block](https://developer.hashicorp.com/terraform/language/import) can be used with the ` + "`" + `id` + "`" + ` attribute, for example:
+In Terraform v1.5.0 and later, the [`import` block](https://developer.hashicorp.com/terraform/language/import) can be used with the `id` attribute, for example:
 
 {{tffile .ImportIDConfigFile }}
 {{- end }}
 {{- if .HasImport }}
 
-The [` + "`" + `terraform import` + "`" + ` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
 
 {{codefile "shell" .ImportFile }}
 {{- end }}


### PR DESCRIPTION
The shared resource docs template contained literal Go string-concatenation syntax (` + "`" + `) pasted from a Go source string, which rendered verbatim into the Import section of every generated resource page. This replaces the sequences with plain backticks and regenerates the affected docs (19 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)