### PR TITLE
fix(port_profile): keep an explicitly empty port_security_mac_address

### DIFF
--- a/unifi/port_profile_mac_allowlist_test.go
+++ b/unifi/port_profile_mac_allowlist_test.go
@@ -1,0 +1,62 @@
+package unifi
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/ubiquiti-community/go-unifi/unifi"
+)
+
+// Port security with an empty allowlist is how the controller stores a port whose
+// Port State is Disabled: security is on and no MAC may pass. A configuration that
+// asks for that has to survive the read, or Create and Update both fail with
+// "provider produced inconsistent result after apply".
+//
+// Unit rather than acceptance test: the conversion is what regresses, and it needs
+// no controller.
+func TestPortProfileEmptyMacAllowlistIsPreserved(t *testing.T) {
+	ctx := context.Background()
+	r := &portProfileResource{}
+
+	emptySet, d := types.SetValueFrom(ctx, types.StringType, []string{})
+	if d.HasError() {
+		t.Fatalf("building the empty set: %v", d)
+	}
+
+	tests := []struct {
+		name     string
+		inModel  types.Set
+		fromAPI  []string
+		wantNull bool
+		wantLen  int
+	}{
+		{"explicit empty is kept", emptySet, nil, false, 0},
+		{"unset stays null", types.SetNull(types.StringType), nil, true, 0},
+		{"api addresses are adopted", types.SetNull(types.StringType), []string{"aa:bb:cc:dd:ee:ff"}, false, 1},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			model := &portProfileResourceModel{
+				Name:                   types.StringValue("test"),
+				PortSecurityMacAddress: tc.inModel,
+			}
+			api := &unifi.PortProfile{
+				Name:                   "test",
+				PortSecurityEnabled:    true,
+				PortSecurityMACAddress: tc.fromAPI,
+			}
+			if d := r.portProfileToModel(ctx, api, model, "default"); d.HasError() {
+				t.Fatalf("conversion: %v", d)
+			}
+			got := model.PortSecurityMacAddress
+			if got.IsNull() != tc.wantNull {
+				t.Fatalf("port_security_mac_address null = %v, want %v", got.IsNull(), tc.wantNull)
+			}
+			if !tc.wantNull && len(got.Elements()) != tc.wantLen {
+				t.Errorf("port_security_mac_address has %d elements, want %d", len(got.Elements()), tc.wantLen)
+			}
+		})
+	}
+}

--- a/unifi/port_profile_resource.go
+++ b/unifi/port_profile_resource.go
@@ -1075,10 +1075,12 @@ func (r *portProfileResource) portProfileToModel(
 
 	model.PortSecurityEnabled = types.BoolValue(portProfile.PortSecurityEnabled)
 
-	// Convert port security MAC addresses
-	if len(portProfile.PortSecurityMACAddress) == 0 {
-		model.PortSecurityMacAddress = types.SetNull(types.StringType)
-	} else {
+	// An empty allowlist with port security on is how the controller stores a disabled port, so an
+	// explicitly empty set is meaningful and nulling it fails the apply as an inconsistent result.
+	macExplicitlyEmpty := !model.PortSecurityMacAddress.IsNull() &&
+		!model.PortSecurityMacAddress.IsUnknown() &&
+		len(model.PortSecurityMacAddress.Elements()) == 0
+	if len(portProfile.PortSecurityMACAddress) > 0 {
 		macAddressList := make([]types.String, len(portProfile.PortSecurityMACAddress))
 		for i, mac := range portProfile.PortSecurityMACAddress {
 			macAddressList[i] = types.StringValue(mac)
@@ -1086,6 +1088,8 @@ func (r *portProfileResource) portProfileToModel(
 		macAddressSet, d := types.SetValueFrom(ctx, types.StringType, macAddressList)
 		diags.Append(d...)
 		model.PortSecurityMacAddress = macAddressSet
+	} else if !macExplicitlyEmpty {
+		model.PortSecurityMacAddress = types.SetNull(types.StringType)
 	}
 
 	// Only set speed if it was in the plan or if it's non-zero


### PR DESCRIPTION
## Description

A port profile whose Port State is Disabled is stored by the controller as port security enabled with an
empty MAC allowlist, so no device may pass. `unifi_port_profile` cannot express that today: the read turns
an empty allowlist into null whenever the API reports no addresses, so the value the configuration asked
for cannot be held in state, and both create and update end with:

```text
Error: Provider produced inconsistent result after apply

When applying changes to unifi_port_profile.disabled, provider ... produced an unexpected
new value: .port_security_mac_address: was cty.SetValEmpty(cty.String), but now null.
```

The controller accepted the write. Only the model conversion is wrong.

### Reproducer

```hcl
resource "unifi_port_profile" "disabled" {
  name = "Disabled"

  port_security_enabled     = true
  port_security_mac_address = []

  forward               = "disabled"
  tagged_vlan_mgmt      = "block_all"
  native_networkconf_id = ""
  poe_mode              = "off"
  setting_preference    = "manual"
}
```

### Cause

In `portProfileToModel`:

```go
	if len(portProfile.PortSecurityMACAddress) == 0 {
		model.PortSecurityMacAddress = types.SetNull(types.StringType)
	}
```

An empty allowlist and an absent allowlist are not the same thing here, because emptiness is what carries
the meaning.

## Change

An empty set is preserved when the configuration set one, and an unset attribute still reads as null. This
is the same distinction `main` already makes for `native_networkconf_id`, which is no longer nulled on read
after the go-unifi serialization change.

## Test

`unifi/port_profile_mac_allowlist_test.go` covers the three cases: an explicit empty set survives, an unset
attribute stays null, and addresses reported by the API are adopted. On unfixed source the first fails:

```text
--- FAIL: TestPortProfileEmptyMacAllowlistIsPreserved/explicit_empty_is_kept
    port_security_mac_address null = true, want false
```

## Verification against a real controller

Applied against UniFi Network 10.5.67 through the Cloud Connector. The apply completes, a following plan
reports no changes, and the stored object is identical to what the UI writes when the Port State radio is
set to Disabled, field for field.

For anyone else chasing this: the Port State radio is `port_security_enabled` with an empty allowlist.
`forward = "disabled"` alone does not disable a port. A profile carrying `forward` disabled, `block_all`
and no native network still renders as Active until port security is on.

## Note on building `main`

`main` does not currently compile, before any change of mine, against its pinned go-unifi `v1.34.0` or
against go-unifi `main`:

```text
unifi/setting_resource.go:3466: undefined: settings.SettingIpsSuppression
unifi/device_resource.go:3112: radio.AssistedRoamingEnabled undefined
unifi/network_resource.go:1446: cannot use dns (variable of type string) as *string value
```

The change and its test were therefore verified on the `v0.55.0` tag, where the package builds, and the
diff is identical on both bases. Happy to rebase if/when needed.

## Environment

| Component | Detail |
| --- | --- |
| Provider | 0.55.0, plus this change |
| OpenTofu | 1.12.6 |
| UniFi Network | 10.5.67 (`atag_10.5.67_35187`) |
| Hardware | UDM Pro, UniFi OS 5.1.31 |
| Connection | Cloud Connector (`api.ui.com`) |
