### PR TITLE
fix(network): collapse duplicate DHCP NTP servers

### DIFF
--- a/unifi/network_data_source.go
+++ b/unifi/network_data_source.go
@@ -705,7 +705,7 @@ func (d *networkDataSource) setDataSourceData(
 		winsObj, d := types.ObjectValueFrom(ctx, winsValue.AttributeTypes(), winsValue)
 		diags.Append(d...)
 
-		ntpServers := collectNonEmptyStringPointers(network.DHCPDNtp1, network.DHCPDNtp2)
+		ntpServers := uniqueStrings(collectNonEmptyStringPointers(network.DHCPDNtp1, network.DHCPDNtp2))
 		var ntpServersList types.List
 		if len(ntpServers) > 0 {
 			ntpServersList, d = types.ListValueFrom(ctx, types.StringType, ntpServers)
@@ -864,4 +864,21 @@ func collectNonEmptyStringPointers(ptrs ...*string) []string {
 		}
 	}
 	return result
+}
+
+func uniqueStrings(values []string) []string {
+	if len(values) < 2 {
+		return values
+	}
+
+	seen := make(map[string]struct{}, len(values))
+	unique := make([]string, 0, len(values))
+	for _, value := range values {
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		unique = append(unique, value)
+	}
+	return unique
 }

--- a/unifi/network_resource.go
+++ b/unifi/network_resource.go
@@ -2381,6 +2381,7 @@ func (r *networkResource) networkToModel(
 		if network.DHCPDNtp2 != nil && *network.DHCPDNtp2 != "" {
 			ntpServers = append(ntpServers, *network.DHCPDNtp2)
 		}
+		ntpServers = uniqueStrings(ntpServers)
 
 		ntpServersList, d := stringListOrNull(ctx, ntpServers, previousDhcpServer.NtpServers)
 		diags.Append(d...)


### PR DESCRIPTION
## Summary
- Collapse duplicate DHCP NTP server values read back from UniFi into a unique ordered list.
- Apply the same normalization to the network data source readback path.
- Prevent Terraform post-apply consistency failures and persistent drift when UniFi stores a single NTP server in both DHCP NTP fields.

## Validation
- Local downstream Terraform config validated and GitLab plan converged with this provider commit.
- `docker run --rm -v "/tmp/opencode/terraform-provider-unifi-index-fix:/src" -w /src golang:1.25 go test ./...` currently fails on upstream `main` compile errors unrelated to this change: missing `SettingIpsSuppression` and `DeviceRadioTable.AssistedRoaming*` symbols from `go-unifi`.