### PR TITLE
fix(firewall-policy): refresh controller-assigned index

### DIFF
--- a/unifi/firewall_policy_resource.go
+++ b/unifi/firewall_policy_resource.go
@@ -21,7 +21,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/identityschema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
@@ -428,9 +427,6 @@ func (r *firewallPolicyResource) Schema(
 					"exposes no reorder operation, so policy ordering cannot be managed through " +
 					"this provider. Reorder policies in the UniFi UI if needed.",
 				Computed: true,
-				PlanModifiers: []planmodifier.Int64{
-					int64planmodifier.UseStateForUnknown(),
-				},
 			},
 			"create_allow_respond": schema.BoolAttribute{
 				MarkdownDescription: "When `true`, UniFi automatically creates a matching rule to allow established/related return traffic. Recommended for `ALLOW` policies. Defaults to `false`.",

--- a/unifi/firewall_policy_resource_test.go
+++ b/unifi/firewall_policy_resource_test.go
@@ -660,6 +660,34 @@ func TestFirewallPolicyConnectionStatesSettable(t *testing.T) {
 	}
 }
 
+// TestFirewallPolicyIndexDoesNotUseStateForUnknown guards the case where UniFi
+// renumbers sibling firewall policies during the same apply. The index is
+// controller-assigned, so an update plan must not preserve the prior index and
+// then reject the controller's refreshed value after apply.
+func TestFirewallPolicyIndexDoesNotUseStateForUnknown(t *testing.T) {
+	r := &firewallPolicyResource{}
+	resp := &fwresource.SchemaResponse{}
+	r.Schema(context.Background(), fwresource.SchemaRequest{}, resp)
+
+	attr, ok := resp.Schema.Attributes["index"]
+	if !ok {
+		t.Fatal("Schema missing index attribute")
+	}
+	indexAttr, ok := attr.(schema.Int64Attribute)
+	if !ok {
+		t.Fatalf("index attribute type = %T, want schema.Int64Attribute", attr)
+	}
+	if !indexAttr.IsComputed() {
+		t.Error("index must stay Computed")
+	}
+	if indexAttr.IsOptional() {
+		t.Error("index must stay read-only")
+	}
+	if len(indexAttr.PlanModifiers) != 0 {
+		t.Fatalf("index PlanModifiers = %d, want 0", len(indexAttr.PlanModifiers))
+	}
+}
+
 func Test_firewallPolicyResource_Configure(t *testing.T) {
 	type args struct {
 		ctx  context.Context


### PR DESCRIPTION
## Summary

- remove `UseStateForUnknown` from the computed-only `unifi_firewall_policy.index` attribute
- keep `index` read-only and controller-assigned
- add a regression test ensuring `index` has no plan modifiers

## Problem

PR #349 correctly made `index` computed-only because UniFi owns firewall policy ordering and does not honor per-policy `index` writes. However, keeping `UseStateForUnknown` can still preserve a stale prior index during an update plan.

When sibling firewall policies are deleted in the same apply, UniFi can renumber the remaining policies. If another policy is updated during that apply, Terraform may expect the previous computed index while the controller returns the refreshed index, causing:

```text
Error: Provider produced inconsistent result after apply
.index: was cty.NumberIntVal(...), but now cty.NumberIntVal(...)
```

Since `index` is read-only/controller-assigned, the provider should allow the post-apply read to refresh it rather than preserving prior state in the plan.

## Verification

- `go test ./... -count=1`
- `go build ./...`
- Tested against a real UniFi controller using Terraform CI:
  - create two disabled firewall policies
  - apply succeeded
  - delete one disabled policy and update the sibling disabled policy in the same apply
  - apply succeeded without the previous `.index` inconsistent-result error
  - remove final disabled test policy
  - cleanup apply succeeded

Closes the remaining computed-index variant of #348.